### PR TITLE
Replace monad-control with unliftio-core

### DIFF
--- a/examples/AcidRain.hs
+++ b/examples/AcidRain.hs
@@ -1,15 +1,39 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 -- This example is adapted from Gabriel Gonzalez's pipes-concurrency package.
 -- https://hackage.haskell.org/package/pipes-concurrency-2.0.8/docs/Pipes-Concurrent-Tutorial.html
 
 import Streamly
 import Streamly.Prelude as S
+import Control.Concurrent.STM (TVar, atomically, newTVarIO, readTVar, writeTVar)
 import Control.Monad (when)
+import Control.Monad.Catch (MonadThrow)
 import Control.Monad.IO.Class (MonadIO(liftIO))
-import Control.Monad.State (MonadState, get, modify, runStateT)
+import Control.Monad.IO.Unlift -- (MonadUnliftIO(askUnliftIO))
+import Control.Monad.Reader (ReaderT(..))
+import Control.Monad.State (MonadState, get, modify, runStateT, state)
+import Data.Coerce (coerce)
 
 data Event = Harm Int | Heal Int | Quit deriving (Show)
+
+newtype GameMonad a = GameMonad { unGameMonad :: ReaderT (TVar Int) IO a }
+  deriving (Functor, Applicative, Monad, MonadIO, MonadThrow)
+
+instance MonadState Int GameMonad where
+  state f = GameMonad $ ReaderT $ \healthVar -> do
+    atomically $ do
+      health <- readTVar healthVar
+      let (x, health') = f health
+      writeTVar healthVar health'
+      return x
+
+instance MonadUnliftIO GameMonad where
+  askUnliftIO = GameMonad $ do
+    UnliftIO f <- askUnliftIO
+    pure (UnliftIO (\m -> f (unGameMonad m)))
 
 userAction :: MonadAsync m => SerialT m Event
 userAction = S.repeatM $ liftIO askUser
@@ -40,5 +64,6 @@ main :: IO ()
 main = do
     putStrLn "Your health is deteriorating due to acid rain,\
              \ type \"potion\" or \"quit\""
-    _ <- runStateT (runStream game) 60
+    healthVar <- newTVarIO 60
+    _ <- runReaderT (unGameMonad (runStream game)) healthVar
     return ()

--- a/src/Streamly/SVar.hs
+++ b/src/Streamly/SVar.hs
@@ -113,7 +113,7 @@ import Control.Exception (SomeException(..), catch, mask, assert, Exception)
 import Control.Monad (when)
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.IO.Class (MonadIO(..))
-import Control.Monad.Trans.Control (MonadBaseControl, control)
+import Control.Monad.IO.Unlift (MonadUnliftIO, withRunInIO)
 import Data.Atomics
        (casIORef, readForCAS, peekTicket, atomicModifyIORefCAS_,
         writeBarrier, storeLoadBarrier)
@@ -760,7 +760,7 @@ atomicModifyIORefCAS ref fn = do
 -- 'MonadAsync'.
 --
 -- @since 0.1.0
-type MonadAsync m = (MonadIO m, MonadBaseControl IO m, MonadThrow m)
+type MonadAsync m = (MonadUnliftIO m, MonadThrow m)
 
 -- Stolen from the async package. The perf improvement is modest, 2% on a
 -- thread heavy benchmark (parallel composition using noop computations).
@@ -773,16 +773,15 @@ rawForkIO action = IO $ \ s ->
    case (fork# action s) of (# s1, tid #) -> (# s1, ThreadId tid #)
 
 {-# INLINE doFork #-}
-doFork :: MonadBaseControl IO m
+doFork :: MonadUnliftIO m
     => m ()
     -> (SomeException -> IO ())
     -> m ThreadId
 doFork action exHandler =
-    control $ \runInIO ->
-        mask $ \restore -> do
-                tid <- rawForkIO $ catch (restore $ void $ runInIO action)
-                                         exHandler
-                runInIO (return tid)
+  withRunInIO $ \runInIO ->
+    mask $ \restore ->
+      rawForkIO $ catch (restore $ runInIO action)
+                        exHandler
 
 -- XXX Can we make access to remainingWork and yieldRateInfo fields in sv
 -- faster, along with the fields in sv required by send?

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -12,6 +12,7 @@ extra-deps:
     - SDL-0.6.5.1
     - gauge-0.2.3
     - basement-0.0.7
+    - unliftio-core-0.1.1.0
 flags: {}
 extra-package-dbs: []
 # For mac ports installed SDL library on Mac OS X

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -178,10 +178,10 @@ library
 
                     -- transfomers
                      , exceptions        >= 0.8   && < 0.11
-                     , monad-control     >= 1.0   && < 2
                      , mtl               >= 2.2   && < 3
                      , transformers      >= 0.4   && < 0.6
                      , transformers-base >= 0.4   && < 0.5
+                     , unliftio-core                 < 0.1.3
 
   if impl(ghc < 8.0)
     build-depends:
@@ -491,7 +491,10 @@ executable AcidRain
     build-Depends:
         streamly
       , base         >= 4.8   && < 5
+      , exceptions   >= 0.8   && < 0.11
       , mtl          >= 2.2   && < 3
+      , stm
+      , unliftio-core            < 0.1.3
     if impl(ghc < 8.0)
       build-depends:
           semigroups    >= 0.18   && < 0.19


### PR DESCRIPTION
Hello there, this patch swaps out `monad-control` for `unliftio-core`, in case you want it. Have you heard of `unliftio-core` before? If not, I would be glad to try and dig up some blog posts that I've read that justify why the change is beneficial.