### PR TITLE
merge the ArrayStream module to Array module itself

### DIFF
--- a/benchmark/FileIO.hs
+++ b/benchmark/FileIO.hs
@@ -17,7 +17,6 @@ import Gauge
 
 import qualified Streamly.FileSystem.Handle as FH
 import qualified Streamly.Memory.Array as A
-import qualified Streamly.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Fold as FL
 import qualified Streamly.Data.String as SS
@@ -111,7 +110,7 @@ main = do
                 S.sum (S.map A.length s)
             , mkBench "linecount" href $ do
                 Handles inh _ <- readIORef href
-                S.length $ AS.splitOn 10 $ FH.readArrays inh
+                S.length $ A.splitOn 10 $ FH.readArrays inh
             , mkBench "sum" href $ do
                 let foldlArr' f z = runIdentity . S.foldl' f z . A.read
                 Handles inh _ <- readIORef href
@@ -201,7 +200,7 @@ main = do
                 Handles inh outh <- readIORef href
                 S.runFold (FH.writeArraysInChunksOf (1024*1024) outh)
                     $ Internal.insertAfterEach (return $ A.fromList [10])
-                    $ AS.splitOn 10
+                    $ A.splitOn 10
                     $ FH.readArraysOf (1024*1024) inh
             , mkBench "words-unwords" href $ do
                 Handles inh outh <- readIORef href

--- a/examples/HandleIO.hs
+++ b/examples/HandleIO.hs
@@ -1,7 +1,6 @@
 import qualified Streamly.Prelude as S
 import qualified Streamly.Fold as FL
--- import qualified Streamly.Memory.Array as A
-import qualified Streamly.Memory.ArrayStream as AS
+import qualified Streamly.Memory.Array as A
 import qualified Streamly.FileSystem.Handle as FH
 import qualified System.IO as FH
 -- import qualified Streamly.FileSystem.FD as FH
