### PR TITLE
Renaming of read / write apis

### DIFF
--- a/benchmark/FileIO.hs
+++ b/benchmark/FileIO.hs
@@ -117,7 +117,7 @@ main = do
                 S.foldl' (\acc arr -> acc + foldlArr' (+) 0 arr) 0 s
             , mkBench "cat" href $ do
                 Handles inh _ <- readIORef href
-                FH.writeArrays devNull $ FH.readArraysOfUpto (256*1024) inh
+                FH.writeArrays devNull $ FH.readArraysOf (256*1024) inh
             ]
         , bgroup "readStream"
             [ mkBench "last" href $ do
@@ -198,7 +198,7 @@ main = do
                 FH.writeArraysPackedUpto (1024*1024) outh
                     $ S.insertAfterEach (return $ A.fromList [10])
                     $ AS.splitOn 10
-                    $ FH.readArraysOfUpto (1024*1024) inh
+                    $ FH.readArraysOf (1024*1024) inh
             -}
             , mkBench "words-unwords" href $ do
                 Handles inh outh <- readIORef href

--- a/examples/FileIOExamples.hs
+++ b/examples/FileIOExamples.hs
@@ -7,13 +7,13 @@ import Data.Char (ord)
 import System.Environment (getArgs)
 
 cat :: FilePath -> IO ()
-cat src = File.writeArrays "/dev/stdout" $ File.readArraysOfUpto (256*1024) src
+cat src = File.writeArrays "/dev/stdout" $ File.readArraysOf (256*1024) src
 
 cp :: FilePath -> FilePath -> IO ()
-cp src dst = File.writeArrays dst $ File.readArraysOfUpto (256*1024) src
+cp src dst = File.writeArrays dst $ File.readArraysOf (256*1024) src
 
 append :: FilePath -> FilePath -> IO ()
-append src dst = File.appendArrays dst $ File.readArraysOfUpto (256*1024) src
+append src dst = File.appendArrays dst $ File.readArraysOf (256*1024) src
 
 ord' :: Num a => Char -> a
 ord' = (fromIntegral . ord)

--- a/examples/HandleIO.hs
+++ b/examples/HandleIO.hs
@@ -12,12 +12,12 @@ import System.Environment (getArgs)
 import System.IO (IOMode(..), hSeek, SeekMode(..))
 
 cat :: FH.Handle -> IO ()
-cat src = FH.writeArrays FH.stdout $ FH.readArraysOfUpto (256*1024) src
+cat src = FH.writeArrays FH.stdout $ FH.readArraysOf (256*1024) src
 -- byte stream version
 -- cat src = FH.write FH.stdout $ FH.read src
 
 cp :: FH.Handle -> FH.Handle -> IO ()
-cp src dst = FH.writeArrays dst $ FH.readArraysOfUpto (256*1024) src
+cp src dst = FH.writeArrays dst $ FH.readArraysOf (256*1024) src
 -- byte stream version
 -- cp src dst = FH.write dst $ FH.read src
 

--- a/src/Streamly/FileSystem/FD.hs
+++ b/src/Streamly/FileSystem/FD.hs
@@ -403,7 +403,7 @@ _writevArraysPackedUpto n h xs =
 writeInChunksOf :: MonadIO m => Int -> Handle -> SerialT m Word8 -> m ()
 writeInChunksOf n h m = writeArrays h $ AS.arraysOf n m
 
--- > write = 'writeByChunks' A.defaultChunkSize
+-- > write = 'writeInChunksOf' A.defaultChunkSize
 --
 -- | Write a byte stream to a file handle. Combines the bytes in chunks of size
 -- up to 'A.defaultChunkSize' before writing.  Note that the write behavior

--- a/src/Streamly/FileSystem/FD.hs
+++ b/src/Streamly/FileSystem/FD.hs
@@ -75,7 +75,7 @@ module Streamly.FileSystem.FD
     -- , readUtf8
     -- , readLines
     -- , readFrames
-    , readByChunksUpto
+    , readInChunksOf
 
     -- -- * Array Read
     -- , readArrayUpto
