### PR TITLE
Fix a bug in zipWithM rule that causes effects to run only once.

### DIFF
--- a/src/Streamly/Streams/Instances.hs
+++ b/src/Streamly/Streams/Instances.hs
@@ -108,6 +108,7 @@ instance (a ~ Char) => IsString (STREAM Identity a) where {                   \
     fromString = P.fromList };                                                \
                                                                               \
 instance NFData a => NFData (STREAM Identity a) where {                       \
+    {-# INLINE rnf #-};                                                       \
     rnf = runIdentity . P.foldl' (\_ x -> rnf x) () };                        \
 
 -------------------------------------------------------------------------------

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE ViewPatterns              #-}
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE MagicHash                 #-}
+{-# LANGUAGE TypeApplications          #-}
 
 #include "inline.hs"
 
@@ -255,6 +256,7 @@ import Control.Monad.Catch (MonadCatch)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans (MonadTrans(lift))
 import Data.Bits (shiftR, shiftL, (.|.), (.&.))
+import Data.Functor.Identity (Identity)
 import Data.Maybe (fromJust, isJust)
 import Data.Word (Word32)
 import Foreign.Ptr (Ptr)
@@ -2353,7 +2355,7 @@ zipWithM f (Stream stepa ta) (Stream stepb tb) = Stream step (ta, tb, Nothing)
             Stop     -> return Stop
 
 {-# RULES "zipWithM xs xs"
-    forall f xs. zipWithM f xs xs = mapM (\x -> f x x) xs #-}
+    forall f xs. zipWithM @Identity f xs xs = mapM (\x -> f x x) xs #-}
 
 {-# INLINE zipWith #-}
 zipWith :: Monad m => (a -> b -> c) -> Stream m a -> Stream m b -> Stream m c

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -11,7 +11,10 @@
 {-# LANGUAGE ViewPatterns              #-}
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE MagicHash                 #-}
+
+#if __GLASGOW_HASKELL__ >= 801
 {-# LANGUAGE TypeApplications          #-}
+#endif
 
 #include "inline.hs"
 
@@ -256,7 +259,9 @@ import Control.Monad.Catch (MonadCatch)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans (MonadTrans(lift))
 import Data.Bits (shiftR, shiftL, (.|.), (.&.))
+#if __GLASGOW_HASKELL__ >= 801
 import Data.Functor.Identity (Identity)
+#endif
 import Data.Maybe (fromJust, isJust)
 import Data.Word (Word32)
 import Foreign.Ptr (Ptr)
@@ -2354,8 +2359,10 @@ zipWithM f (Stream stepa ta) (Stream stepb tb) = Stream step (ta, tb, Nothing)
             Skip sb' -> return $ Skip (sa, sb', Just x)
             Stop     -> return Stop
 
+#if __GLASGOW_HASKELL__ >= 801
 {-# RULES "zipWithM xs xs"
     forall f xs. zipWithM @Identity f xs xs = mapM (\x -> f x x) xs #-}
+#endif
 
 {-# INLINE zipWith #-}
 zipWith :: Monad m => (a -> b -> c) -> Stream m a -> Stream m b -> Stream m c


### PR DESCRIPTION
I looked through other rules and as far as I can tell they are safe, these was the only one that needed fixing to run only in Identity.