### PR TITLE
Implement IO write operations as folds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,14 +431,14 @@ withArg2 f = do
 ### cat
 
 ``` haskell
-cat = FH.writeArrays stdout . FH.readArrays
+cat = S.runFold (FH.writeArrays stdout) . FH.readArrays
 main = withArg cat
 ```
 
 ### cp
 
 ``` haskell
-cp src dst = FH.writeArrays dst $ FH.readArrays src
+cp src dst = S.runFold (FH.writeArrays dst) $ FH.readArrays src
 main = withArg2 cp
 ```
 

--- a/bench.sh
+++ b/bench.sh
@@ -2,7 +2,7 @@
 
 print_help () {
   echo "Usage: $0 "
-  echo "       [--benchmarks <all|linear|linear-async|linear-rate|nested|fileio|base>]"
+  echo "       [--benchmarks <all|linear|linear-async|linear-rate|nested|fileio|array|base>]"
   echo "       [--group-diff]"
   echo "       [--graphs]"
   echo "       [--no-measure]"
@@ -231,7 +231,7 @@ run_reports() {
 #-----------------------------------------------------------------------------
 
 DEFAULT_BENCHMARKS="linear"
-ALL_BENCHMARKS="linear linear-async linear-rate nested fileio base"
+ALL_BENCHMARKS="linear linear-async linear-rate nested fileio array base"
 GROUP_DIFF=0
 
 COMPARE=0

--- a/benchmark/ArrayOps.hs
+++ b/benchmark/ArrayOps.hs
@@ -49,7 +49,7 @@ type Stream = A.Array
 
 {-# INLINE sourceUnfoldr #-}
 sourceUnfoldr :: MonadIO m => Int -> m (Stream Int)
-sourceUnfoldr n = A.writeN value $ S.unfoldr step n
+sourceUnfoldr n = S.runFold (A.writeN value) $ S.unfoldr step n
     where
     step cnt =
         if cnt > n + value
@@ -58,18 +58,18 @@ sourceUnfoldr n = A.writeN value $ S.unfoldr step n
 
 {-# INLINE sourceIntFromTo #-}
 sourceIntFromTo :: MonadIO m => Int -> m (Stream Int)
-sourceIntFromTo n = A.writeN value $ S.enumerateFromTo n (n + value)
+sourceIntFromTo n = S.runFold (A.writeN value) $ S.enumerateFromTo n (n + value)
 
 {-# INLINE sourceIntFromToFromStream #-}
 sourceIntFromToFromStream :: MonadIO m => Int -> m (Stream Int)
-sourceIntFromToFromStream n = A.write $ S.enumerateFromTo n (n + value)
+sourceIntFromToFromStream n = S.runFold A.write $ S.enumerateFromTo n (n + value)
 
 sourceIntFromToFromList :: MonadIO m => Int -> m (Stream Int)
 sourceIntFromToFromList n = P.return $ A.fromList $ [n..n + value]
 
 {-# INLINE sourceFromList #-}
 sourceFromList :: MonadIO m => Int -> m (Stream Int)
-sourceFromList n = A.writeN value $ S.fromList [n..n+value]
+sourceFromList n = S.runFold (A.writeN value) $ S.fromList [n..n+value]
 
 {-# INLINE sourceIsList #-}
 sourceIsList :: Int -> Stream Int
@@ -280,7 +280,7 @@ onArray
     :: MonadIO m => (S.SerialT m Int -> S.SerialT m Int)
     -> Stream Int
     -> m (Stream Int)
-onArray f arr = A.writeN value $ f $ A.read arr
+onArray f arr = S.runFold (A.writeN value) $ f $ A.read arr
 
 scanl'        n = composeN n $ onArray $ S.scanl' (+) 0
 scanl1'       n = composeN n $ onArray $ S.scanl1' (+)

--- a/benchmark/Chart.hs
+++ b/benchmark/Chart.hs
@@ -22,7 +22,14 @@ import BenchShow
 -- Command line parsing
 ------------------------------------------------------------------------------
 
-data BenchType = Linear | LinearAsync | LinearRate | Nested | Base | FileIO
+data BenchType
+    = Linear
+    | LinearAsync
+    | LinearRate
+    | Nested
+    | Base
+    | FileIO
+    | Array
     deriving Show
 
 data Options = Options
@@ -63,6 +70,7 @@ parseBench = do
         Just "nested" -> setBenchType Nested
         Just "base" -> setBenchType Base
         Just "fileio" -> setBenchType FileIO
+        Just "array" -> setBenchType Array
         Just str -> do
                 liftIO $ putStrLn $ "unrecognized benchmark type " <> str
                 mzero
@@ -233,6 +241,10 @@ makeFileIOGraphs :: Config -> String -> IO ()
 makeFileIOGraphs cfg@Config{..} inputFile =
     ignoringErr $ graph inputFile "fileIO" cfg
 
+makeArrayGraphs :: Config -> String -> IO ()
+makeArrayGraphs cfg@Config{..} inputFile =
+    ignoringErr $ graph inputFile "array" cfg
+
 ------------------------------------------------------------------------------
 -- Reports/Charts for base streams
 ------------------------------------------------------------------------------
@@ -334,6 +346,11 @@ main = do
                             makeFileIOGraphs
                             "charts/fileio/results.csv"
                             "charts/fileio"
+                Array -> benchShow opts cfg
+                            { title = Just "Array" }
+                            makeArrayGraphs
+                            "charts/array/results.csv"
+                            "charts/array"
                 Base -> do
                     let cfg' = cfg { title = Just "100,000 elems" }
                     if groupDiff

--- a/benchmark/FileIO.hs
+++ b/benchmark/FileIO.hs
@@ -21,6 +21,7 @@ import qualified Streamly.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Fold as FL
 import qualified Streamly.String as SS
+import qualified Streamly.Internal as Internal
 
 #ifdef DEVBUILD
 import Data.Char (ord, chr)
@@ -139,6 +140,9 @@ main = do
             , mkBench "cat" href $ do
                 Handles inh _ <- readIORef href
                 S.runFold (FH.write devNull) $ FH.read inh
+            , mkBench "catStream" href $ do
+                Handles inh _ <- readIORef href
+                Internal.writeS devNull $ FH.read inh
             ]
         , bgroup "copyArray"
             [ mkBench "copy" href $ do

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -224,7 +224,7 @@ main =
         , benchIOSink "toListRevF" (S.runFold Internal.toListRevF)
         , benchIOSink "toStream" (S.runFold Internal.toStream)
         , benchIOSink "toStreamRev" (S.runFold Internal.toStreamRev)
-        , benchIOSink "writeNF" (S.runFold (A.writeNF Ops.value))
+        , benchIOSink "writeN" (S.runFold (A.writeN Ops.value))
 
         , benchIOSink "index" (S.runFold (FL.index Ops.maxValue))
         , benchIOSink "head" (S.runFold FL.head)

--- a/examples/EchoServer.hs
+++ b/examples/EchoServer.hs
@@ -7,5 +7,6 @@ import qualified Streamly.Prelude as S
 
 main :: IO ()
 main = S.drain
-    $ parallely $ S.mapM (flip withSocket (\sk -> writeArrays sk $ readArrays sk))
+    $ parallely $ S.mapM (flip withSocket echo)
     $ serially $ connectionsOnAllAddrs 8090
+    where echo sk = S.runFold (writeArrays sk) $ readArrays sk

--- a/examples/FileSinkServer.hs
+++ b/examples/FileSinkServer.hs
@@ -21,7 +21,7 @@ main :: IO ()
 main = do
     file <- fmap head getArgs
     withFile file AppendMode
-        (\src -> FH.write src
+        (\src -> S.runFold (FH.write src)
         $ encodeChar8Unchecked
         $ S.concatMap A.read
         $ S.concatMapBy parallel (flip NS.withSocketS recv)
@@ -30,6 +30,6 @@ main = do
     where
 
     recv =
-          S.splitBySuffix (== '\n') A.writeF
+          S.splitBySuffix (== '\n') A.write
         . decodeChar8
         . NS.read

--- a/examples/FromFileClient.hs
+++ b/examples/FromFileClient.hs
@@ -16,5 +16,6 @@ main :: IO ()
 main =
     let sendFile file =
             withFile file ReadMode $ \src ->
-                Client.writeArrays (127, 0, 0, 1) 8090 $ FH.readArrays src
+                  S.runFold (Client.writeArrays (127, 0, 0, 1) 8090)
+                $ FH.readArrays src
      in getArgs >>= S.drain . parallely . S.mapM sendFile . S.fromList

--- a/examples/HandleIO.hs
+++ b/examples/HandleIO.hs
@@ -12,12 +12,12 @@ import System.Environment (getArgs)
 import System.IO (IOMode(..), hSeek, SeekMode(..))
 
 cat :: FH.Handle -> IO ()
-cat src = FH.writeArrays FH.stdout $ FH.readArraysOf (256*1024) src
+cat src = S.runFold (FH.writeArrays FH.stdout) $ FH.readArraysOf (256*1024) src
 -- byte stream version
 -- cat src = FH.write FH.stdout $ FH.read src
 
 cp :: FH.Handle -> FH.Handle -> IO ()
-cp src dst = FH.writeArrays dst $ FH.readArraysOf (256*1024) src
+cp src dst = S.runFold (FH.writeArrays dst) $ FH.readArraysOf (256*1024) src
 -- byte stream version
 -- cp src dst = FH.write dst $ FH.read src
 

--- a/examples/HandleIO.hs
+++ b/examples/HandleIO.hs
@@ -14,12 +14,12 @@ import System.IO (IOMode(..), hSeek, SeekMode(..))
 cat :: FH.Handle -> IO ()
 cat src = S.runFold (FH.writeArrays FH.stdout) $ FH.readArraysOf (256*1024) src
 -- byte stream version
--- cat src = FH.write FH.stdout $ FH.read src
+-- cat src = S.runFold (FH.write FH.stdout) $ FH.read src
 
 cp :: FH.Handle -> FH.Handle -> IO ()
 cp src dst = S.runFold (FH.writeArrays dst) $ FH.readArraysOf (256*1024) src
 -- byte stream version
--- cp src dst = FH.write dst $ FH.read src
+-- cp src dst = S.runFold (FH.write dst) $ FH.read src
 
 ord' :: Num a => Char -> a
 ord' = (fromIntegral . ord)

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -330,7 +330,7 @@ writeInChunksOfS n h m = writeArraysS h $ AS.arraysOf n m
 -- @since 0.7.0
 {-# INLINE writeInChunksOf #-}
 writeInChunksOf :: MonadIO m => Int -> Handle -> Fold m Word8 ()
-writeInChunksOf n h = FL.lchunksOf n A.write (writeArrays h)
+writeInChunksOf n h = FL.lchunksOf n (A.writeN n) (writeArrays h)
 
 -- > write = 'writeInChunksOf' A.defaultChunkSize
 --

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -86,7 +86,6 @@ module Streamly.FileSystem.Handle
     -- -- * Array Write
     , writeArray
     , writeArrays
-    -- , writeArraysPackedUpto
     , writeArraysInChunksOf
 
     -- -- * Random Access (Seek)
@@ -113,17 +112,17 @@ where
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Word (Word8)
 import Foreign.ForeignPtr (withForeignPtr)
-import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
-import Foreign.Ptr (minusPtr, plusPtr)
+import Foreign.Ptr (plusPtr)
 import Foreign.Storable (Storable(..))
 import GHC.ForeignPtr (mallocPlainForeignPtrBytes)
-import System.IO (Handle, hGetBufSome, hPutBuf)
+import System.IO (Handle, hGetBufSome)
 import Prelude hiding (read)
 
+import Streamly.FileSystem.Handle.Internal (writeArray)
 import Streamly.Memory.Array.Types (Array(..))
-import Streamly.Streams.Serial (SerialT)
 import Streamly.Streams.StreamK.Type (IsStream, mkStream)
-import Streamly.Memory.Array.Types (defaultChunkSize, shrinkToFit, lpackArraysChunksOf)
+import Streamly.Memory.Array.Types
+       (defaultChunkSize, shrinkToFit, lpackArraysChunksOf)
 import Streamly.Fold (Fold)
 -- import Streamly.String (encodeUtf8, decodeUtf8, foldLines)
 
@@ -131,7 +130,6 @@ import qualified Streamly.Fold as FL
 import qualified Streamly.Fold.Types as FL
 import qualified Streamly.Memory.Array as A
 import qualified Streamly.Memory.ArrayStream as AS
-import qualified Streamly.Prelude as S
 import qualified Streamly.Streams.StreamD.Type as D
 
 -------------------------------------------------------------------------------
@@ -169,22 +167,6 @@ readArrayUpto size h = do
                 }
         -- XXX shrink only if the diff is significant
         shrinkToFit v
-
--------------------------------------------------------------------------------
--- Array IO (output)
--------------------------------------------------------------------------------
-
--- | Write an 'Array' to a file handle.
---
--- @since 0.7.0
-{-# INLINABLE writeArray #-}
-writeArray :: Storable a => Handle -> Array a -> IO ()
-writeArray _ arr | A.length arr == 0 = return ()
-writeArray h Array{..} = withForeignPtr aStart $ \p -> hPutBuf h p aLen
-    where
-    aLen =
-        let p = unsafeForeignPtrToPtr aStart
-        in aEnd `minusPtr` p
 
 -------------------------------------------------------------------------------
 -- Stream of Arrays IO
@@ -271,28 +253,9 @@ read = AS.flatten . readArrays
 -- | Write a stream of arrays to a handle.
 --
 -- @since 0.7.0
-{-# INLINE writeArraysS #-}
-writeArraysS :: (MonadIO m, Storable a)
-    => Handle -> SerialT m (Array a) -> m ()
-writeArraysS h m = S.mapM_ (liftIO . writeArray h) m
-
--- | Write a stream of arrays to a handle.
---
--- @since 0.7.0
 {-# INLINE writeArrays #-}
 writeArrays :: (MonadIO m, Storable a) => Handle -> Fold m (Array a) ()
 writeArrays h = FL.drainBy (liftIO . writeArray h)
-
--- | @writeArraysPackedUpto chunkSize handle stream@ writes a stream of arrays
--- to @handle@ after coalescing the adjacent arrays in chunks of @chunkSize@.
--- The chunk size is only a maximum and the actual writes could be smaller as
--- we do not split the arrays to fit exactly to the specified size.
---
--- @since 0.7.0
-{-# INLINE _writeArraysPackedUpto #-}
-_writeArraysPackedUpto :: (MonadIO m, Storable a)
-    => Int -> Handle -> SerialT m (Array a) -> m ()
-_writeArraysPackedUpto n h xs = writeArraysS h $ AS.compact n xs
 
 -- | @writeArraysInChunksOf chunkSize handle@ writes a stream of arrays
 -- to @handle@ after coalescing the adjacent arrays in chunks of @chunkSize@.
@@ -314,15 +277,6 @@ writeArraysInChunksOf n h = lpackArraysChunksOf n (writeArrays h)
 -- do not want buffering to occur at GHC level as well. Same thing applies to
 -- writes as well.
 
--- | @writeInChunksOf chunkSize handle stream@ writes @stream@ to @handle@ in
--- chunks of @chunkSize@.  A write is performed to the IO device as soon as we
--- collect the required input size.
---
--- @since 0.7.0
-{-# INLINE writeInChunksOfS #-}
-writeInChunksOfS :: MonadIO m => Int -> Handle -> SerialT m Word8 -> m ()
-writeInChunksOfS n h m = writeArraysS h $ AS.arraysOf n m
-
 -- | @writeInChunksOf chunkSize handle@ writes the input stream to @handle@ in
 -- chunks of @chunkSize@.  A write is performed to the IO device as soon as we
 -- collect the required input size.
@@ -331,16 +285,6 @@ writeInChunksOfS n h m = writeArraysS h $ AS.arraysOf n m
 {-# INLINE writeInChunksOf #-}
 writeInChunksOf :: MonadIO m => Int -> Handle -> Fold m Word8 ()
 writeInChunksOf n h = FL.lchunksOf n (A.writeN n) (writeArrays h)
-
--- > write = 'writeInChunksOf' A.defaultChunkSize
---
--- | Write a byte stream to a file handle. Accumulates the input in chunks of
--- up to 'A.defaultChunkSize' before writing.
---
--- @since 0.7.0
-{-# INLINE _writeS #-}
-_writeS :: MonadIO m => Handle -> SerialT m Word8 -> m ()
-_writeS = writeInChunksOfS defaultChunkSize
 
 -- > write = 'writeInChunksOf' A.defaultChunkSize
 --

--- a/src/Streamly/FileSystem/Handle/Internal.hs
+++ b/src/Streamly/FileSystem/Handle/Internal.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+#include "inline.hs"
+
+-- |
+-- Module      : Streamly.FileSystem.Handle.Internal
+-- Copyright   : (c) 2018 Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : harendra.kumar@gmail.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- Streaming based IO write rotuines based on file handles.
+
+module Streamly.FileSystem.Handle.Internal
+    (
+    writeArray
+
+    -- Byte stream write
+    , writeS
+    , writeSInChunksOf
+
+    -- -- * Array stream Write
+    , writeSArrays
+    , writeSArraysInChunksOf
+    )
+where
+
+import Control.Monad.IO.Class (MonadIO(..))
+import Data.Word (Word8)
+import Foreign.ForeignPtr (withForeignPtr)
+import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
+import Foreign.Ptr (minusPtr)
+import Foreign.Storable (Storable(..))
+import System.IO (Handle, hPutBuf)
+import Prelude hiding (read)
+
+import Streamly.Memory.Array.Types (Array(..))
+import Streamly.Streams.Serial (SerialT)
+import Streamly.Memory.Array.Types (defaultChunkSize)
+
+import qualified Streamly.Memory.Array as A
+import qualified Streamly.Memory.ArrayStream as AS
+import qualified Streamly.Prelude as S
+
+-------------------------------------------------------------------------------
+-- Array IO (output)
+-------------------------------------------------------------------------------
+
+-- | Write an 'Array' to a file handle.
+--
+-- @since 0.7.0
+{-# INLINABLE writeArray #-}
+writeArray :: Storable a => Handle -> Array a -> IO ()
+writeArray _ arr | A.length arr == 0 = return ()
+writeArray h Array{..} = withForeignPtr aStart $ \p -> hPutBuf h p aLen
+    where
+    aLen =
+        let p = unsafeForeignPtrToPtr aStart
+        in aEnd `minusPtr` p
+
+-------------------------------------------------------------------------------
+-- Stream of Arrays IO
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- Writing
+-------------------------------------------------------------------------------
+
+-- | Write a stream of arrays to a handle.
+--
+-- @since 0.7.0
+{-# INLINE writeSArrays #-}
+writeSArrays :: (MonadIO m, Storable a)
+    => Handle -> SerialT m (Array a) -> m ()
+writeSArrays h m = S.mapM_ (liftIO . writeArray h) m
+
+-- | @writeArraysPackedUpto chunkSize handle stream@ writes a stream of arrays
+-- to @handle@ after coalescing the adjacent arrays in chunks of @chunkSize@.
+-- The chunk size is only a maximum and the actual writes could be smaller as
+-- we do not split the arrays to fit exactly to the specified size.
+--
+-- @since 0.7.0
+{-# INLINE writeSArraysInChunksOf #-}
+writeSArraysInChunksOf :: (MonadIO m, Storable a)
+    => Int -> Handle -> SerialT m (Array a) -> m ()
+writeSArraysInChunksOf n h xs = writeSArrays h $ AS.compact n xs
+
+-- | @writeSInChunksOf chunkSize handle stream@ writes @stream@ to @handle@ in
+-- chunks of @chunkSize@.  A write is performed to the IO device as soon as we
+-- collect the required input size.
+--
+-- @since 0.7.0
+{-# INLINE writeSInChunksOf #-}
+writeSInChunksOf :: MonadIO m => Int -> Handle -> SerialT m Word8 -> m ()
+writeSInChunksOf n h m = writeSArrays h $ AS.arraysOf n m
+
+-- > write = 'writeInChunksOf' A.defaultChunkSize
+--
+-- | Write a byte stream to a file handle. Accumulates the input in chunks of
+-- up to 'A.defaultChunkSize' before writing.
+--
+-- NOTE: This may perform better than the 'write' fold, you can try this if you
+-- need some extra perf boost.
+--
+-- @since 0.7.0
+{-# INLINE writeS #-}
+writeS :: MonadIO m => Handle -> SerialT m Word8 -> m ()
+writeS = writeSInChunksOf defaultChunkSize

--- a/src/Streamly/Internal.hs
+++ b/src/Streamly/Internal.hs
@@ -66,11 +66,15 @@ module Streamly.Internal
     , duplicate
     , initialize
     , runStep
+
+    -- * Streamly.FileSystem.Handle
+    , writeS
     )
 where
 
 import Prelude hiding (break, span, splitAt)
 
+import Streamly.FileSystem.Handle.Internal (writeS)
 import Streamly.Streams.Combinators (inspectMode)
 import Streamly.Streams.Parallel (tapAsync)
 

--- a/src/Streamly/Internal.hs
+++ b/src/Streamly/Internal.hs
@@ -64,6 +64,8 @@ module Streamly.Internal
     , lsessionsOf
     , lchunksOf
     , duplicate
+    , initialize
+    , runStep
     )
 where
 

--- a/src/Streamly/Memory/Array.hs
+++ b/src/Streamly/Memory/Array.hs
@@ -79,12 +79,12 @@ module Streamly.Memory.Array
 
     -- Monadic APIs
     -- , newArray
-    , writeN
+    , A.writeN
     , write
 
     -- Stream Folds
-    , A.writeNF
-    , writeF
+    -- , writeNS
+    -- , writeS
 
     -- * Elimination
     -- 'GHC.Exts.toList' from "GHC.Exts" can be used to convert an array to a
@@ -157,9 +157,9 @@ newArray len = undefined
 -- array may hold less than N elements.
 --
 -- @since 0.7.0
-{-# INLINE writeN #-}
-writeN :: (MonadIO m, Storable a) => Int -> SerialT m a -> m (Array a)
-writeN n m = do
+{-# INLINE _writeNS #-}
+_writeNS :: (MonadIO m, Storable a) => Int -> SerialT m a -> m (Array a)
+_writeNS n m = do
     if n < 0 then error "writeN: negative write count specified" else return ()
     A.fromStreamDN n $ D.toStreamD m
 
@@ -204,9 +204,9 @@ toArrayMinChunk elemCount = Fold step initial extract
 -- /Caution! Do not use this on infinite streams./
 --
 -- @since 0.7.0
-{-# INLINE writeF #-}
-writeF :: forall m a. (MonadIO m, Storable a) => Fold m a (Array a)
-writeF = toArrayMinChunk (A.bytesToCount (undefined :: a) (A.mkChunkSize 1024))
+{-# INLINE write #-}
+write :: forall m a. (MonadIO m, Storable a) => Fold m a (Array a)
+write = toArrayMinChunk (A.bytesToCount (undefined :: a) (A.mkChunkSize 1024))
 
 -- | Create an 'Array' from a stream. This is useful when we want to create a
 -- single array from a stream of unknown size. 'writeN' is at least twice
@@ -216,9 +216,9 @@ writeF = toArrayMinChunk (A.bytesToCount (undefined :: a) (A.mkChunkSize 1024))
 -- may fail.  When the stream size is not known, `arraysOf` followed by
 -- processing of indvidual arrays in the resulting stream should be preferred.
 --
-{-# INLINE write #-}
-write :: (MonadIO m, Storable a) => SerialT m a -> m (Array a)
-write = P.runFold writeF
+{-# INLINE _writeS #-}
+_writeS :: (MonadIO m, Storable a) => SerialT m a -> m (Array a)
+_writeS = P.runFold write
 -- write m = A.fromStreamD $ D.toStreamD m
 
 -------------------------------------------------------------------------------

--- a/src/Streamly/Memory/Array/Types.hs
+++ b/src/Streamly/Memory/Array/Types.hs
@@ -491,7 +491,7 @@ writeN n = Fold step initial extract
     step (Array start end bound) x = do
         liftIO $ poke end x
         return $ Array start (end `plusPtr` sizeOf (undefined :: a)) bound
-    extract = liftIO . shrinkToFit
+    extract = return -- liftIO . shrinkToFit
 
 {-# INLINE_NORMAL fromStreamDN #-}
 fromStreamDN :: forall m a. (MonadIO m, Storable a)

--- a/src/Streamly/Network/Client.hs
+++ b/src/Streamly/Network/Client.hs
@@ -180,7 +180,7 @@ writeInChunksOf
     -> (Word8, Word8, Word8, Word8)
     -> PortNumber
     -> Fold m Word8 ()
-writeInChunksOf n addr port = FL.lchunksOf n A.write (writeArrays addr port)
+writeInChunksOf n addr port = FL.lchunksOf n (A.writeN n) (writeArrays addr port)
 
 {-
 -- | Write a stream to the supplied IPv4 host address and port number.

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -310,7 +310,7 @@ writeInChunksOfS n h m = writeArraysS h $ AS.arraysOf n m
 -- @since 0.7.0
 {-# INLINE writeInChunksOf #-}
 writeInChunksOf :: MonadIO m => Int -> Socket -> Fold m Word8 ()
-writeInChunksOf n h = FL.lchunksOf n A.write (writeArrays h)
+writeInChunksOf n h = FL.lchunksOf n (A.writeN n) (writeArrays h)
 
 -- > write = 'writeInChunksOf' A.defaultChunkSize
 --

--- a/src/Streamly/Streams/StreamD/Type.hs
+++ b/src/Streamly/Streams/StreamD/Type.hs
@@ -300,6 +300,7 @@ instance Monad m => Monad (Stream m) where
 foldrM :: Monad m => (a -> m b -> m b) -> m b -> Stream m a -> m b
 foldrM f z (Stream step state) = go SPEC state
   where
+    {-# INLINE_LATE go #-}
     go !_ st = do
           r <- step defState st
           case r of
@@ -312,6 +313,7 @@ foldrMx :: Monad m
     => (a -> m x -> m x) -> m x -> (m x -> m b) -> Stream m a -> m b
 foldrMx fstep final convert (Stream step state) = convert $ go SPEC state
   where
+    {-# INLINE_LATE go #-}
     go !_ st = do
           r <- step defState st
           case r of
@@ -349,6 +351,7 @@ foldrS
     -> Stream m b
 foldrS f final (Stream step state) = go SPEC state
   where
+    {-# INLINE_LATE go #-}
     go !_ st = do
         -- defState??
         r <- yieldM $ step defState st
@@ -365,6 +368,7 @@ foldrT :: (Monad m, Monad (t m), MonadTrans t)
     => (a -> t m b -> t m b) -> t m b -> Stream m a -> t m b
 foldrT f final (Stream step state) = go SPEC state
   where
+    {-# INLINE_LATE go #-}
     go !_ st = do
           r <- lift $ step defState st
           case r of
@@ -383,6 +387,7 @@ foldlMx' fstep begin done (Stream step state) =
     begin >>= \x -> go SPEC x state
   where
     -- XXX !acc?
+    {-# INLINE_LATE go #-}
     go !_ acc st = acc `seq` do
         r <- step defState st
         case r of
@@ -402,6 +407,7 @@ foldlx' fstep begin done m =
 foldlM' :: Monad m => (b -> a -> m b) -> b -> Stream m a -> m b
 foldlM' fstep begin (Stream step state) = go SPEC begin state
   where
+    {-# INLINE_LATE go #-}
     go !_ acc st = acc `seq` do
         r <- step defState st
         case r of

--- a/src/Streamly/String.hs
+++ b/src/Streamly/String.hs
@@ -204,7 +204,7 @@ isSpace c
 -- 'foldLines' instead.
 {-# INLINE lines #-}
 lines :: (MonadIO m, IsStream t) => t m Char -> t m (Array Char)
-lines = S.splitOnSuffix (== '\n') A.writeF
+lines = S.splitOnSuffix (== '\n') A.write
 
 -- | Break a string up into a list of strings, which were delimited
 -- by characters representing white space.
@@ -216,7 +216,7 @@ lines = S.splitOnSuffix (== '\n') A.writeF
 -- 'foldWords' instead.
 {-# INLINE words #-}
 words :: (MonadIO m, IsStream t) => t m Char -> t m (Array Char)
-words = S.wordsBy isSpace A.writeF
+words = S.wordsBy isSpace A.write
 
 -- | Flattens the stream of @Array Char@, after appending a terminating
 -- newline to each string.

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -219,6 +219,7 @@ library
                      , Streamly.FileSystem.FDIO
                      , Streamly.FileSystem.FD
                      , Streamly.FileSystem.File
+                     , Streamly.FileSystem.Handle.Internal
 
                     -- Time
                      , Streamly.Time.Units

--- a/test/Arrays.hs
+++ b/test/Arrays.hs
@@ -42,7 +42,7 @@ testLength =
     forAll (choose (0, maxArrLen)) $ \len ->
         forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
             monadicIO $ do
-                arr <-  A.writeN len
+                arr <-  S.runFold (A.writeN len)
                       $ S.fromList list
                 assert (A.length arr == len)
 
@@ -51,7 +51,7 @@ testFromToStreamN =
     forAll (choose (0, maxArrLen)) $ \len ->
         forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
             monadicIO $ do
-                arr <- A.writeN len
+                arr <- S.runFold (A.writeN len)
                      $ S.fromList list
                 xs <- S.toList
                     $ A.read arr
@@ -62,7 +62,7 @@ testToStreamRev =
     forAll (choose (0, maxArrLen)) $ \len ->
         forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
             monadicIO $ do
-                arr <- A.writeN len
+                arr <- S.runFold (A.writeN len)
                      $ S.fromList list
                 xs <- S.toList
                     $ A.readRev arr
@@ -95,7 +95,7 @@ testFromToStream =
     forAll (choose (0, maxArrLen)) $ \len ->
         forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
             monadicIO $ do
-                arr <- A.write $ S.fromList list
+                arr <- S.runFold A.write $ S.fromList list
                 xs <- S.toList
                     $ A.read arr
                 assert (xs == list)


### PR DESCRIPTION
The `fileio` `readStream/cat` benchmark seems to have gotten badly affected. Maybe some INLINE issue. Need to investigate.