@@ -321,13 +321,13 @@ readArrays = readArraysOfUpto defaultChunkSize
 -- read requests at the same time. For serial case we can use async IO. We can
 -- also control the read throughput in mbps or IOPS.
 
--- | @readByChunksUpto chunkSize handle@ reads a byte stream from a file handle,
+-- | @readInChunksOf chunkSize handle@ reads a byte stream from a file handle,
 -- reads are performed in chunks of up to @chunkSize@.  The stream ends as soon
 -- as EOF is encountered.
 --
-{-# INLINE readByChunksUpto #-}
-readByChunksUpto :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
-readByChunksUpto chunkSize h = AS.flatten $ readArraysOfUpto chunkSize h
+{-# INLINE readInChunksOf #-}
+readInChunksOf :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
+readInChunksOf chunkSize h = AS.flatten $ readArraysOfUpto chunkSize h
 
 -- TODO
 -- read :: (IsStream t, MonadIO m, Storable a) => Handle -> t m a

--- a/src/Streamly/FileSystem/FD.hs
+++ b/src/Streamly/FileSystem/FD.hs
@@ -90,7 +90,7 @@ module Streamly.FileSystem.FD
     -- , writeUtf8
     -- , writeUtf8Lines
     -- , writeFrames
-    , writeByChunksOf
+    , writeInChunksOf
 
     -- -- * Array Write
     -- , writeArray
@@ -399,9 +399,9 @@ _writevArraysPackedUpto n h xs =
 -- input elements.
 --
 -- @since 0.7.0
-{-# INLINE writeByChunksOf #-}
-writeByChunksOf :: MonadIO m => Int -> Handle -> SerialT m Word8 -> m ()
-writeByChunksOf n h m = writeArrays h $ AS.arraysOf n m
+{-# INLINE writeInChunksOf #-}
+writeInChunksOf :: MonadIO m => Int -> Handle -> SerialT m Word8 -> m ()
+writeInChunksOf n h m = writeArrays h $ AS.arraysOf n m
 
 -- > write = 'writeByChunks' A.defaultChunkSize
 --
@@ -412,7 +412,7 @@ writeByChunksOf n h m = writeArrays h $ AS.arraysOf n m
 -- @since 0.7.0
 {-# INLINE write #-}
 write :: MonadIO m => Handle -> SerialT m Word8 -> m ()
-write = writeByChunksOf defaultChunkSize
+write = writeInChunksOf defaultChunkSize
 
 {-
 {-# INLINE write #-}

--- a/src/Streamly/FileSystem/File.hs
+++ b/src/Streamly/FileSystem/File.hs
@@ -214,13 +214,13 @@ readArrays = readArraysOf A.defaultChunkSize
 -- also control the read throughput in mbps or IOPS.
 
 {-
--- | @readByChunksUpto chunkSize handle@ reads a byte stream from a file
+-- | @readInChunksOf chunkSize handle@ reads a byte stream from a file
 -- handle, reads are performed in chunks of up to @chunkSize@.  The stream ends
 -- as soon as EOF is encountered.
 --
-{-# INLINE readByChunksUpto #-}
-readByChunksUpto :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
-readByChunksUpto chunkSize h = A.flattenArrays $ readArraysOf chunkSize h
+{-# INLINE readInChunksOf #-}
+readInChunksOf :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
+readInChunksOf chunkSize h = A.flattenArrays $ readArraysOf chunkSize h
 -}
 
 -- TODO

--- a/src/Streamly/FileSystem/File.hs
+++ b/src/Streamly/FileSystem/File.hs
@@ -63,7 +63,7 @@ module Streamly.FileSystem.File
     -- -- * Array Read
     -- , readArrayOf
 
-    , readArraysOfUpto
+    , readArraysOf
     -- , readArraysOf
     , readArrays
 
@@ -183,26 +183,27 @@ appendArray file arr = SIO.withFile file AppendMode (\h -> FH.writeArray h arr)
 -- Stream of Arrays IO
 -------------------------------------------------------------------------------
 
--- | @readArraysOfUpto size file@ reads a stream of arrays from file @file@.
+-- | @readArraysOf size file@ reads a stream of arrays from file @file@.
 -- The maximum size of a single array is specified by @size@. The actual size
 -- read may be less than or equal to @size@.
-{-# INLINABLE readArraysOfUpto #-}
-readArraysOfUpto :: (IsStream t, MonadCatch m, MonadIO m)
+{-# INLINABLE readArraysOf #-}
+readArraysOf :: (IsStream t, MonadCatch m, MonadIO m)
     => Int -> FilePath -> t m (Array Word8)
-readArraysOfUpto size file = withFile file ReadMode (FH.readArraysOfUpto size)
+readArraysOf size file = withFile file ReadMode (FH.readArraysOf size)
 
 -- XXX read 'Array a' instead of Word8
 --
 -- | @readArrays file@ reads a stream of arrays from file @file@.
--- The maximum size of a single array is limited to @defaultChunkSize@.
+-- The maximum size of a single array is limited to @defaultChunkSize@. The
+-- actual size read may be less than @defaultChunkSize@.
 --
--- > readArrays = readArraysOfUpto defaultChunkSize
+-- > readArrays = readArraysOf defaultChunkSize
 --
 -- @since 0.7.0
 {-# INLINE readArrays #-}
 readArrays :: (IsStream t, MonadCatch m, MonadIO m)
     => FilePath -> t m (Array Word8)
-readArrays = readArraysOfUpto A.defaultChunkSize
+readArrays = readArraysOf A.defaultChunkSize
 
 -------------------------------------------------------------------------------
 -- Read File to Stream
@@ -219,7 +220,7 @@ readArrays = readArraysOfUpto A.defaultChunkSize
 --
 {-# INLINE readByChunksUpto #-}
 readByChunksUpto :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
-readByChunksUpto chunkSize h = A.flattenArrays $ readArraysOfUpto chunkSize h
+readByChunksUpto chunkSize h = A.flattenArrays $ readArraysOf chunkSize h
 -}
 
 -- TODO

--- a/src/Streamly/FileSystem/File.hs
+++ b/src/Streamly/FileSystem/File.hs
@@ -72,7 +72,7 @@ module Streamly.FileSystem.File
     -- , writeUtf8
     -- , writeUtf8ByLines
     -- , writeByFrames
-    , writeByChunks
+    , writeInChunksOf
 
     -- -- * Array Write
     , writeArray
@@ -287,12 +287,12 @@ writeArrays = writeArraysMode WriteMode
 -- input elements.
 --
 -- @since 0.7.0
-{-# INLINE writeByChunks #-}
-writeByChunks :: (MonadAsync m, MonadCatch m)
+{-# INLINE writeInChunksOf #-}
+writeInChunksOf :: (MonadAsync m, MonadCatch m)
     => Int -> FilePath -> SerialT m Word8 -> m ()
-writeByChunks n file xs = writeArrays file $ AS.arraysOf n xs
+writeInChunksOf n file xs = writeArrays file $ AS.arraysOf n xs
 
--- > write = 'writeByChunks' A.defaultChunkSize
+-- > write = 'writeInChunksOf' A.defaultChunkSize
 --
 -- | Write a byte stream to a file. Combines the bytes in chunks of size
 -- up to 'A.defaultChunkSize' before writing. If the file exists it is
@@ -302,7 +302,7 @@ writeByChunks n file xs = writeArrays file $ AS.arraysOf n xs
 -- @since 0.7.0
 {-# INLINE write #-}
 write :: (MonadAsync m, MonadCatch m) => FilePath -> SerialT m Word8 -> m ()
-write = writeByChunks A.defaultChunkSize
+write = writeInChunksOf A.defaultChunkSize
 
 {-
 {-# INLINE write #-}

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -67,7 +67,7 @@ module Streamly.FileSystem.Handle
     -- , readArrayUpto
     -- , readArrayOf
 
-    , readArraysOfUpto
+    , readArraysOf
     -- , readArraysOf
     , readArrays
 
@@ -187,13 +187,13 @@ writeArray h Array{..} = withForeignPtr aStart $ \p -> hPutBuf h p aLen
 -- Stream of Arrays IO
 -------------------------------------------------------------------------------
 
--- | @readArraysOfUpto size h@ reads a stream of arrays from file handle @h@.
+-- | @readArraysOf size h@ reads a stream of arrays from file handle @h@.
 -- The maximum size of a single array is specified by @size@. The actual size
 -- read may be less than or equal to @size@.
-{-# INLINABLE _readArraysOfUpto #-}
-_readArraysOfUpto :: (IsStream t, MonadIO m)
+{-# INLINABLE _readArraysOf #-}
+_readArraysOf :: (IsStream t, MonadIO m)
     => Int -> Handle -> t m (Array Word8)
-_readArraysOfUpto size h = go
+_readArraysOf size h = go
   where
     -- XXX use cons/nil instead
     go = mkStream $ \_ yld _ stp -> do
@@ -202,13 +202,14 @@ _readArraysOfUpto size h = go
         then stp
         else yld arr go
 
--- | @readArraysOfUpto size handle@ reads a stream of arrays from the file
+-- | @readArraysOf size handle@ reads a stream of arrays from the file
 -- handle @handle@.  The maximum size of a single array is limited to @size@.
+-- The actual size read may be less than or equal to @size@.
 --
 -- @since 0.7.0
-{-# INLINE_NORMAL readArraysOfUpto #-}
-readArraysOfUpto :: (IsStream t, MonadIO m) => Int -> Handle -> t m (Array Word8)
-readArraysOfUpto size h = D.fromStreamD (D.Stream step ())
+{-# INLINE_NORMAL readArraysOf #-}
+readArraysOf :: (IsStream t, MonadIO m) => Int -> Handle -> t m (Array Word8)
+readArraysOf size h = D.fromStreamD (D.Stream step ())
   where
     {-# INLINE_LATE step #-}
     step _ _ = do
@@ -222,14 +223,15 @@ readArraysOfUpto size h = D.fromStreamD (D.Stream step ())
 --
 -- | @readArrays handle@ reads a stream of arrays from the specified file
 -- handle.  The maximum size of a single array is limited to
+-- @defaultChunkSize@. The actual size read may be less than or equal to
 -- @defaultChunkSize@.
 --
--- > readArrays = readArraysOfUpto defaultChunkSize
+-- > readArrays = readArraysOf defaultChunkSize
 --
 -- @since 0.7.0
 {-# INLINE readArrays #-}
 readArrays :: (IsStream t, MonadIO m) => Handle -> t m (Array Word8)
-readArrays = readArraysOfUpto defaultChunkSize
+readArrays = readArraysOf defaultChunkSize
 
 -------------------------------------------------------------------------------
 -- Read File to Stream
@@ -245,7 +247,7 @@ readArrays = readArraysOfUpto defaultChunkSize
 -- @since 0.7.0
 {-# INLINE readByChunksUpto #-}
 readByChunksUpto :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
-readByChunksUpto chunkSize h = AS.flatten $ readArraysOfUpto chunkSize h
+readByChunksUpto chunkSize h = AS.flatten $ readArraysOf chunkSize h
 
 -- TODO
 -- Generate a stream of elements of the given type from a file 'Handle'.

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -61,7 +61,7 @@ module Streamly.FileSystem.Handle
     -- , readUtf8
     -- , readLines
     -- , readFrames
-    , readByChunksUpto
+    , readInChunksOf
 
     -- -- * Array Read
     -- , readArrayUpto
@@ -241,13 +241,13 @@ readArrays = readArraysOf defaultChunkSize
 -- read requests at the same time. For serial case we can use async IO. We can
 -- also control the read throughput in mbps or IOPS.
 
--- | @readByChunksUpto chunkSize handle@ reads a byte stream from a file
+-- | @readInChunksOf chunkSize handle@ reads a byte stream from a file
 -- handle, reads are performed in chunks of up to @chunkSize@.
 --
 -- @since 0.7.0
-{-# INLINE readByChunksUpto #-}
-readByChunksUpto :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
-readByChunksUpto chunkSize h = AS.flatten $ readArraysOf chunkSize h
+{-# INLINE readInChunksOf #-}
+readInChunksOf :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
+readInChunksOf chunkSize h = AS.flatten $ readArraysOf chunkSize h
 
 -- TODO
 -- Generate a stream of elements of the given type from a file 'Handle'.

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -81,7 +81,7 @@ module Streamly.FileSystem.Handle
     -- , writeUtf8
     -- , writeUtf8ByLines
     -- , writeByFrames
-    , writeByChunksOf
+    , writeInChunksOf
 
     -- -- * Array Write
     , writeArray
@@ -291,16 +291,16 @@ writeArraysPackedUpto n h xs = writeArrays h $ AS.compact n xs
 -- do not want buffering to occur at GHC level as well. Same thing applies to
 -- writes as well.
 
--- | @writeByChunksOf chunkSize handle stream@ writes @stream@ to @handle@ in
+-- | @writeInChunksOf chunkSize handle stream@ writes @stream@ to @handle@ in
 -- chunks of @chunkSize@.  A write is performed to the IO device as soon as we
 -- collect the required input size.
 --
 -- @since 0.7.0
-{-# INLINE writeByChunksOf #-}
-writeByChunksOf :: MonadIO m => Int -> Handle -> SerialT m Word8 -> m ()
-writeByChunksOf n h m = writeArrays h $ AS.arraysOf n m
+{-# INLINE writeInChunksOf #-}
+writeInChunksOf :: MonadIO m => Int -> Handle -> SerialT m Word8 -> m ()
+writeInChunksOf n h m = writeArrays h $ AS.arraysOf n m
 
--- > write = 'writeByChunksOf' A.defaultChunkSize
+-- > write = 'writeInChunksOf' A.defaultChunkSize
 --
 -- | Write a byte stream to a file handle. Combines the bytes in chunks of
 -- up to 'A.defaultChunkSize' before writing.
@@ -308,7 +308,7 @@ writeByChunksOf n h m = writeArrays h $ AS.arraysOf n m
 -- @since 0.7.0
 {-# INLINE write #-}
 write :: MonadIO m => Handle -> SerialT m Word8 -> m ()
-write = writeByChunksOf defaultChunkSize
+write = writeInChunksOf defaultChunkSize
 
 {-
 {-# INLINE write #-}

--- a/src/Streamly/Network/Client.hs
+++ b/src/Streamly/Network/Client.hs
@@ -47,7 +47,7 @@ module Streamly.Network.Client
     -- , writeUtf8
     -- , writeUtf8ByLines
     -- , writeByFrames
-    -- , writeByChunks
+    -- , writeInChunksOf
 
     -- -- * Array Write
     -- , writeArray
@@ -133,15 +133,15 @@ writeArrays addr port xs =
 -- input elements.
 --
 -- @since 0.7.0
-{-# INLINE writeByChunks #-}
-writeByChunks
+{-# INLINE writeInChunksOf #-}
+writeInChunksOf
     :: (MonadCatch m, MonadAsync m)
     => Int
     -> (Word8, Word8, Word8, Word8)
     -> PortNumber
     -> SerialT m Word8
     -> m ()
-writeByChunks n addr port m = writeArrays addr port $ AS.arraysOf n m
+writeInChunksOf n addr port m = writeArrays addr port $ AS.arraysOf n m
 
 -- | Write a stream to the supplied IPv4 host address and port number.
 --
@@ -149,4 +149,4 @@ writeByChunks n addr port m = writeArrays addr port $ AS.arraysOf n m
 {-# INLINE write #-}
 write :: (MonadCatch m, MonadAsync m)
     => (Word8, Word8, Word8, Word8) -> PortNumber -> SerialT m Word8 -> m ()
-write = writeByChunks defaultChunkSize
+write = writeInChunksOf defaultChunkSize

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -56,7 +56,7 @@ module Streamly.Network.Socket
     -- , writeUtf8
     -- , writeUtf8ByLines
     -- , writeByFrames
-    , writeByChunks
+    , writeInChunksOf
 
     -- -- * Array Write
     , writeArray
@@ -292,11 +292,11 @@ writeArrays h m = S.mapM_ (liftIO . writeArray h) m
 -- input elements.
 --
 -- @since 0.7.0
-{-# INLINE writeByChunks #-}
-writeByChunks :: MonadIO m => Int -> Socket -> SerialT m Word8 -> m ()
-writeByChunks n h m = writeArrays h $ AS.arraysOf n m
+{-# INLINE writeInChunksOf #-}
+writeInChunksOf :: MonadIO m => Int -> Socket -> SerialT m Word8 -> m ()
+writeInChunksOf n h m = writeArrays h $ AS.arraysOf n m
 
--- > write = 'writeByChunks' A.defaultChunkSize
+-- > write = 'writeInChunksOf' A.defaultChunkSize
 --
 -- | Write a byte stream to a file handle. Combines the bytes in chunks of size
 -- up to 'A.defaultChunkSize' before writing.  Note that the write behavior
@@ -305,7 +305,7 @@ writeByChunks n h m = writeArrays h $ AS.arraysOf n m
 -- @since 0.7.0
 {-# INLINE write #-}
 write :: MonadIO m => Socket -> SerialT m Word8 -> m ()
-write = writeByChunks A.defaultChunkSize
+write = writeInChunksOf A.defaultChunkSize
 
 {-
 {-# INLINE write #-}

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -154,9 +154,9 @@ readArrayUptoWith f size h = do
 -- handle it blocks until some data becomes available. If data is available
 -- then it immediately returns that data without blocking. It reads a maximum
 -- of up to the size requested.
-{-# INLINABLE readArrayUpto #-}
-readArrayUpto :: Int -> Socket -> IO (Array Word8)
-readArrayUpto = readArrayUptoWith recvBuf
+{-# INLINABLE readArrayOf #-}
+readArrayOf :: Int -> Socket -> IO (Array Word8)
+readArrayOf = readArrayUptoWith recvBuf
 
 -------------------------------------------------------------------------------
 -- Array IO (output)
@@ -217,14 +217,14 @@ readArraysUptoWith f size h = go
         then stp
         else yld arr go
 
--- | @readArraysUpto size h@ reads a stream of arrays from file handle @h@.
+-- | @readArraysOf size h@ reads a stream of arrays from file handle @h@.
 -- The maximum size of a single array is limited to @size@.
 -- 'fromHandleArraysUpto' ignores the prevailing 'TextEncoding' and 'NewlineMode'
 -- on the 'Handle'.
-{-# INLINABLE readArraysUpto #-}
-readArraysUpto :: (IsStream t, MonadIO m)
+{-# INLINABLE readArraysOf #-}
+readArraysOf :: (IsStream t, MonadIO m)
     => Int -> Socket -> t m (Array Word8)
-readArraysUpto = readArraysUptoWith readArrayUpto
+readArraysOf = readArraysUptoWith readArrayOf
 
 -- XXX read 'Array a' instead of Word8
 --
@@ -236,7 +236,7 @@ readArraysUpto = readArraysUptoWith readArrayUpto
 -- @since 0.7.0
 {-# INLINE readArrays #-}
 readArrays :: (IsStream t, MonadIO m) => Socket -> t m (Array Word8)
-readArrays = readArraysUpto A.defaultChunkSize
+readArrays = readArraysOf A.defaultChunkSize
 
 -------------------------------------------------------------------------------
 -- Read File to Stream

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -247,13 +247,13 @@ readArrays = readArraysOf A.defaultChunkSize
 -- also control the read throughput in mbps or IOPS.
 
 {-
--- | @readByChunksUpto chunkSize handle@ reads a byte stream from a file
+-- | @readInChunksOf chunkSize handle@ reads a byte stream from a file
 -- handle, reads are performed in chunks of up to @chunkSize@.  The stream ends
 -- as soon as EOF is encountered.
 --
-{-# INLINE readByChunksUpto #-}
-readByChunksUpto :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
-readByChunksUpto chunkSize h = A.flattenArrays $ readArraysUpto chunkSize h
+{-# INLINE readInChunksOf #-}
+readInChunksOf :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
+readInChunksOf chunkSize h = A.flattenArrays $ readArraysUpto chunkSize h
 -}
 
 -- TODO


### PR DESCRIPTION
The following functions are renamed in this PR
- readArraysOfUpto -> readArraysOf
- readByChunksUpto -> readInChunksOf
- writeByChunksUpto -> writeInChunksOf
- writeByChunks -> writeInChunksOf (to be consistent with readInChunksOf)

Some functions, not exposed, might still have the old names.