### PR TITLE
Add an inspection test for #214

### DIFF
--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -273,7 +273,7 @@ import qualified Control.Monad.Catch as MC
 import Streamly.Mem.Array.Types (Array(..))
 import Streamly.Fold.Types (Fold(..))
 import Streamly.Pipe.Types (Pipe(..), PipeState(..))
-import Streamly.SVar (MonadAsync, defState, adaptState, State)
+import Streamly.SVar (MonadAsync, defState, adaptState)
 
 import Streamly.Streams.StreamD.Type
 
@@ -370,11 +370,11 @@ replicateM :: forall m a. Monad m => Int -> m a -> Stream m a
 replicateM n p = Stream step n
   where
     {-# INLINE_LATE step #-}
-    step :: State K.Stream m a -> Int -> m (Step Int a)
-    step _ i | i <= 0    = return Stop
-             | otherwise = do
-                x <- p
-                return $ Yield x (i - 1)
+    step _ (i :: Int)
+      | i <= 0    = return Stop
+      | otherwise = do
+          x <- p
+          return $ Yield x (i - 1)
 
 {-# INLINE_NORMAL replicate #-}
 replicate :: Monad m => Int -> a -> Stream m a

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ extra-deps:
     - Chart-1.9.1
     - Chart-diagrams-1.9.2
     - bench-show-0.2.2
+    - inspection-testing-0.4.2.1
 
 #allow-newer: true
 flags: {}

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -339,7 +339,7 @@ test-suite test
 --     , base              >= 4.8   && < 5
 --     , hspec             >= 2.0   && < 3
 --   default-language: Haskell2010
--- 
+--
 -- test-suite pure-streams-streamly
 --   type: exitcode-stdio-1.0
 --   main-is: PureStreams.hs
@@ -501,6 +501,17 @@ test-suite parallel-loops
       streamly
     , base   >= 4.8   && < 5
     , random >= 1.0.0 && < 2
+
+test-suite inspection
+  type: exitcode-stdio-1.0
+  default-language: Haskell2010
+  main-is: inspection.hs
+  hs-source-dirs:  test
+  ghc-options:  -fno-ignore-asserts -O2 -Wall -threaded -with-rtsopts=-N
+  build-Depends:
+      streamly
+    , base               >= 4.8   && < 5
+    , inspection-testing >= 0.4   && < 0.5
 
 -------------------------------------------------------------------------------
 -- Benchmarks

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -512,6 +512,8 @@ test-suite inspection
       streamly
     , base               >= 4.8   && < 5
     , inspection-testing >= 0.4   && < 0.5
+  if impl(ghc < 8.0)
+    buildable: False
 
 -------------------------------------------------------------------------------
 -- Benchmarks

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -514,6 +514,9 @@ test-suite inspection
     , inspection-testing >= 0.4   && < 0.5
   if impl(ghc < 8.0)
     buildable: False
+  -- On Windows we're getting "unknown symbol `clock_gettime'"
+  if os(windows)
+    buildable: False
 
 -------------------------------------------------------------------------------
 -- Benchmarks

--- a/test/inspection.hs
+++ b/test/inspection.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -O -fplugin Test.Inspection.Plugin #-}
+
+import Streamly
+import qualified Streamly.Prelude as S
+import Test.Inspection
+
+main :: IO ()
+main = pure ()  -- If the test compiles, it passes
+
+-------------------------------------------------------------------------------
+-- #214 regression test: 'concatMap (replicate n)' should be specialized
+-------------------------------------------------------------------------------
+
+{-# INLINE concatMap1 #-}
+concatMap1 :: MonadAsync m => SerialT m Int -> m ()
+concatMap1 src = S.drain $ S.concatMap (S.replicate 3) src
+
+{-# INLINE sourceUnfoldrMN #-}
+sourceUnfoldrMN :: MonadAsync m => Int -> Int -> SerialT m Int
+sourceUnfoldrMN m n = S.unfoldrM step n
+    where
+    step cnt =
+        if cnt > n + m
+        then return Nothing
+        else return (Just (cnt, cnt + 1))
+
+test214 :: IO ()
+test214 = concatMap1 (sourceUnfoldrMN 1000000 5)
+
+inspect $ hasNoTypeClasses 'test214


### PR DESCRIPTION
This is how it looks when the test fails:

```
test/inspection.hs:33:1: test214 does not contain dictionary values failed:
    go_sdTh = \ (ds1 [Dmd=<S,1*U>] :: ghc-prim-0.5.3:GHC.Types.SPEC)
    [... many more lines stripped --@neongreen]