### PR TITLE
Optimizations

### DIFF
--- a/src/Streamly/Prelude.hs
+++ b/src/Streamly/Prelude.hs
@@ -979,10 +979,15 @@ mapMaybe f m = fromStreamS $ S.mapMaybe f $ toStreamS m
 -- /Concurrent (do not use with 'parallely' on infinite streams)/
 --
 -- @since 0.3.0
-{-# INLINE mapMaybeM #-}
+{-# INLINE_EARLY mapMaybeM #-}
 mapMaybeM :: (IsStream t, MonadAsync m, Functor (t m))
           => (a -> m (Maybe b)) -> t m a -> t m b
-mapMaybeM f = fmap fromJust . filter isJust . mapM f
+mapMaybeM f = fmap fromJust . filter isJust . K.mapM f
+
+{-# RULES "mapMaybeM serial" mapMaybeM = mapMaybeMSerial #-}
+{-# INLINE mapMaybeMSerial #-}
+mapMaybeMSerial :: Monad m => (a -> m (Maybe b)) -> SerialT m a -> SerialT m b
+mapMaybeMSerial f m = fromStreamD $ D.mapMaybeM f $ toStreamD m
 
 ------------------------------------------------------------------------------
 -- Transformation by Reordering

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -504,7 +504,7 @@ postscanlM' fstep begin (Stream step state) =
             Skip s -> return $ Skip (s, acc)
             Stop   -> return Stop
 
-{-# INLINE_LATE scanlM' #-}
+{-# INLINE_NORMAL scanlM' #-}
 scanlM' :: Monad m => (b -> a -> m b) -> b -> Stream m a -> Stream m b
 scanlM' fstep begin s = begin `seq` (begin `cons` postscanlM' fstep begin s)
 
@@ -673,7 +673,7 @@ zipWithM f (Stream stepa ta) (Stream stepb tb) = Stream step (ta, tb, Nothing)
         return $
           case r of
             Yield x sa' -> Skip (sa', sb, Just x)
-            Skip sa'    -> Skip (sa', sb, Nothing) 
+            Skip sa'    -> Skip (sa', sb, Nothing)
             Stop        -> Stop
 
     step gst (sa, sb, Just x) = do

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -148,7 +148,7 @@ library
                      , Streamly.Internal
 
     default-language: Haskell2010
-    ghc-options:      -Wall
+    ghc-options:      -Wall -fspec-constr-recursive=10
 
     if flag(streamk)
       cpp-options:    -DUSE_STREAMK_ONLY
@@ -312,7 +312,7 @@ benchmark linear
   main-is: Linear.hs
   other-modules: LinearOps
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall
+  ghc-options:  -O2 -Wall -fspec-constr-recursive=10
   if flag(dev)
     ghc-options:    -Wmissed-specialisations
                     -Wall-missed-specialisations
@@ -339,7 +339,7 @@ benchmark linear-async
   main-is: LinearAsync.hs
   other-modules: LinearOps
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall
+  ghc-options:  -O2 -Wall -fspec-constr-recursive=10
   cpp-options: -DLINEAR_ASYNC
   if flag(dev)
     ghc-options:    -Wmissed-specialisations
@@ -367,7 +367,7 @@ benchmark linear-rate
   main-is: LinearRate.hs
   other-modules: LinearOps
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall
+  ghc-options:  -O2 -Wall -fspec-constr-recursive=10
   if flag(dev)
     ghc-options:    -Wmissed-specialisations
                     -Wall-missed-specialisations
@@ -394,7 +394,7 @@ benchmark nested
   main-is: Nested.hs
   other-modules: NestedOps
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall
+  ghc-options:  -O2 -Wall -fspec-constr-recursive=10
   if flag(dev)
     ghc-options:    -Wmissed-specialisations
                     -Wall-missed-specialisations
@@ -435,7 +435,7 @@ benchmark base
                    , StreamKOps
 
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall
+  ghc-options:  -O2 -Wall -fspec-constr-recursive=10
   if flag(dev)
     ghc-options:    -Wmissed-specialisations
                     -Wall-missed-specialisations


### PR DESCRIPTION
Two main optimizations in this PR:

1) `mapMaybeM` optimized for composition 
2) use `-fspec-constr-recursive=10` to enable deeper spec-constr optimization for composed ops

Here are the before and after results:

```
100,000 elems(time)
Benchmark                             default(0)(μs)(base) default(1)(%)(-base)
------------------------------------- -------------------- --------------------
serially/mixedX4/take-drop                         2797.43               -86.88
serially/mixedX4/drop-scan                         4850.58               -91.23
serially/filteringX4/dropWhile-false               2799.01               -92.85
serially/mixedX4/filter-drop                        580.90               -94.41
serially/filteringX4/drop-one                       635.97               -94.85
serially/mixedX4/drop-map                           643.70               -94.96
serially/transformationX4/mapMaybeM                3749.98               -98.23
```