@@ -26,7 +25,7 @@ ord' = (fromIntegral . ord)
 
 wcl :: FH.Handle -> IO ()
 wcl src = print =<< (S.length
-    $ AS.splitOn 10
+    $ A.splitOn 10
     $ FH.readArrays src)
 {-
 -- Char stream version

--- a/src/Streamly/Data/String.hs
+++ b/src/Streamly/Data/String.hs
@@ -90,7 +90,6 @@ import Streamly.Memory.Array (Array)
 
 import qualified Streamly.Prelude as S
 import qualified Streamly.Memory.Array as A
-import qualified Streamly.Memory.ArrayStream as AS
 import qualified Streamly.Streams.StreamD as D
 
 -- type String = List Char
@@ -276,4 +275,4 @@ unlines = AS.unlinesBy '\n'
 -- > unwords . words /= id
 {-# INLINE unwords #-}
 unwords :: (MonadAsync m, IsStream t) => t m (Array Char) -> t m Char
-unwords = AS.flatten . (S.intersperse (A.fromList " "))
+unwords = A.concat . (S.intersperse (A.fromList " "))

--- a/src/Streamly/Data/String.hs
+++ b/src/Streamly/Data/String.hs
@@ -250,14 +250,14 @@ words = foldWords A.write
 -- >>> S.toList $ unlines $ S.fromList ["lines", "this", "string"]
 -- "lines\nthis\nstring\n"
 --
--- > unlines = AS.unlinesBy '\n'
+-- > unlines = A.concatWithSuffix '\n'
 --
 -- Note that, in general
 --
 -- > unlines . lines /= id
 {-# INLINE unlines #-}
 unlines :: (MonadIO m, IsStream t) => t m (Array Char) -> t m Char
-unlines = AS.unlinesBy '\n'
+unlines = A.concatWithSuffix '\n'
 
 -- | Flattens the stream of @Array Char@, after appending a separating
 -- space to each string.
@@ -268,7 +268,7 @@ unlines = AS.unlinesBy '\n'
 -- "unwords this string"
 --
 --
--- > unwords = AS.flatten . (S.intersperse (A.fromList " "))
+-- > unwords = A.concat . (S.intersperse (A.fromList " "))
 --
 -- Note that, in general
 --

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -129,7 +129,6 @@ import Streamly.Fold (Fold)
 import qualified Streamly.Fold as FL
 import qualified Streamly.Fold.Types as FL
 import qualified Streamly.Memory.Array as A
-import qualified Streamly.Memory.ArrayStream as AS
 import qualified Streamly.Streams.StreamD.Type as D
 
 -------------------------------------------------------------------------------
@@ -232,7 +231,7 @@ readArrays = readArraysOf defaultChunkSize
 -- @since 0.7.0
 {-# INLINE readInChunksOf #-}
 readInChunksOf :: (IsStream t, MonadIO m) => Int -> Handle -> t m Word8
-readInChunksOf chunkSize h = AS.flatten $ readArraysOf chunkSize h
+readInChunksOf chunkSize h = A.concat $ readArraysOf chunkSize h
 
 -- TODO
 -- Generate a stream of elements of the given type from a file 'Handle'.
@@ -244,7 +243,7 @@ readInChunksOf chunkSize h = AS.flatten $ readArraysOf chunkSize h
 -- @since 0.7.0
 {-# INLINE read #-}
 read :: (IsStream t, MonadIO m) => Handle -> t m Word8
-read = AS.flatten . readArrays
+read = A.concat . readArrays
 
 -------------------------------------------------------------------------------
 -- Writing

--- a/src/Streamly/Memory/Array.hs
+++ b/src/Streamly/Memory/Array.hs
@@ -127,7 +127,7 @@ module Streamly.Memory.Array
     -- ** Elimination
     , AS.concat
     -- , AS.concatRev
-    , AS.unlinesBy
+    , AS.concatWithSuffix
     , AS.toArray
 
     -- ** Transformation

--- a/src/Streamly/Memory/Array.hs
+++ b/src/Streamly/Memory/Array.hs
@@ -65,7 +65,8 @@ module Streamly.Memory.Array
 
     -- , defaultChunkSize
 
-    -- * Construction
+    -- * Arrays
+    -- ** Construction
     -- | When performance matters, the fastest way to generate an array is
     -- 'writeN'. For regular use, 'IsList' and 'IsString' instances can be
     -- used to conveniently construct arrays from literal values.
@@ -86,7 +87,7 @@ module Streamly.Memory.Array
     -- , writeNS
     -- , writeS
 
-    -- * Elimination
+    -- ** Elimination
     -- 'GHC.Exts.toList' from "GHC.Exts" can be used to convert an array to a
     -- list.
 
@@ -94,7 +95,7 @@ module Streamly.Memory.Array
     , A.read
     , readRev
 
-    -- * Random Access
+    -- ** Random Access
     , length
     -- , (!!)
 
@@ -118,6 +119,20 @@ module Streamly.Memory.Array
     -- , runStreamFold
     , runFold
     -}
+
+    -- * Streams of Arrays
+    -- ** Creation
+    , AS.arraysOf
+
+    -- ** Elimination
+    , AS.flatten
+    -- , AS.concatRev
+    , AS.unlinesBy
+    , AS.toArray
+
+    -- ** Transformation
+    , AS.splitOn
+    , AS.compact -- compact
     )
 where
 
@@ -136,6 +151,7 @@ import Streamly.Streams.StreamK.Type (IsStream)
 import Streamly.Fold.Types (Fold(..))
 
 import qualified Streamly.Memory.Array.Types as A
+import qualified Streamly.Memory.ArrayStream as AS
 import qualified Streamly.Streams.Prelude as P
 import qualified Streamly.Streams.Serial as Serial
 import qualified Streamly.Streams.StreamD as D

--- a/src/Streamly/Memory/Array.hs
+++ b/src/Streamly/Memory/Array.hs
@@ -125,7 +125,7 @@ module Streamly.Memory.Array
     , AS.arraysOf
 
     -- ** Elimination
-    , AS.flatten
+    , AS.concat
     -- , AS.concatRev
     , AS.unlinesBy
     , AS.toArray
@@ -143,7 +143,7 @@ import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import Foreign.Ptr (minusPtr, plusPtr)
 import Foreign.Storable (Storable(..))
-import Prelude hiding (length, null, last, map, (!!), read)
+import Prelude hiding (length, null, last, map, (!!), read, concat)
 
 import Streamly.Memory.Array.Types (Array(..), length)
 import Streamly.Streams.Serial (SerialT)

--- a/src/Streamly/Memory/ArrayStream.hs
+++ b/src/Streamly/Memory/ArrayStream.hs
@@ -24,8 +24,8 @@ module Streamly.Memory.ArrayStream
       arraysOf
 
     -- * Flattening to elements
-    , flatten
-    -- , _flattenArraysRev
+    , concat
+    , concatRev
     , unlinesBy
 
     -- * Transformation
@@ -43,7 +43,7 @@ import Data.Word (Word8)
 import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.Ptr (minusPtr, plusPtr, castPtr)
 import Foreign.Storable (Storable(..))
-import Prelude hiding (length, null, last, map, (!!), read)
+import Prelude hiding (length, null, last, map, (!!), read, concat)
 
 import Streamly.Memory.Array.Types (Array(..), length)
 import Streamly.Streams.Serial (SerialT)
@@ -62,12 +62,12 @@ import qualified Streamly.Streams.Prelude as P
 --
 -- Same as the following but more efficient:
 --
--- > flatten = S.concatMap A.read
+-- > concat = S.concatMap A.read
 --
 -- @since 0.7.0
-{-# INLINE flatten #-}
-flatten :: (IsStream t, MonadIO m, Storable a) => t m (Array a) -> t m a
-flatten m = D.fromStreamD $ A.flattenArrays (D.toStreamD m)
+{-# INLINE concat #-}
+concat :: (IsStream t, MonadIO m, Storable a) => t m (Array a) -> t m a
+concat m = D.fromStreamD $ A.flattenArrays (D.toStreamD m)
 
 -- XXX should we have a reverseArrays API to reverse the stream of arrays
 -- instead?
@@ -76,9 +76,9 @@ flatten m = D.fromStreamD $ A.flattenArrays (D.toStreamD m)
 -- contents of each array before flattening.
 --
 -- @since 0.7.0
-{-# INLINE _flattenArraysRev #-}
-_flattenArraysRev :: (IsStream t, MonadIO m, Storable a) => t m (Array a) -> t m a
-_flattenArraysRev m = D.fromStreamD $ A.flattenArraysRev (D.toStreamD m)
+{-# INLINE concatRev #-}
+concatRev :: (IsStream t, MonadIO m, Storable a) => t m (Array a) -> t m a
+concatRev m = D.fromStreamD $ A.flattenArraysRev (D.toStreamD m)
 
 -- XXX use an Array instead as separator? Or use a separate unlinesArraysBySeq
 -- API for that?

--- a/src/Streamly/Memory/ArrayStream.hs
+++ b/src/Streamly/Memory/ArrayStream.hs
@@ -26,7 +26,7 @@ module Streamly.Memory.ArrayStream
     -- * Flattening to elements
     , concat
     , concatRev
-    , unlinesBy
+    , concatWithSuffix
 
     -- * Transformation
     , splitOn
@@ -87,10 +87,10 @@ concatRev m = D.fromStreamD $ A.flattenArraysRev (D.toStreamD m)
 -- array.
 --
 -- @since 0.7.0
-{-# INLINE unlinesBy #-}
-unlinesBy :: (MonadIO m, IsStream t, Storable a)
+{-# INLINE concatWithSuffix #-}
+concatWithSuffix :: (MonadIO m, IsStream t, Storable a)
     => a -> t m (Array a) -> t m a
-unlinesBy x = D.fromStreamD . A.unlines x . D.toStreamD
+concatWithSuffix x = D.fromStreamD . A.unlines x . D.toStreamD
 
 -- | Split a stream of arrays on a given separator byte, dropping the separator
 -- and coalescing all the arrays between two separators into a single array.

--- a/src/Streamly/Network/Client.hs
+++ b/src/Streamly/Network/Client.hs
@@ -73,7 +73,6 @@ import Streamly.Streams.StreamK.Type (IsStream)
 
 import qualified Streamly.Fold.Types as FL
 import qualified Streamly.Memory.Array as A
-import qualified Streamly.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Network.Socket as SK
 
@@ -111,7 +110,7 @@ withConnection addr port =
 {-# INLINE read #-}
 read :: (IsStream t, MonadCatch m, MonadIO m)
     => (Word8, Word8, Word8, Word8) -> PortNumber -> t m Word8
-read addr port = AS.flatten $ withConnection addr port SK.readArrays
+read addr port = A.concat $ withConnection addr port SK.readArrays
 
 -------------------------------------------------------------------------------
 -- Writing

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -95,8 +95,7 @@ import Streamly.Fold (Fold)
 import qualified Streamly.Fold as FL
 import qualified Streamly.Fold.Types as FL
 import qualified Streamly.Memory.Array as A
-import qualified Streamly.Memory.ArrayStream as AS
-import qualified Streamly.Memory.Array.Types as A hiding (flattenArrays)
+import qualified Streamly.Memory.Array.Types as A
 import qualified Streamly.Prelude as S
 
 -- | @'withSocket' socket act@ runs the monadic computation @act@ passing the
@@ -266,7 +265,7 @@ readInChunksOf chunkSize h = A.flattenArrays $ readArraysUpto chunkSize h
 -- @since 0.7.0
 {-# INLINE read #-}
 read :: (IsStream t, MonadIO m) => Socket -> t m Word8
-read = AS.flatten . readArrays
+read = A.concat . readArrays
 
 -------------------------------------------------------------------------------
 -- Writing
@@ -302,7 +301,7 @@ writeArrays h = FL.drainBy (liftIO . writeArray h)
 -- @since 0.7.0
 {-# INLINE writeInChunksOfS #-}
 writeInChunksOfS :: MonadIO m => Int -> Socket -> SerialT m Word8 -> m ()
-writeInChunksOfS n h m = writeArraysS h $ AS.arraysOf n m
+writeInChunksOfS n h m = writeArraysS h $ A.arraysOf n m
 
 -- | Write a byte stream to a socket. Accumulates the input in chunks of
 -- specified number of bytes before writing.

--- a/src/Streamly/Prelude/Internal.hs
+++ b/src/Streamly/Prelude/Internal.hs
@@ -379,7 +379,7 @@ import qualified System.IO as IO
 
 import Streamly.Enumeration (Enumerable(..), enumerate, enumerateTo)
 import Streamly.Fold.Types (Fold (..))
-import Streamly.Memory.Array (Array)
+import Streamly.Memory.Array.Types (Array)
 -- import Streamly.Memory.Ring (Ring)
 import Streamly.SVar (MonadAsync, defState)
 import Streamly.Streams.Async (mkAsync')
@@ -396,7 +396,7 @@ import Streamly.Time.Units
 
 import Streamly.Strict
 
-import qualified Streamly.Memory.Array as A
+import qualified Streamly.Memory.Array.Types as A
 import qualified Streamly.Fold as FL
 import qualified Streamly.Fold.Types as FL
 import qualified Streamly.Streams.Prelude as P

--- a/src/Streamly/Prelude/Internal.hs
+++ b/src/Streamly/Prelude/Internal.hs
@@ -2105,14 +2105,15 @@ interposeBy :: (IsStream t, Monad m)
     => (a -> a -> Ordering) -> t m a -> t m a -> t m a
 interposeBy = undefined
 
--- XXX shall we intercalate an Array instead? A stream is exhaustible and
--- should be used only once unless it is a pure stream. or we can have
--- intercalateN to intercalate n elements from the input stream at a time and
--- generate the stream by cycling the array.
---
--- | A generalization of intersperseM to intersperse sequences.
-intercalate :: (IsStream t, MonadAsync m) => t m a -> t m a -> t m a
+-- | Insert a stream between segements of streams and flatten.
+intercalate :: (IsStream t, MonadAsync m)
+    => SerialT Identity b -> (a -> t m b) -> t m a -> t m b
 intercalate = undefined
+
+-- | Insert a stream after segements of streams and flatten.
+intercalatePost :: (IsStream t, MonadAsync m)
+    => SerialT Identity b -> (a -> t m b) -> t m a -> t m b
+intercalatePost = undefined
 -}
 
 ------------------------------------------------------------------------------

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -214,6 +214,7 @@ library
                      , Streamly.Pipe.Types
                      , Streamly.Pipe
 
+                     , Streamly.Memory.ArrayStream
                      , Streamly.Prelude.Internal
                      , Streamly.FileSystem.IOVec
                      , Streamly.FileSystem.FDIO
@@ -234,7 +235,6 @@ library
 
                     -- IO devices
                      , Streamly.Memory.Array
-                     , Streamly.Memory.ArrayStream
                      , Streamly.FileSystem.Handle
 
                      , Streamly.Tutorial

--- a/test/Arrays.hs
+++ b/test/Arrays.hs
@@ -12,7 +12,6 @@ import Test.QuickCheck.Monadic (monadicIO, assert)
 import Test.Hspec as H
 
 import qualified Streamly.Memory.Array as A
-import qualified Streamly.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
 
 -- Coverage build takes too long with default number of tests
@@ -75,7 +74,7 @@ testArraysOf =
             monadicIO $ do
                 xs <- S.toList
                     $ S.concatMap A.read
-                    $ AS.arraysOf 240
+                    $ A.arraysOf 240
                     $ S.fromList list
                 assert (xs == list)
 
@@ -85,8 +84,8 @@ testFlattenArrays =
         forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
             monadicIO $ do
                 xs <- S.toList
-                    $ AS.flatten
-                    $ AS.arraysOf 240
+                    $ A.flatten
+                    $ A.arraysOf 240
                     $ S.fromList list
                 assert (xs == list)
 

--- a/test/Arrays.hs
+++ b/test/Arrays.hs
@@ -84,7 +84,7 @@ testFlattenArrays =
         forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
             monadicIO $ do
                 xs <- S.toList
-                    $ A.flatten
+                    $ A.concat
                     $ A.arraysOf 240
                     $ S.fromList list
                 assert (xs == list)
@@ -109,5 +109,5 @@ main = hspec
         prop "read . writeN n === id" $ testFromToStreamN
         prop "readRev . write === reverse" $ testToStreamRev
         prop "arraysOf concats to original" $ testArraysOf
-        prop "flattenArrays concats to original" $ testFlattenArrays
+        prop "concats to original" $ testFlattenArrays
         prop "read . write === id" $ testFromToStream

--- a/test/String.hs
+++ b/test/String.hs
@@ -13,7 +13,6 @@ import Test.QuickCheck.Monadic (run, monadicIO, assert)
 import           Test.Hspec as H
 
 import qualified Streamly.Memory.Array as A
-import qualified Streamly.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Data.String as SS
 
@@ -58,7 +57,7 @@ testLinesArray =
         monadicIO $ do
             xs <- S.toList
                     $ S.map A.toList
-                    $ AS.splitOn 10
+                    $ A.splitOn 10
                     $ S.yield (A.fromList list)
             assert (xs == map (map (fromIntegral . ord))
                               (lines (map (chr .  fromIntegral) list)))


### PR DESCRIPTION
Each container type (e.g. Handle/Socket/File) may have similar nested/stream
level operations. We need a standardized way of naming the combinators related
to streams of containers.  Also, we cannot have a separate module for such
combinators for each container type. Therefore it makes sense to put them in
the same module.