### PR TITLE
WIP/POC - Add a cleanup continuation for cleanups on exception

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,10 @@
   used in a stateful monad e.g. `StateT`. Particularly, this bug cannot affect
   `ReaderT`.
 
+### Breaking Changes
+
+* Monad constraints may have to be added in some APIs.
+
 ## 0.5.1
 
 * Performance improvements, especially space consumption, for concurrent

--- a/benchmark/LinearOps.hs
+++ b/benchmark/LinearOps.hs
@@ -52,7 +52,7 @@ sourceFromListM :: (S.MonadAsync m, S.IsStream t) => Int -> t m Int
 sourceFromListM n = S.fromListM (Prelude.fmap return [n..n+value])
 
 {-# INLINE sourceFromFoldable #-}
-sourceFromFoldable :: S.IsStream t => Int -> t m Int
+sourceFromFoldable :: (S.IsStream t, Monad m) => Int -> t m Int
 sourceFromFoldable n = S.fromFoldable [n..n+value]
 
 {-# INLINE sourceFromFoldableM #-}

--- a/benchmark/StreamKOps.hs
+++ b/benchmark/StreamKOps.hs
@@ -52,7 +52,7 @@ last :: Monad m => Stream m Int -> m (Maybe Int)
 type Stream m a = S.Stream m a
 
 {-# INLINE sourceUnfoldr #-}
-sourceUnfoldr :: Int -> Stream m Int
+sourceUnfoldr :: Monad m => Int -> Stream m Int
 sourceUnfoldr n = S.unfoldr step n
     where
     step cnt =
@@ -76,7 +76,7 @@ sourceFromEnum n = S.enumFromStepN n 1 value
 -}
 
 {-# INLINE sourceFromFoldable #-}
-sourceFromFoldable :: Int -> Stream m Int
+sourceFromFoldable :: Monad m => Int -> Stream m Int
 sourceFromFoldable n = S.fromFoldable [n..n+value]
 
 {-
@@ -86,7 +86,7 @@ sourceFromFoldableM n = S.fromFoldableM (Prelude.fmap return [n..n+value])
 -}
 
 {-# INLINE sourceFoldMapWith #-}
-sourceFoldMapWith :: Int -> Stream m Int
+sourceFoldMapWith :: Monad m => Int -> Stream m Int
 sourceFoldMapWith n = S.foldMapWith S.serial S.yield [n..n+value]
 
 {-# INLINE sourceFoldMapWithM #-}

--- a/test/Prop.hs
+++ b/test/Prop.hs
@@ -35,7 +35,7 @@ maxTestCount = 100
 maxTestCount = 10
 #endif
 
-singleton :: IsStream t => a -> t m a
+singleton :: (IsStream t, Monad m) => a -> t m a
 singleton a = a .: nil
 
 sortEq :: Ord a => [a] -> [a] -> Bool


### PR DESCRIPTION
This is a more intrusive approach compared to register/releasing cleanup handlers in a global state. Especially because cons/uncons functions too have to be aware of cleanup handlers. Because of that I am tending towards using the register/release approach. This PR is to keep this change until the other approach is tried.