### PR TITLE
Streamly.Mem.Array.Stream

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -83,6 +83,8 @@ example, concat streams concurrently using this.
     character streams and other character stream operations.
   * _Arrays_: `Streamly.Mem.Array` module provides arrays for efficient
     in-memory buffering and efficient interfacing with IO.
+  * `Streamly.Mem.Array.Stream` module provide combinators to work on streams
+    of arrays.
 
 * Add the following to `Streamly.Prelude`:
     * `foldrS` to fold a stream to a stream

--- a/examples/HandleIO.hs
+++ b/examples/HandleIO.hs
@@ -1,6 +1,7 @@
 import qualified Streamly.Prelude as S
 import qualified Streamly.Fold as FL
-import qualified Streamly.Mem.Array as A
+-- import qualified Streamly.Mem.Array as A
+import qualified Streamly.Mem.Array.Stream as AS
 import qualified Streamly.FileSystem.Handle as FH
 import qualified System.IO as FH
 -- import qualified Streamly.FileSystem.FD as FH
@@ -25,7 +26,7 @@ ord' = (fromIntegral . ord)
 
 wcl :: FH.Handle -> IO ()
 wcl src = print =<< (S.length
-    $ A.splitArraysOn 10
+    $ AS.splitOn 10
     $ FH.readArrays src)
 {-
 -- Char stream version

--- a/src/Streamly/FileSystem/FD.hs
+++ b/src/Streamly/FileSystem/FD.hs
@@ -151,6 +151,7 @@ import qualified Streamly.FileSystem.FDIO as RawIO hiding (write)
 -- import Streamly.String (encodeUtf8, decodeUtf8, foldLines)
 
 import qualified Streamly.Mem.Array as A
+import qualified Streamly.Mem.Array.Stream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Streams.StreamD.Type as D
 
@@ -326,7 +327,7 @@ readArrays = readArraysOfUpto defaultChunkSize
 --
 {-# INLINE readByChunksUpto #-}
 readByChunksUpto :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
-readByChunksUpto chunkSize h = A.flattenArrays $ readArraysOfUpto chunkSize h
+readByChunksUpto chunkSize h = AS.flatten $ readArraysOfUpto chunkSize h
 
 -- TODO
 -- read :: (IsStream t, MonadIO m, Storable a) => Handle -> t m a
@@ -338,7 +339,7 @@ readByChunksUpto chunkSize h = A.flattenArrays $ readArraysOfUpto chunkSize h
 -- @since 0.7.0
 {-# INLINE read #-}
 read :: (IsStream t, MonadIO m) => Handle -> t m Word8
-read = A.flattenArrays . readArrays
+read = AS.flatten . readArrays
 
 -------------------------------------------------------------------------------
 -- Writing
@@ -360,7 +361,7 @@ writeArrays h m = S.mapM_ (liftIO . writeArray h) m
 {-# INLINE writeArraysPackedUpto #-}
 writeArraysPackedUpto :: (MonadIO m, Storable a)
     => Int -> Handle -> SerialT m (Array a) -> m ()
-writeArraysPackedUpto n h xs = writeArrays h $ A.packArraysChunksOf n xs
+writeArraysPackedUpto n h xs = writeArrays h $ AS.compact n xs
 
 #if !defined(mingw32_HOST_OS)
 -- XXX this is incomplete
@@ -400,7 +401,7 @@ _writevArraysPackedUpto n h xs =
 -- @since 0.7.0
 {-# INLINE writeByChunksOf #-}
 writeByChunksOf :: MonadIO m => Int -> Handle -> SerialT m Word8 -> m ()
-writeByChunksOf n h m = writeArrays h $ A.arraysOf n m
+writeByChunksOf n h m = writeArrays h $ AS.arraysOf n m
 
 -- > write = 'writeByChunks' A.defaultChunkSize
 --

--- a/src/Streamly/FileSystem/File.hs
+++ b/src/Streamly/FileSystem/File.hs
@@ -123,7 +123,7 @@ import Streamly.SVar (MonadAsync)
 -- import Streamly.String (encodeUtf8, decodeUtf8, foldLines)
 
 import qualified Streamly.FileSystem.Handle as FH
-import qualified Streamly.Mem.Array as A
+import qualified Streamly.Mem.Array.Stream as AS
 import qualified Streamly.Mem.Array.Types as A hiding (flattenArrays)
 import qualified Streamly.Prelude as S
 
@@ -233,7 +233,7 @@ readByChunksUpto chunkSize h = A.flattenArrays $ readArraysOfUpto chunkSize h
 -- @since 0.7.0
 {-# INLINE read #-}
 read :: (IsStream t, MonadCatch m, MonadIO m) => FilePath -> t m Word8
-read file = A.flattenArrays $ withFile file ReadMode FH.readArrays
+read file = AS.flatten $ withFile file ReadMode FH.readArrays
 
 {-
 -- | Generate a stream of elements of the given type from a file 'Handle'. The
@@ -289,7 +289,7 @@ writeArrays = writeArraysMode WriteMode
 {-# INLINE writeByChunks #-}
 writeByChunks :: (MonadAsync m, MonadCatch m)
     => Int -> FilePath -> SerialT m Word8 -> m ()
-writeByChunks n file xs = writeArrays file $ A.arraysOf n xs
+writeByChunks n file xs = writeArrays file $ AS.arraysOf n xs
 
 -- > write = 'writeByChunks' A.defaultChunkSize
 --
@@ -325,7 +325,7 @@ appendArrays = writeArraysMode AppendMode
 {-# INLINE appendByChunks #-}
 appendByChunks :: (MonadAsync m, MonadCatch m)
     => Int -> FilePath -> SerialT m Word8 -> m ()
-appendByChunks n file xs = appendArrays file $ A.arraysOf n xs
+appendByChunks n file xs = appendArrays file $ AS.arraysOf n xs
 
 -- | Append a byte stream to a file. Combines the bytes in chunks of size up to
 -- 'A.defaultChunkSize' before writing.  If the file exists then the new data

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -127,6 +127,7 @@ import Streamly.Mem.Array.Types (defaultChunkSize, shrinkToFit)
 -- import Streamly.String (encodeUtf8, decodeUtf8, foldLines)
 
 import qualified Streamly.Mem.Array as A
+import qualified Streamly.Mem.Array.Stream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Streams.StreamD.Type as D
 
@@ -244,7 +245,7 @@ readArrays = readArraysOfUpto defaultChunkSize
 -- @since 0.7.0
 {-# INLINE readByChunksUpto #-}
 readByChunksUpto :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
-readByChunksUpto chunkSize h = A.flattenArrays $ readArraysOfUpto chunkSize h
+readByChunksUpto chunkSize h = AS.flatten $ readArraysOfUpto chunkSize h
 
 -- TODO
 -- Generate a stream of elements of the given type from a file 'Handle'.
@@ -256,7 +257,7 @@ readByChunksUpto chunkSize h = A.flattenArrays $ readArraysOfUpto chunkSize h
 -- @since 0.7.0
 {-# INLINE read #-}
 read :: (IsStream t, MonadIO m) => Handle -> t m Word8
-read = A.flattenArrays . readArrays
+read = AS.flatten . readArrays
 
 -------------------------------------------------------------------------------
 -- Writing
@@ -278,7 +279,7 @@ writeArrays h m = S.mapM_ (liftIO . writeArray h) m
 {-# INLINE writeArraysPackedUpto #-}
 writeArraysPackedUpto :: (MonadIO m, Storable a)
     => Int -> Handle -> SerialT m (Array a) -> m ()
-writeArraysPackedUpto n h xs = writeArrays h $ A.packArraysChunksOf n xs
+writeArraysPackedUpto n h xs = writeArrays h $ AS.compact n xs
 
 -- GHC buffer size dEFAULT_FD_BUFFER_SIZE=8192 bytes.
 --
@@ -295,7 +296,7 @@ writeArraysPackedUpto n h xs = writeArrays h $ A.packArraysChunksOf n xs
 -- @since 0.7.0
 {-# INLINE writeByChunksOf #-}
 writeByChunksOf :: MonadIO m => Int -> Handle -> SerialT m Word8 -> m ()
-writeByChunksOf n h m = writeArrays h $ A.arraysOf n m
+writeByChunksOf n h m = writeArrays h $ AS.arraysOf n m
 
 -- > write = 'writeByChunksOf' A.defaultChunkSize
 --

--- a/src/Streamly/Mem/Array.hs
+++ b/src/Streamly/Mem/Array.hs
@@ -132,7 +132,7 @@ module Streamly.Mem.Array
     , transformWith
 
     -- * Folding Arrays
-    , foldWith
+    -- , foldWith
     , foldArray
     )
 where
@@ -486,6 +486,6 @@ foldArray f arr = FL.foldl' f (A.read arr)
 -- | Fold an array using a stream fold operation.
 --
 -- @since 0.7.0
-{-# INLINE foldWith #-}
-foldWith :: (MonadIO m, Storable a) => (SerialT m a -> m b) -> Array a -> m b
-foldWith f arr = f (A.read arr)
+{-# INLINE _foldWith #-}
+_foldWith :: (MonadIO m, Storable a) => (SerialT m a -> m b) -> Array a -> m b
+_foldWith f arr = f (A.read arr)

--- a/src/Streamly/Mem/Array/Stream.hs
+++ b/src/Streamly/Mem/Array/Stream.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+#include "inline.hs"
+
+-- |
+-- Module      : Streamly.Mem.Array.Stream
+-- Copyright   : (c) 2019 Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : harendra.kumar@gmail.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- Combinators to efficiently manipulate streams of arrays.
+--
+module Streamly.Mem.Array.Stream
+    (
+    -- * Creation
+      arraysOf
+
+    -- * Flattening to elements
+    , flatten
+    -- , _flattenArraysRev
+    , unlinesBy
+
+    -- * Transformation
+    , splitOn
+    , compact -- compact
+
+    -- * Elimination
+    , toArray
+    )
+where
+
+import Control.Monad.IO.Class (MonadIO(..))
+-- import Data.Functor.Identity (Identity)
+import Data.Word (Word8)
+import Foreign.ForeignPtr (withForeignPtr)
+import Foreign.Ptr (minusPtr, plusPtr, castPtr)
+import Foreign.Storable (Storable(..))
+import Prelude hiding (length, null, last, map, (!!), read)
+
+import Streamly.Mem.Array.Types (Array(..), length)
+import Streamly.Streams.Serial (SerialT)
+import Streamly.Streams.StreamK.Type (IsStream)
+
+import qualified Streamly.Mem.Array.Types as A
+import qualified Streamly.Prelude as S
+import qualified Streamly.Streams.StreamD as D
+import qualified Streamly.Streams.Prelude as P
+
+-- | Convert a stream of arrays into a stream of their elements.
+--
+-- Same as the following but more efficient:
+--
+-- > flatten = S.concatMap A.read
+--
+-- @since 0.7.0
+{-# INLINE flatten #-}
+flatten :: (IsStream t, MonadIO m, Storable a) => t m (Array a) -> t m a
+flatten m = D.fromStreamD $ A.flattenArrays (D.toStreamD m)
+
+-- XXX should we have a reverseArrays API to reverse the stream of arrays
+-- instead?
+--
+-- | Convert a stream of arrays into a stream of their elements reversing the
+-- contents of each array before flattening.
+--
+-- @since 0.7.0
+{-# INLINE _flattenArraysRev #-}
+_flattenArraysRev :: (IsStream t, MonadIO m, Storable a) => t m (Array a) -> t m a
+_flattenArraysRev m = D.fromStreamD $ A.flattenArraysRev (D.toStreamD m)
+
+-- XXX use an Array instead as separator? Or use a separate unlinesArraysBySeq
+-- API for that?
+--
+-- | Flatten a stream of arrays appending the given element after each
+-- array.
+--
+-- @since 0.7.0
+{-# INLINE unlinesBy #-}
+unlinesBy :: (MonadIO m, IsStream t, Storable a)
+    => a -> t m (Array a) -> t m a
+unlinesBy x = D.fromStreamD . A.unlines x . D.toStreamD
+
+-- | Split a stream of arrays on a given separator byte, dropping the separator
+-- and coalescing all the arrays between two separators into a single array.
+--
+-- @since 0.7.0
+{-# INLINE splitOn #-}
+splitOn
+    :: (IsStream t, MonadIO m)
+    => Word8
+    -> t m (Array Word8)
+    -> t m (Array Word8)
+splitOn byte s = D.fromStreamD $ A.splitOn byte $ D.toStreamD s
+
+-- | Coalesce adajcent arrays in incoming stream to form bigger arrays of a
+-- maximum specified size.
+--
+-- @since 0.7.0
+{-# INLINE compact #-}
+compact :: (MonadIO m, Storable a)
+    => Int -> SerialT m (Array a) -> SerialT m (Array a)
+compact n xs =
+    D.fromStreamD $ A.packArraysChunksOf n (D.toStreamD xs)
+
+-- | Groups the elements in an input stream into arrays of given size.
+--
+-- Same as the following but more efficient:
+--
+-- > arraysOf n = FL.groupsOf n (FL.toArrayN n)
+--
+-- @since 0.7.0
+{-# INLINE arraysOf #-}
+arraysOf :: (IsStream t, MonadIO m, Storable a)
+    => Int -> t m a -> t m (Array a)
+arraysOf n str =
+    D.fromStreamD $ A.fromStreamDArraysOf n (D.toStreamD str)
+
+-- XXX Both of these implementations of splicing seem to perform equally well.
+-- We need to perform benchmarks over a range of sizes though.
+
+-- CAUTION! length must more than equal to lengths of all the arrays in the
+-- stream.
+{-# INLINE spliceArraysLenUnsafe #-}
+spliceArraysLenUnsafe :: (MonadIO m, Storable a)
+    => Int -> SerialT m (Array a) -> m (Array a)
+spliceArraysLenUnsafe len buffered = do
+    arr <- liftIO $ A.newArray len
+    end <- S.foldlM' writeArr (aEnd arr) buffered
+    return $ arr {aEnd = end}
+
+    where
+
+    writeArr dst Array{..} =
+        liftIO $ withForeignPtr aStart $ \src -> do
+                        let count = aEnd `minusPtr` src
+                        A.memcpy (castPtr dst) (castPtr src) count
+                        return $ dst `plusPtr` count
+
+{-# INLINE _spliceArraysBuffered #-}
+_spliceArraysBuffered :: (MonadIO m, Storable a)
+    => SerialT m (Array a) -> m (Array a)
+_spliceArraysBuffered s = do
+    buffered <- P.foldr S.cons S.nil s
+    len <- S.sum (S.map length buffered)
+    spliceArraysLenUnsafe len s
+
+{-# INLINE spliceArraysRealloced #-}
+spliceArraysRealloced :: forall m a. (MonadIO m, Storable a)
+    => SerialT m (Array a) -> m (Array a)
+spliceArraysRealloced s = do
+    idst <- liftIO $ A.newArray (A.bytesToCount (undefined :: a)
+                                (A.mkChunkSizeKB 4))
+
+    arr <- S.foldlM' A.spliceWithDoubling idst s
+    liftIO $ A.shrinkToFit arr
+
+-- | Given a stream of arrays, splice them all together to generate a single
+-- array. The stream must be /finite/.
+--
+-- @since 0.7.0
+{-# INLINE toArray #-}
+toArray :: (MonadIO m, Storable a) => SerialT m (Array a) -> m (Array a)
+toArray = spliceArraysRealloced
+-- spliceArrays = _spliceArraysBuffered
+

--- a/src/Streamly/Mem/Array/Types.hs
+++ b/src/Streamly/Mem/Array/Types.hs
@@ -71,6 +71,7 @@ module Streamly.Mem.Array.Types
     , shrinkToFit
     , memcpy
     , memcmp
+    , bytesToCount
 
     , unlines
     )
@@ -209,6 +210,12 @@ memcmp p1 p2 len = do
 {-# INLINE unsafeInlineIO #-}
 unsafeInlineIO :: IO a -> a
 unsafeInlineIO (IO m) = case m realWorld# of (# _, r #) -> r
+
+{-# INLINE bytesToCount #-}
+bytesToCount :: Storable a => a -> Int -> Int
+bytesToCount x n =
+    let elemSize = sizeOf x
+    in n + elemSize - 1 `div` elemSize
 
 -------------------------------------------------------------------------------
 -- Construction

--- a/src/Streamly/Network/Client.hs
+++ b/src/Streamly/Network/Client.hs
@@ -70,7 +70,7 @@ import Streamly.Mem.Array.Types (Array(..), defaultChunkSize)
 import Streamly.Streams.Serial (SerialT)
 import Streamly.Streams.StreamK.Type (IsStream)
 
-import qualified Streamly.Mem.Array as A
+import qualified Streamly.Mem.Array.Stream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Network.Socket as SK
 
@@ -108,7 +108,7 @@ withConnection addr port =
 {-# INLINE read #-}
 read :: (IsStream t, MonadCatch m, MonadIO m)
     => (Word8, Word8, Word8, Word8) -> PortNumber -> t m Word8
-read addr port = A.flattenArrays $ withConnection addr port SK.readArrays
+read addr port = AS.flatten $ withConnection addr port SK.readArrays
 
 -------------------------------------------------------------------------------
 -- Writing
@@ -141,7 +141,7 @@ writeByChunks
     -> PortNumber
     -> SerialT m Word8
     -> m ()
-writeByChunks n addr port m = writeArrays addr port $ A.arraysOf n m
+writeByChunks n addr port m = writeArrays addr port $ AS.arraysOf n m
 
 -- | Write a stream to the supplied IPv4 host address and port number.
 --

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -93,6 +93,7 @@ import Streamly.Streams.StreamK.Type (IsStream, mkStream)
 -- import Streamly.String (encodeUtf8, decodeUtf8, foldLines)
 
 import qualified Streamly.Mem.Array as A
+import qualified Streamly.Mem.Array.Stream as AS
 import qualified Streamly.Mem.Array.Types as A hiding (flattenArrays)
 import qualified Streamly.Prelude as S
 
@@ -265,7 +266,7 @@ readByChunksUpto chunkSize h = A.flattenArrays $ readArraysUpto chunkSize h
 -- @since 0.7.0
 {-# INLINE read #-}
 read :: (IsStream t, MonadIO m) => Socket -> t m Word8
-read = A.flattenArrays . readArrays
+read = AS.flatten . readArrays
 
 -------------------------------------------------------------------------------
 -- Writing
@@ -293,7 +294,7 @@ writeArrays h m = S.mapM_ (liftIO . writeArray h) m
 -- @since 0.7.0
 {-# INLINE writeByChunks #-}
 writeByChunks :: MonadIO m => Int -> Socket -> SerialT m Word8 -> m ()
-writeByChunks n h m = writeArrays h $ A.arraysOf n m
+writeByChunks n h m = writeArrays h $ AS.arraysOf n m
 
 -- > write = 'writeByChunks' A.defaultChunkSize
 --

--- a/src/Streamly/String.hs
+++ b/src/Streamly/String.hs
@@ -76,6 +76,7 @@ import qualified Streamly.Prelude as S
 import qualified Streamly.Fold as FL
 import qualified Streamly.Mem.Array.Types as A (unlines)
 import qualified Streamly.Mem.Array as A
+import qualified Streamly.Mem.Array.Stream as AS
 import qualified Streamly.Streams.StreamD as D
 
 -- type String = List Char
@@ -246,4 +247,4 @@ unlines = D.fromStreamD . A.unlines '\n' . D.toStreamD
 -- > unwords . words /= id
 {-# INLINE unwords #-}
 unwords :: (MonadAsync m, IsStream t) => t m (Array Char) -> t m Char
-unwords = A.flattenArrays . (S.intersperse (A.fromList " "))
+unwords = AS.flatten . (S.intersperse (A.fromList " "))

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -232,6 +232,7 @@ library
 
                     -- IO devices
                      , Streamly.Mem.Array
+                     , Streamly.Mem.Array.Stream
                      , Streamly.FileSystem.Handle
 
                      , Streamly.Tutorial

--- a/test/Arrays.hs
+++ b/test/Arrays.hs
@@ -12,6 +12,7 @@ import Test.QuickCheck.Monadic (monadicIO, assert)
 import Test.Hspec as H
 
 import qualified Streamly.Mem.Array as A
+import qualified Streamly.Mem.Array.Stream as AS
 import qualified Streamly.Prelude as S
 
 -- Coverage build takes too long with default number of tests
@@ -74,7 +75,7 @@ testArraysOf =
             monadicIO $ do
                 xs <- S.toList
                     $ S.concatMap A.read
-                    $ A.arraysOf 240
+                    $ AS.arraysOf 240
                     $ S.fromList list
                 assert (xs == list)
 
@@ -84,8 +85,8 @@ testFlattenArrays =
         forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
             monadicIO $ do
                 xs <- S.toList
-                    $ A.flattenArrays
-                    $ A.arraysOf 240
+                    $ AS.flatten
+                    $ AS.arraysOf 240
                     $ S.fromList list
                 assert (xs == list)
 

--- a/test/String.hs
+++ b/test/String.hs
@@ -13,6 +13,7 @@ import Test.QuickCheck.Monadic (run, monadicIO, assert)
 import           Test.Hspec as H
 
 import qualified Streamly.Mem.Array as A
+import qualified Streamly.Mem.Array.Stream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.String as SS
 
@@ -57,7 +58,7 @@ testLinesArray =
         monadicIO $ do
             xs <- S.toList
                     $ S.map A.toList
-                    $ A.splitArraysOn 10
+                    $ AS.splitOn 10
                     $ S.yield (A.fromList list)
             assert (xs == map (map (fromIntegral . ord))
                               (lines (map (chr .  fromIntegral) list)))


### PR DESCRIPTION
A new module to deal with combinators that work on streams of arrays.

Is that the correct place in module hierarchy? Or are there any other possibilities e.g. `Streamly.Mem.ArrayStream`?