### PR TITLE
ran src through hlint, made most changes; added .hlint.yaml.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,70 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Warnings currently triggered by your code
+- suggest: {name: "Unused LANGUAGE pragma"}
+- suggest: {name: "Eta reduce"}
+- suggest: {name: "Reduce duplication"}
+- ignore: {name: "Use list literal pattern"}
+- ignore: {name: "Use tuple-section"} # requires GHC extension
+- ignore: {name: "Use fromMaybe"} # may want to use this suggestion, but it didn't match the common idiom of the library
+- ignore: {name: "Use unless"} # low power-to-weight
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+- group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/src/Streamly/Prelude.hs
+++ b/src/Streamly/Prelude.hs
@@ -379,7 +379,7 @@ unfoldrMSerial step seed = fromStreamS (S.unfoldrM step seed)
 -- @since 0.4.0
 {-# INLINE yield #-}
 yield :: IsStream t => a -> t m a
-yield a = K.yield a
+yield = K.yield
 
 -- | Create a singleton stream from a monadic action. Same as @m \`consM` nil@
 -- but more efficient.
@@ -393,7 +393,7 @@ yield a = K.yield a
 -- @since 0.4.0
 {-# INLINE yieldM #-}
 yieldM :: (Monad m, IsStream t) => m a -> t m a
-yieldM m = K.yieldM m
+yieldM = K.yieldM
 
 -- | Generate a stream by performing a monadic action @n@ times. Can be
 -- expressed as @stimes n (yieldM m)@.
@@ -627,14 +627,14 @@ foldlM' step begin m = S.foldlM' step begin $ toStreamS m
 -- @since 0.1.1
 {-# INLINE null #-}
 null :: Monad m => SerialT m a -> m Bool
-null m = K.null m
+null = K.null
 
 -- | Extract the first element of the stream, if any.
 --
 -- @since 0.1.0
 {-# INLINE head #-}
 head :: Monad m => SerialT m a -> m (Maybe a)
-head m = K.head m
+head = K.head
 
 -- | Extract all but the first element of the stream, if any.
 --
@@ -814,7 +814,7 @@ toHandle h m = go (toStream m)
         let stop = return ()
             single a = liftIO (IO.hPutStrLn h a)
             yieldk a r = liftIO (IO.hPutStrLn h a) >> go r
-        in (K.unStream m1) defState stop single yieldk
+        in K.unStream m1 defState stop single yieldk
 
 ------------------------------------------------------------------------------
 -- Transformation by Folding (Scans)

--- a/src/Streamly/SVar.hs
+++ b/src/Streamly/SVar.hs
@@ -496,11 +496,9 @@ getStreamRate = _maxStreamRate
 setStreamLatency :: Int -> State t m a -> State t m a
 setStreamLatency n st =
     st { _streamLatency =
-            if n < 0
+            if n <= 0
             then Nothing
-            else if n == 0
-                 then Nothing
-                 else Just (fromIntegral n)
+            else Just (fromIntegral n)
        }
 
 getStreamLatency :: State t m a -> Maybe NanoSecs
@@ -513,14 +511,14 @@ getStreamLatency = _streamLatency
 cleanupSVar :: SVar t m a -> IO ()
 cleanupSVar sv = do
     workers <- readIORef (workerThreads sv)
-    Prelude.mapM_ (\tid -> throwTo tid ThreadAbort)
+    Prelude.mapM_ (`throwTo` ThreadAbort)
           (S.toList workers)
 
 cleanupSVarFromWorker :: SVar t m a -> IO ()
 cleanupSVarFromWorker sv = do
     workers <- readIORef (workerThreads sv)
     self <- myThreadId
-    mapM_ (\tid -> throwTo tid ThreadAbort)
+    mapM_ (`throwTo` ThreadAbort)
           (S.toList workers \\ [self])
 
 -------------------------------------------------------------------------------
@@ -751,6 +749,21 @@ atomicModifyIORefCAS ref fn = do
         then return result
         else loop tkt (tries - 1)
 
+{-# INLINE ringDoorBell #-}
+ringDoorBell :: SVar t m a -> IO ()
+ringDoorBell sv = do
+    storeLoadBarrier
+    w <- readIORef $ needDoorBell sv
+    when w $ do
+        -- Note: the sequence of operations is important for correctness here.
+        -- We need to set the flag to false strictly before sending the
+        -- outputDoorBell, otherwise the outputDoorBell may get processed too early and
+        -- then we may set the flag to False to later making the consumer lose
+        -- the flag, even without receiving a outputDoorBell.
+        atomicModifyIORefCAS_ (needDoorBell sv) (const False)
+        void $ tryPutMVar (outputDoorBell sv) ()
+
+
 ------------------------------------------------------------------------------
 -- Spawning threads and collecting result in streamed fashion
 ------------------------------------------------------------------------------
@@ -770,7 +783,7 @@ type MonadAsync m = (MonadIO m, MonadBaseControl IO m, MonadThrow m)
 {-# INLINE rawForkIO #-}
 rawForkIO :: IO () -> IO ThreadId
 rawForkIO action = IO $ \ s ->
-   case (fork# action s) of (# s1, tid #) -> (# s1, ThreadId tid #)
+   case fork# action s of (# s1, tid #) -> (# s1, ThreadId tid #)
 
 {-# INLINE doFork #-}
 doFork :: MonadBaseControl IO m
@@ -857,7 +870,7 @@ send sv msg = do
         Unlimited -> return True
         Limited lim -> do
             active <- readIORef (workerCount sv)
-            return $ len < ((fromIntegral lim) - active)
+            return $ len < (fromIntegral lim - active)
 
 workerCollectLatency :: WorkerInfo -> IO (Maybe (Count, NanoSecs))
 workerCollectLatency winfo = do
@@ -865,7 +878,7 @@ workerCollectLatency winfo = do
     cnt1 <- readIORef (workerYieldCount winfo)
     let cnt = cnt1 - cnt0
 
-    if (cnt > 0)
+    if cnt > 0
     then do
         t1 <- getTime Monotonic
         let period = fromInteger $ toNanoSecs (t1 - t0)
@@ -919,7 +932,7 @@ checkRatePeriodic :: SVar t m a
 checkRatePeriodic sv yinfo winfo ycnt = do
     i <- readIORef (workerPollingInterval yinfo)
     -- XXX use generation count to check if the interval has been updated
-    if (i /= 0 && (ycnt `mod` i) == 0)
+    if i /= 0 && (ycnt `mod` i) == 0
     then do
         workerUpdateLatency yinfo winfo
         -- XXX not required for parallel streams
@@ -961,12 +974,11 @@ workerStopUpdate winfo info = do
 sendStop :: SVar t m a -> Maybe WorkerInfo -> IO ()
 sendStop sv mwinfo = do
     atomicModifyIORefCAS_ (workerCount sv) $ \n -> n - 1
-    case mwinfo of
-        Just winfo ->
-            case yieldRateInfo sv of
-                Nothing -> return ()
-                Just info -> workerStopUpdate winfo info
-        Nothing -> return ()
+    case (mwinfo, yieldRateInfo sv) of
+      (Just winfo, Just info) ->
+          workerStopUpdate winfo info
+      _ ->
+          return ()
     myThreadId >>= \tid -> void $ send sv (ChildStop tid Nothing)
 
 -------------------------------------------------------------------------------
@@ -981,16 +993,7 @@ sendStop sv mwinfo = do
 enqueueLIFO :: SVar t m a -> IORef [t m a] -> t m a -> IO ()
 enqueueLIFO sv q m = do
     atomicModifyIORefCAS_ q $ \ms -> m : ms
-    storeLoadBarrier
-    w <- readIORef $ needDoorBell sv
-    when w $ do
-        -- Note: the sequence of operations is important for correctness here.
-        -- We need to set the flag to false strictly before sending the
-        -- outputDoorBell, otherwise the outputDoorBell may get processed too early and
-        -- then we may set the flag to False to later making the consumer lose
-        -- the flag, even without receiving a outputDoorBell.
-        atomicModifyIORefCAS_ (needDoorBell sv) (const False)
-        void $ tryPutMVar (outputDoorBell sv) ()
+    ringDoorBell sv
 
 -------------------------------------------------------------------------------
 -- WAsync
@@ -1004,16 +1007,7 @@ enqueueLIFO sv q m = do
 enqueueFIFO :: SVar t m a -> LinkedQueue (t m a) -> t m a -> IO ()
 enqueueFIFO sv q m = do
     pushL q m
-    storeLoadBarrier
-    w <- readIORef $ needDoorBell sv
-    when w $ do
-        -- Note: the sequence of operations is important for correctness here.
-        -- We need to set the flag to false strictly before sending the
-        -- outputDoorBell, otherwise the outputDoorBell may get processed too early and
-        -- then we may set the flag to False to later making the consumer lose
-        -- the flag, even without receiving a outputDoorBell.
-        atomicModifyIORefCAS_ (needDoorBell sv) (const False)
-        void $ tryPutMVar (outputDoorBell sv) ()
+    ringDoorBell sv
 
 -------------------------------------------------------------------------------
 -- Ahead
@@ -1085,16 +1079,7 @@ enqueueAhead sv q m = do
     atomicModifyIORefCAS_ q $ \ case
         ([], n) -> ([m], n + 1)  -- increment sequence
         _ -> error "not empty"
-    storeLoadBarrier
-    w <- readIORef $ needDoorBell sv
-    when w $ do
-        -- Note: the sequence of operations is important for correctness here.
-        -- We need to set the flag to false strictly before sending the
-        -- outputDoorBell, otherwise the outputDoorBell may get processed too early and
-        -- then we may set the flag to False to later making the consumer lose
-        -- the flag, even without receiving a outputDoorBell.
-        atomicModifyIORefCAS_ (needDoorBell sv) (const False)
-        void $ tryPutMVar (outputDoorBell sv) ()
+    ringDoorBell sv
 
 -- enqueue without incrementing the sequence number
 {-# INLINE reEnqueueAhead #-}
@@ -1103,11 +1088,7 @@ reEnqueueAhead sv q m = do
     atomicModifyIORefCAS_ q $ \ case
         ([], n) -> ([m], n)  -- DO NOT increment sequence
         _ -> error "not empty"
-    storeLoadBarrier
-    w <- readIORef $ needDoorBell sv
-    when w $ do
-        atomicModifyIORefCAS_ (needDoorBell sv) (const False)
-        void $ tryPutMVar (outputDoorBell sv) ()
+    ringDoorBell sv
 
 -- Normally the thread that has the token should never go away. The token gets
 -- handed over to another thread, but someone or the other has the token at any
@@ -1138,7 +1119,7 @@ queueEmptyAhead q = liftIO $ do
 {-# INLINE dequeueAhead #-}
 dequeueAhead :: MonadIO m
     => IORef ([t m a], Int) -> m (Maybe (t m a, Int))
-dequeueAhead q = liftIO $ do
+dequeueAhead q = liftIO $
     atomicModifyIORefCAS q $ \case
             ([], n) -> (([], n), Nothing)
             (x : [], n) -> (([], n), Just (x, n))
@@ -1235,7 +1216,7 @@ addThread sv tid =
 {-# INLINE delThread #-}
 delThread :: MonadIO m => SVar t m a -> ThreadId -> m ()
 delThread sv tid =
-    liftIO $ modifyIORef (workerThreads sv) $ (\s -> S.delete tid s)
+    liftIO $ modifyIORef (workerThreads sv) (S.delete tid)
 
 -- If present then delete else add. This takes care of out of order add and
 -- delete i.e. a delete arriving before we even added a thread.
@@ -1245,14 +1226,13 @@ delThread sv tid =
 modifyThread :: MonadIO m => SVar t m a -> ThreadId -> m ()
 modifyThread sv tid = do
     changed <- liftIO $ atomicModifyIORefCAS (workerThreads sv) $ \old ->
-        if (S.member tid old)
-        then let new = (S.delete tid old) in (new, new)
-        else let new = (S.insert tid old) in (new, old)
-    if null changed
-    then liftIO $ do
-        writeBarrier
-        void $ tryPutMVar (outputDoorBell sv) ()
-    else return ()
+        if S.member tid old
+        then let new = S.delete tid old in (new, new)
+        else let new = S.insert tid old in (new, old)
+    when (null changed) $
+         liftIO $ do
+            writeBarrier
+            void $ tryPutMVar (outputDoorBell sv) ()
 
 -- | This is safe even if we are adding more threads concurrently because if
 -- a child thread is adding another thread then anyway 'workerThreads' will
@@ -1292,7 +1272,7 @@ pushWorker yieldMax sv = do
                 cntRef <- newIORef 0
                 t <- getTime Monotonic
                 lat <- newIORef (0, t)
-                return $ Just $ WorkerInfo
+                return $ Just WorkerInfo
                     { workerYieldMax = yieldMax
                     , workerYieldCount = cntRef
                     , workerLatencyStart = lat
@@ -1309,10 +1289,11 @@ pushWorker yieldMax sv = do
 -- using a CAS based modification.
 {-# NOINLINE pushWorkerPar #-}
 pushWorkerPar :: MonadAsync m => SVar t m a -> (Maybe WorkerInfo -> m ()) -> m ()
-pushWorkerPar sv wloop = do
+pushWorkerPar sv wloop =
     -- We do not use workerCount in case of ParallelVar but still there is no
     -- harm in maintaining it correctly.
 #ifdef DIAGNOSTICS
+  do
     liftIO $ atomicModifyIORefCAS_ (workerCount sv) $ \n -> n + 1
     recordMaxWorkers sv
     -- This allocation matters when significant number of workers are being
@@ -1347,14 +1328,14 @@ dispatchWorker yieldCount sv = do
     -- Note, "done" may not mean that the work is actually finished if there
     -- are workers active, because there may be a worker which has not yet
     -- queued the leftover work.
-    if (not done)
+    if not done
     then do
         qDone <- liftIO $ isQueueDone sv
         -- Note that the worker count is only decremented during event
         -- processing in fromStreamVar and therefore it is safe to read and
         -- use it without a lock.
         active <- liftIO $ readIORef $ workerCount sv
-        if (not qDone)
+        if not qDone
         then do
             -- Note that we may deadlock if the previous workers (tasks in the
             -- stream) wait/depend on the future workers (tasks in the stream)
@@ -1408,7 +1389,7 @@ rateRecoveryTime :: NanoSecs
 rateRecoveryTime = 1000000
 
 nanoToMicroSecs :: NanoSecs -> Int
-nanoToMicroSecs s = (fromIntegral s) `div` 1000
+nanoToMicroSecs s = fromIntegral s `div` 1000
 
 -- We either block, or send one worker with limited yield count or one or more
 -- workers with unlimited yield count.
@@ -1493,7 +1474,7 @@ estimateWorkers workerLimit svarYields gainLossYields
                 in assert (sleepTime >= 0) $
                     -- if s is less than 0 it means our maxSleepTime is less
                     -- than the worker latency.
-                    if (s > 0) then BlockWait s else ManyWorkers 1 (Count 0)
+                    if s > 0 then BlockWait s else ManyWorkers 1 (Count 0)
     where
         withLimit n =
             case workerLimit of
@@ -1519,7 +1500,7 @@ getWorkerLatency yinfo  = do
         pendingTime  = colTime + time
         new =
             if pendingCount > 0
-            then let lat = pendingTime `div` (fromIntegral pendingCount)
+            then let lat = pendingTime `div` fromIntegral pendingCount
                  -- XXX Give more weight to new?
                  in (lat + prev) `div` 2
             else prev
@@ -1583,9 +1564,9 @@ collectLatency _ss yinfo = do
         lcount' = lcount + pendingCount
         tripleWith lat = (lcount', ltime, lat)
 
-    if (pendingCount > 0)
+    if pendingCount > 0
     then do
-        let new = pendingTime `div` (fromIntegral pendingCount)
+        let new = pendingTime `div` fromIntegral pendingCount
 #ifdef DIAGNOSTICS
         minLat <- readIORef (minWorkerLatency _ss)
         when (new < minLat || minLat == 0) $
@@ -1599,7 +1580,7 @@ collectLatency _ss yinfo = do
         -- return the previous latency derived from the previous batch.
         if     (pendingCount > fromIntegral magicMaxBuffer)
             || (pendingTime > minThreadDelay)
-            || (let r = (fromIntegral new) / (fromIntegral prev) :: Double
+            || (let r = fromIntegral new / fromIntegral prev :: Double
                  in prev > 0 && (r > 2 || r < 0.5))
             || (prev == 0)
         then do
@@ -1698,18 +1679,17 @@ dispatchWorkerPaced sv = do
                     liftIO $ writeIORef periodRef period
 
                 cnt <- liftIO $ readIORef $ workerCount sv
-                if (cnt < netWorkers)
+                if cnt < netWorkers
                 then do
                     let total = netWorkers - cnt
                         batch = max 1 $ fromIntegral $
                                     minThreadDelay `div` targetLat
-                    r <- dispatchN (min total batch)
                     -- XXX stagger the workers over a period?
                     -- XXX cannot sleep, as that would mean we cannot process the
                     -- outputs. need to try a different mechanism to stagger.
                     -- when (total > batch) $
                        -- liftIO $ threadDelay $ nanoToMicroSecs minThreadDelay
-                    return r
+                    dispatchN (min total batch)
                 else return False
 
     where
@@ -1723,7 +1703,7 @@ dispatchWorkerPaced sv = do
                    else yields + buf
             liftIO $ modifyIORef (svarGainedLostYields yinfo) (+ delta)
 
-    dispatchN n = do
+    dispatchN n =
         if n == 0
         then return True
         else do
@@ -1736,12 +1716,13 @@ sendWorkerDelayPaced :: SVar t m a -> IO ()
 sendWorkerDelayPaced _ = return ()
 
 sendWorkerDelay :: SVar t m a -> IO ()
-sendWorkerDelay _sv = do
+sendWorkerDelay _sv =
     -- XXX we need a better way to handle this than hardcoded delays. The
     -- delays may be different for different systems.
     -- If there is a usecase where this is required we can create a combinator
     -- to set it as a config in the state.
     {-
+  do
     ncpu <- getNumCapabilities
     if ncpu <= 1
     then
@@ -1816,7 +1797,7 @@ sendWorkerWait delay dispatch sv = do
         -- doorbell on the next enqueue.
 
         liftIO $ atomicModifyIORefCAS_ (needDoorBell sv) $ const True
-        liftIO $ storeLoadBarrier
+        liftIO storeLoadBarrier
         canDoMore <- dispatch sv
 
         -- XXX test for the case when we miss sending a worker when the worker
@@ -1865,12 +1846,12 @@ readOutputQBounded sv = do
         cnt <- liftIO $ readIORef $ workerCount sv
         when (cnt <= 0) $ do
             done <- liftIO $ isWorkDone sv
-            when (not done) $ pushWorker 0 sv
+            when (not done) (pushWorker 0 sv)
 
     {-# INLINE blockingRead #-}
     blockingRead = do
         sendWorkerWait sendWorkerDelay (dispatchWorker 0) sv
-        liftIO $ (readOutputQRaw sv >>= return . fst)
+        liftIO (fst `fmap` readOutputQRaw sv)
 
 readOutputQPaced :: MonadAsync m => SVar t m a -> m [ChildEvent a]
 readOutputQPaced sv = do
@@ -1888,7 +1869,7 @@ readOutputQPaced sv = do
     {-# INLINE blockingRead #-}
     blockingRead = do
         sendWorkerWait sendWorkerDelayPaced dispatchWorkerPaced sv
-        liftIO $ (readOutputQRaw sv >>= return . fst)
+        liftIO (fst `fmap` readOutputQRaw sv)
 
 postProcessBounded :: MonadAsync m => SVar t m a -> m Bool
 postProcessBounded sv = do
@@ -1907,7 +1888,7 @@ postProcessBounded sv = do
         r <- liftIO $ isWorkDone sv
         -- Note that we need to guarantee a worker, therefore we cannot just
         -- use dispatchWorker which may or may not send a worker.
-        when (not r) $ pushWorker 0 sv
+        when (not r) (pushWorker 0 sv)
         -- XXX do we need to dispatch many here?
         -- void $ dispatchWorker sv
         return r
@@ -2150,7 +2131,7 @@ getParallelSVar st = do
         case yieldRateInfo sv of
             Nothing -> return ()
             Just yinfo -> void $ collectLatency (svarStats sv) yinfo
-        readOutputQRaw sv >>= return . fst
+        fst `fmap` readOutputQRaw sv
 
 sendFirstWorker :: MonadAsync m => SVar t m a -> t m a -> m (SVar t m a)
 sendFirstWorker sv m = do
@@ -2160,7 +2141,7 @@ sendFirstWorker sv m = do
     liftIO $ enqueue sv m
     case yieldRateInfo sv of
         Nothing -> pushWorker 0 sv
-        Just yinfo  -> do
+        Just yinfo  ->
             if svarLatencyTarget yinfo == maxBound
             then liftIO $ threadDelay maxBound
             else pushWorker 1 sv
@@ -2190,7 +2171,7 @@ newParallelVar st = liftIO $ getParallelSVar st
 -- be read back from the SVar using 'fromSVar'.
 toStreamVar :: MonadAsync m => SVar t m a -> t m a -> m ()
 toStreamVar sv m = do
-    liftIO $ (enqueue sv) m
+    liftIO $ enqueue sv m
     done <- allThreadsDone sv
     -- XXX This is safe only when called from the consumer thread or when no
     -- consumer is present.  There may be a race if we are not running in the

--- a/src/Streamly/Streams/Async.hs
+++ b/src/Streamly/Streams/Async.hs
@@ -469,11 +469,11 @@ newAsyncVar st m = do
 -- @since 0.2.0
 {-# INLINABLE mkAsync #-}
 mkAsync :: (IsStream t, MonadAsync m) => t m a -> m (t m a)
-mkAsync m = newAsyncVar defState (toStream m) >>= return . fromSVar
+mkAsync m = fmap fromSVar (newAsyncVar defState (toStream m))
 
 {-# INLINABLE mkAsync' #-}
 mkAsync' :: (IsStream t, MonadAsync m) => State Stream m a -> t m a -> m (t m a)
-mkAsync' st m = newAsyncVar st (toStream m) >>= return . fromSVar
+mkAsync' st m = fmap fromSVar (newAsyncVar st (toStream m))
 
 -- | Create a new SVar and enqueue one stream computation on it.
 {-# INLINABLE newWAsyncVar #-}
@@ -563,7 +563,7 @@ forkSVarAsync style m1 m2 = Stream $ \st stp sng yld -> do
 {-# INLINE joinStreamVarAsync #-}
 joinStreamVarAsync :: MonadAsync m
     => SVarStyle -> Stream m a -> Stream m a -> Stream m a
-joinStreamVarAsync style m1 m2 = Stream $ \st stp sng yld -> do
+joinStreamVarAsync style m1 m2 = Stream $ \st stp sng yld ->
     case streamVar st of
         Just sv | svarStyle sv == style ->
             liftIO (enqueue sv m2) >> unStream m1 st stp sng yld

--- a/src/Streamly/Streams/Parallel.hs
+++ b/src/Streamly/Streams/Parallel.hs
@@ -91,7 +91,7 @@ forkSVarPar m r = Stream $ \st stp sng yld -> do
     sv <- newParallelVar st
     pushWorkerPar sv (runOne st{streamVar = Just sv} m)
     pushWorkerPar sv (runOne st{streamVar = Just sv} r)
-    (unStream (fromSVar sv)) (rstState st) stp sng yld
+    unStream (fromSVar sv) (rstState st) stp sng yld
 
 {-# INLINE joinStreamVarPar #-}
 joinStreamVarPar :: MonadAsync m
@@ -119,7 +119,7 @@ consMParallel m r = K.yieldM m `parallelStream` r
 -- @since 0.2.0
 {-# INLINE parallel #-}
 parallel :: (IsStream t, MonadAsync m) => t m a -> t m a -> t m a
-parallel m1 m2 = fromStream $ Stream $ \st stp sng yld -> do
+parallel m1 m2 = fromStream $ Stream $ \st stp sng yld ->
     unStream (parallelStream (toStream m1) (toStream m2))
              st stp sng yld
 

--- a/src/Streamly/Streams/SVar.hs
+++ b/src/Streamly/Streams/SVar.hs
@@ -81,8 +81,9 @@ fromStreamVar sv = Stream $ \st stp sng yld -> do
 
     where
 
-    allDone stp = do
+    allDone stp =
 #ifdef DIAGNOSTICS
+        do
             t <- liftIO $ getTime Monotonic
             liftIO $ writeIORef (svarStopTime (svarStats sv)) (Just t)
 #ifdef DIAGNOSTICS_VERBOSE
@@ -114,7 +115,7 @@ fromStreamVar sv = Stream $ \st stp sng yld -> do
 
 {-# INLINE fromSVar #-}
 fromSVar :: (MonadAsync m, IsStream t) => SVar Stream m a -> t m a
-fromSVar sv = do
+fromSVar sv =
     fromStream $ Stream $ \st stp sng yld -> do
         ref <- liftIO $ newIORef ()
         _ <- liftIO $ mkWeakIORef ref hook
@@ -124,8 +125,9 @@ fromSVar sv = do
         unStream (fromStreamVar sv{svarRef = Just ref}) st stp sng yld
     where
 
-    hook = do
+    hook =
 #ifdef DIAGNOSTICS_VERBOSE
+      do
         printSVar sv "SVar Garbage Collected"
 #endif
         cleanupSVar sv
@@ -154,7 +156,7 @@ toSVar sv m = toStreamVar sv (toStream m)
 -- @since 0.4.0
 {-# INLINE_NORMAL maxThreads #-}
 maxThreads :: IsStream t => Int -> t m a -> t m a
-maxThreads n m = fromStream $ Stream $ \st stp sng yld -> do
+maxThreads n m = fromStream $ Stream $ \st stp sng yld ->
     unStream (toStream m) (setMaxThreads n st) stp sng yld
 
 {-
@@ -179,7 +181,7 @@ maxThreadsSerial _ = id
 -- @since 0.4.0
 {-# INLINE_NORMAL maxBuffer #-}
 maxBuffer :: IsStream t => Int -> t m a -> t m a
-maxBuffer n m = fromStream $ Stream $ \st stp sng yld -> do
+maxBuffer n m = fromStream $ Stream $ \st stp sng yld ->
     unStream (toStream m) (setMaxBuffer n st) stp sng yld
 
 {-
@@ -203,7 +205,7 @@ maxBufferSerial _ = id
 -- @since 0.5.0
 {-# INLINE_NORMAL rate #-}
 rate :: IsStream t => Maybe Rate -> t m a -> t m a
-rate r m = fromStream $ Stream $ \st stp sng yld -> do
+rate r m = fromStream $ Stream $ \st stp sng yld ->
     case r of
         Just (Rate low goal _ _) | goal < low ->
             error "rate: Target rate cannot be lower than minimum rate."
@@ -281,7 +283,7 @@ constRate r = rate (Just $ Rate r r r 0)
 --
 {-# INLINE_NORMAL _serialLatency #-}
 _serialLatency :: IsStream t => Int -> t m a -> t m a
-_serialLatency n m = fromStream $ Stream $ \st stp sng yld -> do
+_serialLatency n m = fromStream $ Stream $ \st stp sng yld ->
     unStream (toStream m) (setStreamLatency n st) stp sng yld
 
 {-
@@ -296,7 +298,7 @@ serialLatencySerial _ = id
 -- inherited by everything in enclosed scope.
 {-# INLINE_NORMAL maxYields #-}
 maxYields :: IsStream t => Maybe Int64 -> t m a -> t m a
-maxYields n m = fromStream $ Stream $ \st stp sng yld -> do
+maxYields n m = fromStream $ Stream $ \st stp sng yld ->
     unStream (toStream m) (setYieldLimit n st) stp sng yld
 
 {-# RULES "maxYields serial" maxYields = maxYieldsSerial #-}

--- a/src/Streamly/Streams/Serial.hs
+++ b/src/Streamly/Streams/Serial.hs
@@ -177,7 +177,7 @@ serial m1 m2 = fromStream $ Stream $ \st stp sng yld ->
 instance Monad m => Monad (SerialT m) where
     return = pure
     (SerialT (Stream m)) >>= f = SerialT $ Stream $ \st stp sng yld ->
-        let run x = (unStream x) (rstState st) stp sng yld
+        let run x = unStream x (rstState st) stp sng yld
             single a   = run $ toStream (f a)
             yieldk a r = run $ toStream $ f a <> (fromStream r >>= f)
         in m (rstState st) stp single yieldk
@@ -289,10 +289,10 @@ instance IsStream WSerialT where
 {-# INLINE interleave #-}
 interleave :: Stream m a -> Stream m a -> Stream m a
 interleave m1 m2 = Stream $ \st stp sng yld -> do
-    let stop       = (unStream m2) (rstState st) stp sng yld
+    let stop       = unStream m2 (rstState st) stp sng yld
         single a   = yld a m2
         yieldk a r = yld a (interleave m2 r)
-    (unStream m1) (rstState st) stop single yieldk
+    unStream m1 (rstState st) stop single yieldk
 
 -- | Polymorphic version of the 'Semigroup' operation '<>' of 'WSerialT'.
 -- Interleaves two streams, yielding one element from each stream alternately.
@@ -332,7 +332,7 @@ instance Monoid (WSerialT m a) where
 instance Monad m => Monad (WSerialT m) where
     return = pure
     (WSerialT (Stream m)) >>= f = WSerialT $ Stream $ \st stp sng yld ->
-        let run x = (unStream x) (rstState st) stp sng yld
+        let run x = unStream x (rstState st) stp sng yld
             single a   = run $ toStream (f a)
             yieldk a r = run $ toStream $ f a <> (fromStream r >>= f)
         in m (rstState st) stp single yieldk

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -182,7 +182,7 @@ uncons (Stream step state) = go state
     go st = do
         r <- step defState st
         return $ case r of
-            Yield x s -> Just (x, (Stream step s))
+            Yield x s -> Just (x, Stream step s)
             Stop      -> Nothing
 
 ------------------------------------------------------------------------------
@@ -217,8 +217,8 @@ enumFromStepN from stride n =
     from `seq` stride `seq` n `seq` Stream step (from, n)
     where
         {-# INLINE_LATE step #-}
-        step _ (x, i) | i > 0   = return $ Yield x (x + stride, i - 1)
-                    | otherwise = return $ Stop
+        step _ (x, i) | i > 0     = return $ Yield x (x + stride, i - 1)
+                      | otherwise = return Stop
 
 -------------------------------------------------------------------------------
 -- Generation by Conversion
@@ -246,7 +246,7 @@ yieldM m = Stream step True
 -- | Convert a list of monadic actions to a 'Stream'
 {-# INLINE_LATE fromListM #-}
 fromListM :: MonadAsync m => [m a] -> Stream m a
-fromListM zs = Stream step zs
+fromListM = Stream step
   where
     {-# INLINE_LATE step #-}
     step _ (m:ms) = m >>= \x -> return $ Yield x ms
@@ -255,7 +255,7 @@ fromListM zs = Stream step zs
 -- | Convert a list of pure values to a 'Stream'
 {-# INLINE_LATE fromList #-}
 fromList :: Monad m => [a] -> Stream m a
-fromList zs = Stream step zs
+fromList = Stream step
   where
     {-# INLINE_LATE step #-}
     step _ (x:xs) = return $ Yield x xs
@@ -264,7 +264,7 @@ fromList zs = Stream step zs
 -- XXX pass the state to streamD
 {-# INLINE_LATE fromStreamK #-}
 fromStreamK :: Monad m => K.Stream m a -> Stream m a
-fromStreamK m = Stream step m
+fromStreamK = Stream step
     where
     step gst m1 =
         let stop       = return Stop
@@ -530,7 +530,7 @@ takeWhileM f (Stream step state) = Stream step' state
             Yield x s -> do
                 b <- f x
                 return $ if b then Yield x s else Stop
-            Stop -> return $ Stop
+            Stop -> return Stop
 
 {-# INLINE takeWhile #-}
 takeWhile :: Monad m => (a -> Bool) -> Stream m a -> Stream m a
@@ -593,7 +593,7 @@ filterM f (Stream step state) = Stream step' state
                 if b
                 then return $ Yield x s
                 else step' gst s
-            Stop -> return $ Stop
+            Stop -> return Stop
 
 {-# INLINE filter #-}
 filter :: Monad m => (a -> Bool) -> Stream m a -> Stream m a

--- a/src/Streamly/Streams/StreamK.hs
+++ b/src/Streamly/Streams/StreamK.hs
@@ -366,7 +366,7 @@ uncons m =
     let stop = return Nothing
         single a = return (Just (a, nil))
         yieldk a r = return (Just (a, fromStream r))
-    in (unStream (toStream m)) defState stop single yieldk
+    in unStream (toStream m) defState stop single yieldk
 
 -------------------------------------------------------------------------------
 -- Generation
@@ -454,7 +454,7 @@ foldStream
     -> m r
 foldStream st blank single step m =
     let yieldk a x = step a (fromStream x)
-     in (unStream (toStream m)) st blank single yieldk
+     in unStream (toStream m) st blank single yieldk
 
 -- | Lazy right associative fold.
 foldr :: (IsStream t, Monad m) => (a -> b -> b) -> b -> t m a -> m b
@@ -464,7 +464,7 @@ foldr step acc m = go (toStream m)
         let stop = return acc
             single a = return (step a acc)
             yieldk a r = go r >>= \b -> return (step a b)
-        in (unStream m1) defState stop single yieldk
+        in unStream m1 defState stop single yieldk
 
 -- | Lazy right fold with a monadic step function.
 {-# INLINE foldrM #-}
@@ -475,7 +475,7 @@ foldrM step acc m = go (toStream m)
         let stop = return acc
             single a = step a acc
             yieldk a r = go r >>= step a
-        in (unStream m1) defState stop single yieldk
+        in unStream m1 defState stop single yieldk
 
 {-# INLINE foldr1 #-}
 foldr1 :: (IsStream t, Monad m) => (a -> a -> a) -> t m a -> m (Maybe a)
@@ -483,12 +483,12 @@ foldr1 step m = do
     r <- uncons m
     case r of
         Nothing -> return Nothing
-        Just (h, t) -> go h (toStream t) >>= return . Just
+        Just (h, t) -> fmap Just (go h (toStream t))
     where
     go p m1 =
         let stp = return p
             single a = return $ step a p
-            yieldk a r = go a r >>= return . (step p)
+            yieldk a r = fmap (step p) (go a r)
          in unStream m1 defState stp single yieldk
 
 -- | Strict left fold with an extraction function. Like the standard strict
@@ -503,7 +503,7 @@ foldx step begin done m = get $ go (toStream m) begin
     {-# NOINLINE get #-}
     get m1 =
         let single = return . done
-         in (unStream m1) undefined undefined single undefined
+         in unStream m1 undefined undefined single undefined
 
     -- Note, this can be implemented by making a recursive call to "go",
     -- however that is more expensive because of unnecessary recursion
@@ -514,13 +514,13 @@ foldx step begin done m = get $ go (toStream m) begin
             single a = sng $ step acc a
             yieldk a r =
                 let stream = go r (step acc a)
-                in (unStream stream) defState undefined sng yld
-        in (unStream m1) defState stop single yieldk
+                in unStream stream defState undefined sng yld
+        in unStream m1 defState stop single yieldk
 
 -- | Strict left associative fold.
 {-# INLINE foldl' #-}
 foldl' :: (IsStream t, Monad m) => (b -> a -> b) -> b -> t m a -> m b
-foldl' step begin m = foldx step begin id m
+foldl' step begin = foldx step begin id
 
 -- XXX replace the recursive "go" with explicit continuations.
 -- | Like 'foldx', but with a monadic step function.
@@ -532,11 +532,11 @@ foldxM step begin done m = go begin (toStream m)
         let stop = acc >>= done
             single a = acc >>= \b -> step b a >>= done
             yieldk a r = acc >>= \b -> step b a >>= \x -> go (return x) r
-         in (unStream m1) defState stop single yieldk
+         in unStream m1 defState stop single yieldk
 
 -- | Like 'foldl'' but with a monadic step function.
 foldlM' :: (IsStream t, Monad m) => (b -> a -> m b) -> b -> t m a -> m b
-foldlM' step begin m = foldxM step (return begin) return m
+foldlM' step begin = foldxM step (return begin) return
 
 ------------------------------------------------------------------------------
 -- Specialized folds
@@ -598,7 +598,7 @@ elem e m = go (toStream m)
         let stop      = return False
             single a  = return (a == e)
             yieldk a r = if a == e then return True else go r
-        in (unStream m1) defState stop single yieldk
+        in unStream m1 defState stop single yieldk
 
 {-# INLINE notElem #-}
 notElem :: (IsStream t, Monad m, Eq a) => a -> t m a -> m Bool
@@ -608,7 +608,7 @@ notElem e m = go (toStream m)
         let stop      = return True
             single a  = return (a /= e)
             yieldk a r = if a == e then return False else go r
-        in (unStream m1) defState stop single yieldk
+        in unStream m1 defState stop single yieldk
 
 all :: (IsStream t, Monad m) => (a -> Bool) -> t m a -> m Bool
 all p m = go (toStream m)
@@ -725,7 +725,7 @@ mapM_ f m = go (toStream m)
         let stop = return ()
             single a = void (f a)
             yieldk a r = f a >> go r
-         in (unStream m1) defState stop single yieldk
+         in unStream m1 defState stop single yieldk
 
 ------------------------------------------------------------------------------
 -- Converting folds
@@ -757,7 +757,7 @@ scanx step begin done m =
 
 {-# INLINE scanl' #-}
 scanl' :: IsStream t => (b -> a -> b) -> b -> t m a -> t m b
-scanl' step begin m = scanx step begin id m
+scanl' step begin = scanx step begin id
 
 -------------------------------------------------------------------------------
 -- Filtering
@@ -771,7 +771,7 @@ filter p m = fromStream $ go (toStream m)
         let single a   | p a       = sng a
                        | otherwise = stp
             yieldk a r | p a       = yld a (go r)
-                       | otherwise = (unStream r) (rstState st) stp single yieldk
+                       | otherwise = unStream r (rstState st) stp single yieldk
          in unStream m1 (rstState st) stp single yieldk
 
 {-# INLINE take #-}
@@ -814,7 +814,7 @@ dropWhile p m = fromStream $ go (toStream m)
     go m1 = Stream $ \st stp sng yld ->
         let single a   | p a       = stp
                        | otherwise = sng a
-            yieldk a r | p a = (unStream r) (rstState st) stp single yieldk
+            yieldk a r | p a = unStream r (rstState st) stp single yieldk
                        | otherwise = yld a r
          in unStream m1 (rstState st) stp single yieldk
 
@@ -837,8 +837,8 @@ mapM f m = go (toStream m)
     where
     go m1 = fromStream $ Stream $ \st stp sng yld ->
         let single a  = f a >>= sng
-            yieldk a r = unStream (toStream (f a |: (go r))) st stp sng yld
-         in (unStream m1) (rstState st) stp single yieldk
+            yieldk a r = unStream (toStream (f a |: go r)) st stp sng yld
+         in unStream m1 (rstState st) stp single yieldk
 
 -- Be careful when modifying this, this uses a consM (|:) deliberately to allow
 -- other stream types to overload it.
@@ -849,7 +849,7 @@ sequence m = go (toStream m)
     go m1 = fromStream $ Stream $ \st stp sng yld ->
         let single ma = ma >>= sng
             yieldk ma r = unStream (toStream $ ma |: go r) st stp sng yld
-         in (unStream m1) (rstState st) stp single yieldk
+         in unStream m1 (rstState st) stp single yieldk
 
 -------------------------------------------------------------------------------
 -- Inserting
@@ -881,7 +881,7 @@ mapMaybe f m = go (toStream m)
                 Nothing -> stp
             yieldk a r = case f a of
                 Just b  -> yld b (toStream $ go r)
-                Nothing -> (unStream r) (rstState st) stp single yieldk
+                Nothing -> unStream r (rstState st) stp single yieldk
         in unStream m1 (rstState st) stp single yieldk
 
 ------------------------------------------------------------------------------
@@ -890,15 +890,15 @@ mapMaybe f m = go (toStream m)
 
 {-# INLINE zipWithS #-}
 zipWithS :: (a -> b -> c) -> Stream m a -> Stream m b -> Stream m c
-zipWithS f m1 m2 = go m1 m2
+zipWithS f = go
     where
     go mx my = Stream $ \st stp sng yld -> do
         let merge a ra =
                 let single2 b = sng (f a b)
                     yield2 b rb = yld (f a b) (go ra rb)
                  in unStream my (rstState st) stp single2 yield2
-        let single1 a   = merge a nil
-            yield1 a ra = merge a ra
+        let single1 a = merge a nil
+            yield1 = merge
         unStream mx (rstState st) stp single1 yield1
 
 -- | Zip two streams serially using a pure zipping function.
@@ -920,8 +920,8 @@ zipWithM f m1 m2 = fromStream $ go (toStream m1) (toStream m2)
                     single2 b   = f a b >>= sng
                     yield2 b rb = f a b >>= \x -> runIt (x `cons` go ra rb)
                  in unStream my (rstState st) stp single2 yield2
-        let single1 a  = merge a nil
-            yield1 a ra = merge a ra
+        let single1 a = merge a nil
+            yield1 = merge
         unStream mx (rstState st) stp single1 yield1
 
 ------------------------------------------------------------------------------
@@ -935,7 +935,7 @@ serial :: Stream m a -> Stream m a -> Stream m a
 serial m1 m2 = go m1
     where
     go (Stream m) = Stream $ \st stp sng yld ->
-            let stop       = (unStream m2) (rstState st) stp sng yld
+            let stop       = unStream m2 (rstState st) stp sng yld
                 single a   = yld a m2
                 yieldk a r = yld a (go r)
             in m (rstState st) stop single yieldk
@@ -972,7 +972,7 @@ bindWith par m f = go m
     where
         go (Stream g) =
             Stream $ \st stp sng yld ->
-            let run x = (unStream x) st stp sng yld
+            let run x = unStream x st stp sng yld
                 single a   = run $ f a
                 yieldk a r = run $ f a `par` go r
             in g (rstState st) stp single yieldk
@@ -995,7 +995,7 @@ withLocal f m =
     Stream $ \st stp sng yld ->
         let single = local f . sng
             yieldk a r = local f $ yld a (withLocal f r)
-        in (unStream m) (rstState st) (local f stp) single yieldk
+        in unStream m (rstState st) (local f stp) single yieldk
 
 ------------------------------------------------------------------------------
 -- MonadError


### PR DESCRIPTION
There are still 30 hints for the src tree. One for unnecessary parentheses around a call to `inline`, and the rest for unused LANGUAGE pragmas, to reduce duplication, or for η-reduction.

I didn't do η-reduction when a function didn't have a type signature and had multiple parameters.