### PR TITLE
Fix monadic state capture and restore for concurrent tasks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@
 * Fixed a livelock in ahead style streams. The problem manifests sometimes when
   multiple streams are merged together in ahead style and one of them is a nil
   stream.
+* As per expected concurrency semantics each forked concurrent task must run
+  with the monadic state captured at the fork point.  This release fixes a bug,
+  which, in some cases caused an incorrect monadic state to be used for a
+  concurrent action, leading to unexpected behavior when concurrent streams are
+  used in a stateful monad e.g. `StateT`. Particularly, this bug cannot affect
+  `ReaderT`.
 
 ## 0.5.1
 

--- a/src/Streamly/Streams/Parallel.hs
+++ b/src/Streamly/Streams/Parallel.hs
@@ -67,6 +67,7 @@ runOne st m winfo = unStream m st stop single yieldk
     where
 
     sv = fromJust $ streamVar st
+    mrun = runInIO $ svarMrun sv
 
     withLimitCheck action = do
         yieldLimitOk <- liftIO $ decrementYieldLimitPost sv
@@ -82,7 +83,8 @@ runOne st m winfo = unStream m st stop single yieldk
     -- queue and queue it back on that and exit the thread when the outputQueue
     -- overflows. Parallel is dangerous because it can accumulate unbounded
     -- output in the buffer.
-    yieldk a r = void (sendit a) >> withLimitCheck (runOne st r winfo)
+    yieldk a r = void (sendit a)
+        >> withLimitCheck (void $ liftIO $ mrun $ runOne st r winfo)
 
 {-# NOINLINE forkSVarPar #-}
 forkSVarPar :: MonadAsync m => Stream m a -> Stream m a -> Stream m a

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -10,7 +10,7 @@ extra-deps:
     - http-client-0.5.0
     - http-client-tls-0.3.0
     - SDL-0.6.5.1
-    - gauge-0.2.3
+    - gauge-0.2.4
     - basement-0.0.7
 flags: {}
 extra-package-dbs: []

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -6,7 +6,7 @@ extra-deps:
     - lockfree-queue-0.2.3.1
     - simple-conduit-0.6.0
     - SDL-0.6.5.1
-    - gauge-0.2.3
+    - gauge-0.2.4
     - basement-0.0.4
 flags: {}
 extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@ extra-deps:
     - Chart-1.9
     - Chart-diagrams-1.9
     - SVGFonts-1.6.0.3
-    - bench-show-0.2.0
+    - bench-show-0.2.1
 
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
Currently, the semantics of stateful concurrent tasks is to start with the state from the point where the task is forked but discard any state changes performed in independent threads once they are done. Alternative semantics like merging the state changes or using atomic modifications to state may be implemented in future.

This causes up to 30% regression in async stream generation benchmarks and up to 200% regression in async nested benchmarks. Mostly, due to an additional functional call that cannot be inlined.