### PR TITLE
Conditionally compile network package for ghcjs.

### DIFF
--- a/streamly.cabal
+++ b/streamly.cabal
@@ -221,9 +221,6 @@ library
                      , Streamly.FileSystem.FD
                      , Streamly.FileSystem.Handle
                      , Streamly.FileSystem.File
-                     , Streamly.Network.Socket
-                     , Streamly.Network.Server
-                     , Streamly.Network.Client
 
                     -- Time
                      , Streamly.Time.Units
@@ -231,6 +228,11 @@ library
 
                      , Streamly.Tutorial
                      , Streamly.Internal
+    if !impl(ghcjs)
+       exposed-modules:                      
+                       Streamly.Network.Socket
+                     , Streamly.Network.Server
+                     , Streamly.Network.Client
 
     default-language: Haskell2010
     ghc-options:      -Wall -fspec-constr-recursive=10
@@ -275,8 +277,10 @@ library
                      , mtl               >= 2.2   && < 3
                      , transformers      >= 0.4   && < 0.6
                      , transformers-base >= 0.4   && < 0.5
-                     , network           >= 2.6   && < 4
 
+  if !impl(ghcjs)
+    build-depends:
+                     network           >= 2.6   && < 4
   if impl(ghc < 8.0)
     build-depends:
         semigroups    >= 0.18   && < 0.19


### PR DESCRIPTION
This is a temporary change to not build the network functionality for ghcjs, once the appropriate js ffi is added to the network package we may not need to do this.