### PR TITLE
implement arraysOf in terms of chunksOf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,11 +87,12 @@ matrix:
   - env: BUILD=cabal-v2 GHCVER=8.6.5 GHC_OPTIONS="" CABAL_BUILD_OPTIONS="--flags streamk"
     addons: {apt: {packages: [cabal-install-head,ghc-8.6.5], sources: [hvr-ghc]}}
 
-  - env: BUILD=cabal-v2 GHC_OPTIONS="" GHCVER=8.4.4
+  - env: BUILD=cabal-v2 GHCVER=8.4.4 GHC_OPTIONS=""
     addons: {apt: {packages: [cabal-install-head,ghc-8.4.4], sources: [hvr-ghc]}}
 
-  #- env: BUILD=cabal-v2 GHCVER=8.2.2
-  #  addons: {apt: {packages: [cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}
+  # GHC-8.2.2 hogs memory leading to out-of-memory when compiling benchmarks
+  - env: BUILD=cabal-v2 GHCVER=8.2.2 GHC_OPTIONS="" DISABLE_BENCH=y
+    addons: {apt: {packages: [cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}
 
   - env: BUILD=cabal-v2 GHCVER=8.0.2 GHC_OPTIONS="" CABAL_BUILD_OPTIONS="--flags examples-sdl"
     addons: {apt: {packages: [cabal-install-2.4,ghc-8.0.2,libsdl1.2-dev], sources: [hvr-ghc]}}
@@ -140,8 +141,8 @@ matrix:
 
   # GHC-8.2.2 hogs memory leading to out-of-memory when compiling benchmarks
   # So disable the benchmarks for this build.
-  - env: BUILD=stack GHCVER=8.2.2 RESOLVER=lts-11 GHC_OPTIONS="" DISABLE_SDIST_BUILD=y DISABLE_DIST_CHECKS=y DISABLE_BENCH=y
-    addons: {apt: {packages: [cabal-install-2.4], sources: [hvr-ghc]}}
+  #- env: BUILD=stack GHCVER=8.2.2 RESOLVER=lts-11 GHC_OPTIONS="" DISABLE_SDIST_BUILD=y DISABLE_DIST_CHECKS=y DISABLE_BENCH=y
+  #  addons: {apt: {packages: [cabal-install-2.4], sources: [hvr-ghc]}}
 
   #- env: BUILD=stack RESOLVER=lts-9 GHCVER=8.0
   # addons: {apt: {packages: [cabal-install-2.4], sources: [hvr-ghc]}}

--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,8 @@
 ### Bug Fixes
 
 * Fix a bug that caused `uniq` function to yield the same element twice.
+* Fix a bug that caused "thread blocked indefinitely in an MVar operation"
+  exception in a parallel stream.
 
 ### Major Enhancements
 

--- a/bench.sh
+++ b/bench.sh
@@ -259,14 +259,14 @@ then
   WHICH_COMMAND="stack exec which"
   BUILD_CHART_EXE="stack build --flag streamly:dev"
   GET_BENCH_PROG=stack_bench_prog
-  BUILD_BENCH="stack build $STACK_BUILD_FLAGS --bench --no-run-benchmarks"
+  BUILD_BENCH="stack build $STACK_BUILD_FLAGS --flags "streamly:benchmark" --bench --no-run-benchmarks"
 else
   # XXX cabal issue "cabal v2-exec which" cannot find benchmark/test executables
   #WHICH_COMMAND="cabal v2-exec which"
   WHICH_COMMAND=cabal_which
   BUILD_CHART_EXE="cabal v2-build --flags dev chart"
   GET_BENCH_PROG=cabal_bench_prog
-  BUILD_BENCH="cabal v2-build $CABAL_BUILD_FLAGS --enable-benchmarks"
+  BUILD_BENCH="cabal v2-build $CABAL_BUILD_FLAGS --flag benchmark --enable-benchmarks"
 fi
 
 #-----------------------------------------------------------------------------

--- a/benchmark/FileIO.hs
+++ b/benchmark/FileIO.hs
@@ -131,7 +131,7 @@ main = do
                BFS.copyCodecUtf8 inh outh
            ]
         , bgroup "grouping"
-            [ mkBench "chunksOf 1 (A.writeN)" href $ do
+            [ mkBench "chunksOf (single chunk)" href $ do
                 Handles inh _ <- readIORef href
                 BFS.chunksOf fileSize inh
 

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -16,7 +16,7 @@ import System.Random (randomRIO)
 import Data.Monoid (Last(..))
 
 import qualified GHC.Exts as GHC
-import qualified LinearOps as Ops
+import qualified Streamly.Benchmark.Prelude as Ops
 
 import Streamly
 import qualified Streamly.Fold as FL

--- a/benchmark/LinearAsync.hs
+++ b/benchmark/LinearAsync.hs
@@ -8,7 +8,7 @@
 import Control.DeepSeq (NFData)
 -- import Data.Functor.Identity (Identity, runIdentity)
 import System.Random (randomRIO)
-import qualified LinearOps as Ops
+import qualified Streamly.Benchmark.Prelude as Ops
 
 import Streamly
 import Gauge

--- a/benchmark/LinearRate.hs
+++ b/benchmark/LinearRate.hs
@@ -10,7 +10,7 @@
 
 -- import Data.Functor.Identity (Identity, runIdentity)
 import System.Random (randomRIO)
-import qualified LinearOps as Ops
+import qualified Streamly.Benchmark.Prelude as Ops
 
 import Streamly
 import Gauge

--- a/design/inlining.md
+++ b/design/inlining.md
@@ -109,3 +109,15 @@ on `i` to get it specialized:
 ```
 
 `-flate-specialise` also helps in this case.
+
+## Stream and Fold State Data Structures
+
+Since state is an internal data structure threaded around in the loop, it is a
+good practice to use strict unboxed fields for state data structures where
+possible. In most cases it is not necessary, but in some cases it may affect
+fusion and make a difference of 10x performance or more.  For example, using
+non-strict fields can increase the code size for internal join points and
+functions created during transformations, which can affect the inlining of
+these code blocks which in turn can affect stream fusion. 
+
+See https://gitlab.haskell.org/ghc/ghc/issues/17075 .

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -4,6 +4,19 @@ Recommended GHC options are:
 
   `-O2 -fspec-constr-recursive=10 -fmax-worker-args=16`
 
+`-fspec-constr-recursive` is needed for better stream fusion by enabling
+the `SpecConstr` optimization in more cases.
+
+`-fmax-worker-args` is needed for better stream fusion by enabling the
+`SpecConstr` optimization in some important cases.
+
+In some cases, you may need to use `-funfolding-use-threshold` to make sure
+that the combinators fuse. The default value of this option is `60`. Increasing
+this default value can be detrimental in general, therefore, increase only if
+you suspect an issue. As an example, a value of `75` is necessary and
+sufficient to fuse `S.chunksOf n (A.writeN n)`. Hopefully GHC will fix this so
+that it is not needed in future.
+
 At the very least `-O` compilation option is required. In some cases, the
 program may exhibit memory hog with default optimization options.  For example,
 the following program, if compiled without an optimization option, is known to
@@ -12,9 +25,6 @@ hog memory:
 ```
 main = S.drain $ S.concatMap S.fromList $ S.repeat []
 ```
-
-The `-fspec-constr-recursive=10` option may not be necessary in most cases but
-may help boost performance in some cases.
 
 # Multi-core Parallelism
 

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -2,7 +2,7 @@
 
 Recommended GHC options are: 
 
-  `-O2 -fspec-constr-recursive=10`
+  `-O2 -fspec-constr-recursive=10 -fmax-worker-args=16`
 
 At the very least `-O` compilation option is required. In some cases, the
 program may exhibit memory hog with default optimization options.  For example,

--- a/examples/ControlFlow.hs
+++ b/examples/ControlFlow.hs
@@ -39,7 +39,6 @@ getSequenceMaybeBelow
     :: ( IsStream t
        , Monad m
        , MonadTrans t
-       , Applicative (t (MaybeT m))
        , MonadIO (t (MaybeT m))
        )
     => t (MaybeT m) ()
@@ -102,7 +101,6 @@ getSequenceEitherBelow
     :: ( IsStream t
        , MonadTrans t
        , Monad m
-       , MonadIO (t m)
        , MonadIO (t (ExceptT String m))
        )
     => t (ExceptT String m) ()
@@ -136,8 +134,6 @@ getSequenceEitherAsyncBelow
     :: ( IsStream t
        , MonadTrans t
        , MonadIO m
-       , MonadAsync m
-       , MonadIO (t m)
        , MonadIO (t (ExceptT String m))
        , Semigroup (t (ExceptT String m) Integer)
        )
@@ -171,7 +167,7 @@ mainEitherAsyncBelow = do
 --
 -- Here we can use catchE directly but will have to use monad-control to lift
 -- stream operations with stream arguments.
-getSequenceEitherAbove :: (IsStream t, Monad m, MonadIO (t m))
+getSequenceEitherAbove :: (IsStream t, MonadIO (t m))
     => ExceptT String (t m) ()
 getSequenceEitherAbove = do
     liftIO $ putStrLn "ExceptT above streamly: Enter one char per line: "
@@ -185,8 +181,7 @@ getSequenceEitherAbove = do
     r2 <- liftIO getLine
     when (r2 /= "y") $ throwE $ "Expecting y got: " <> r2
 
-mainEitherAbove :: (IsStream t, Monad m, MonadIO (t m))
-    => ExceptT String (t m) ()
+mainEitherAbove :: (IsStream t, MonadIO (t m)) => ExceptT String (t m) ()
 mainEitherAbove =
     catchE (getSequenceEitherAbove >> liftIO (putStrLn "Bingo"))
            (liftIO . putStrLn)
@@ -202,7 +197,7 @@ instance Exception Unexpected
 -- Note that unlike when ExceptT is used on top, MonadThrow terminates all
 -- iterations of non-determinism rather then just the current iteration.
 --
-getSequenceMonadThrow :: (IsStream t, Monad m, MonadIO (t m), MonadThrow (t m))
+getSequenceMonadThrow :: (IsStream t, MonadIO (t m), MonadThrow (t m))
     => t m ()
 getSequenceMonadThrow = do
     liftIO $ putStrLn "MonadThrow in streamly: Enter one char per line: "
@@ -265,7 +260,7 @@ mainContBelow = do
 -- Using ContT above streamly
 -------------------------------------------------------------------------------
 --
-getSequenceContAbove :: (IsStream t, Monad m, MonadIO (t m))
+getSequenceContAbove :: (IsStream t, MonadIO (t m))
     => ContT r (t m) (Either String ())
 getSequenceContAbove = do
     liftIO $ putStrLn "ContT above streamly: Enter one char per line: "
@@ -284,7 +279,7 @@ getSequenceContAbove = do
         then exit $ Left $ "Expecting y got: " <> r2
         else return $ Right ()
 
-mainContAbove :: (IsStream t, Monad m, MonadIO (t m)) => ContT r (t m) ()
+mainContAbove :: (IsStream t, MonadIO (t m)) => ContT r (t m) ()
 mainContAbove = do
     r <- getSequenceContAbove
     case r of

--- a/src/Streamly/Benchmark/FileIO/Stream.hs
+++ b/src/Streamly/Benchmark/FileIO/Stream.hs
@@ -165,6 +165,7 @@ hinspect $ hasNoTypeClasses 'copyCodecUtf8
 {-# INLINE chunksOf #-}
 chunksOf :: Int -> Handle -> IO Int
 chunksOf n inh =
+    -- writeNUnsafe gives 2.5x boost here over writeN.
     S.length $ S.chunksOf n (AT.writeNUnsafe n) (FH.read inh)
 
 hinspect $ hasNoTypeClasses 'chunksOf

--- a/src/Streamly/Benchmark/FileIO/Stream.hs
+++ b/src/Streamly/Benchmark/FileIO/Stream.hs
@@ -45,6 +45,7 @@ import Streamly.Benchmark.Inspection (hinspect)
 import qualified Streamly.Memory.Array.Types as AT
 
 import qualified Streamly.FileSystem.Handle as FH
+import qualified Streamly.FileSystem.Handle.Internal as FH
 import qualified Streamly.Memory.Array as A
 import qualified Streamly.Prelude.Internal as S
 import qualified Streamly.Fold as FL
@@ -125,7 +126,7 @@ hinspect $ 'cat `hasNoType` ''D.ConcatMapUState
 -- | Send the file contents to /dev/null
 {-# INLINE catStreamWrite #-}
 catStreamWrite :: Handle -> Handle -> IO ()
-catStreamWrite devNull inh = Internal.writeS devNull $ FH.read inh
+catStreamWrite devNull inh = FH.writeS devNull $ FH.read inh
 
 hinspect $ hasNoTypeClasses 'catStreamWrite
 hinspect $ 'catStreamWrite `hasNoType` ''Step

--- a/src/Streamly/Benchmark/FileIO/Stream.hs
+++ b/src/Streamly/Benchmark/FileIO/Stream.hs
@@ -155,7 +155,7 @@ chunksOf n inh =
     S.length $ S.chunksOf n (A.writeN n) (FH.read inh)
 
 hinspect $ hasNoTypeClasses 'chunksOf
--- hinspect $ 'chunksOf `hasNoType` ''Step
+hinspect $ 'chunksOf `hasNoType` ''Step
 
 -- | Lines and unlines
 {-# INLINE linesUnlinesCopy #-}

--- a/src/Streamly/Benchmark/FileIO/Stream.hs
+++ b/src/Streamly/Benchmark/FileIO/Stream.hs
@@ -62,6 +62,7 @@ last = S.last . FH.read
 hinspect $ hasNoTypeClasses 'last
 hinspect $ 'last `hasNoType` ''Step
 hinspect $ 'last `hasNoType` ''AT.FlattenState
+hinspect $ 'last `hasNoType` ''D.ConcatMapUState
 
 -- assert that flattenArrays constructors are not present
 -- | Count the number of bytes in a file.
@@ -72,6 +73,7 @@ countBytes = S.length . FH.read
 hinspect $ hasNoTypeClasses 'countBytes
 hinspect $ 'countBytes `hasNoType` ''Step
 hinspect $ 'countBytes `hasNoType` ''AT.FlattenState
+hinspect $ 'countBytes `hasNoType` ''D.ConcatMapUState
 
 -- | Count the number of lines in a file.
 {-# INLINE countLines #-}
@@ -85,6 +87,7 @@ countLines =
 hinspect $ hasNoTypeClasses 'countLines
 hinspect $ 'countLines `hasNoType` ''Step
 hinspect $ 'countLines `hasNoType` ''AT.FlattenState
+hinspect $ 'countLines `hasNoType` ''D.ConcatMapUState
 
 -- | Count the number of lines in a file.
 {-# INLINE countLinesU #-}
@@ -97,7 +100,7 @@ countLinesU inh =
 
 hinspect $ hasNoTypeClasses 'countLinesU
 hinspect $ 'countLinesU `hasNoType` ''Step
-hinspect $ 'countLinesU `hasNoType` ''Either
+hinspect $ 'countLinesU `hasNoType` ''D.ConcatMapUState
 
 -- | Sum the bytes in a file.
 {-# INLINE sumBytes #-}
@@ -107,6 +110,7 @@ sumBytes = S.sum . FH.read
 hinspect $ hasNoTypeClasses 'sumBytes
 hinspect $ 'sumBytes `hasNoType` ''Step
 hinspect $ 'sumBytes `hasNoType` ''AT.FlattenState
+hinspect $ 'sumBytes `hasNoType` ''D.ConcatMapUState
 
 -- | Send the file contents to /dev/null
 {-# INLINE cat #-}
@@ -116,6 +120,7 @@ cat devNull inh = S.runFold (FH.write devNull) $ FH.read inh
 hinspect $ hasNoTypeClasses 'cat
 hinspect $ 'cat `hasNoType` ''Step
 hinspect $ 'cat `hasNoType` ''AT.FlattenState
+hinspect $ 'cat `hasNoType` ''D.ConcatMapUState
 
 -- | Send the file contents to /dev/null
 {-# INLINE catStreamWrite #-}
@@ -125,6 +130,7 @@ catStreamWrite devNull inh = Internal.writeS devNull $ FH.read inh
 hinspect $ hasNoTypeClasses 'catStreamWrite
 hinspect $ 'catStreamWrite `hasNoType` ''Step
 hinspect $ 'catStreamWrite `hasNoType` ''AT.FlattenState
+hinspect $ 'catStreamWrite `hasNoType` ''D.ConcatMapUState
 
 -- | Copy file
 {-# INLINE copy #-}
@@ -134,6 +140,7 @@ copy inh outh = S.runFold (FH.write outh) (FH.read inh)
 hinspect $ hasNoTypeClasses 'copy
 hinspect $ 'copy `hasNoType` ''Step
 hinspect $ 'copy `hasNoType` ''AT.FlattenState
+hinspect $ 'copy `hasNoType` ''D.ConcatMapUState
 
 -- | Copy file
 {-# INLINE copyCodecChar8 #-}
@@ -147,6 +154,7 @@ copyCodecChar8 inh outh =
 hinspect $ hasNoTypeClasses 'copyCodecChar8
 hinspect $ 'copyCodecChar8 `hasNoType` ''Step
 hinspect $ 'copyCodecChar8 `hasNoType` ''AT.FlattenState
+hinspect $ 'copyCodecChar8 `hasNoType` ''D.ConcatMapUState
 
 -- | Copy file
 {-# INLINE copyCodecUtf8 #-}
@@ -160,6 +168,7 @@ copyCodecUtf8 inh outh =
 hinspect $ hasNoTypeClasses 'copyCodecUtf8
 -- hinspect $ 'copyCodecUtf8 `hasNoType` ''Step
 -- hinspect $ 'copyCodecUtf8 `hasNoType` ''AT.FlattenState
+-- hinspect $ 'copyCodecUtf8 `hasNoType` ''D.ConcatMapUState
 
 -- | Slice in chunks of size n and get the count of chunks.
 {-# INLINE chunksOf #-}
@@ -171,6 +180,7 @@ chunksOf n inh =
 hinspect $ hasNoTypeClasses 'chunksOf
 hinspect $ 'chunksOf `hasNoType` ''Step
 hinspect $ 'chunksOf `hasNoType` ''AT.FlattenState
+hinspect $ 'chunksOf `hasNoType` ''D.ConcatMapUState
 hinspect $ 'chunksOf `hasNoType` ''GroupState
 
 -- This is to make sure that the concatMap in FH.read, groupsOf and foldlM'
@@ -188,6 +198,7 @@ hinspect $ hasNoTypeClasses 'chunksOf
 hinspect $ 'chunksOf `hasNoType` ''Step
 hinspect $ 'chunksOfD `hasNoType` ''GroupState
 hinspect $ 'chunksOfD `hasNoType` ''AT.FlattenState
+hinspect $ 'chunksOfD `hasNoType` ''D.ConcatMapUState
 
 -- | Lines and unlines
 {-# INLINE linesUnlinesCopy #-}
@@ -203,6 +214,7 @@ linesUnlinesCopy inh outh =
 -- hinspect $ hasNoTypeClasses 'linesUnlinesCopy
 -- hinspect $ 'linesUnlinesCopy `hasNoType` ''Step
 -- hinspect $ 'linesUnlinesCopy `hasNoType` ''AT.FlattenState
+-- hinspect $ 'linesUnlinesCopy `hasNoType` ''D.ConcatMapUState
 
 -- | Word, unwords and copy
 {-# INLINE wordsUnwordsCopy #-}
@@ -218,6 +230,7 @@ wordsUnwordsCopy inh outh =
 -- hinspect $ hasNoTypeClasses 'wordsUnwordsCopy
 -- hinspect $ 'wordsUnwordsCopy `hasNoType` ''Step
 -- hinspect $ 'wordsUnwordsCopy `hasNoType` ''AT.FlattenState
+-- hinspect $ 'wordsUnwordsCopy `hasNoType` ''D.ConcatMapUState
 
 lf :: Word8
 lf = fromIntegral (ord '\n')
@@ -256,6 +269,7 @@ splitOn inh =
 hinspect $ hasNoTypeClasses 'splitOn
 hinspect $ 'splitOn `hasNoType` ''Step
 hinspect $ 'splitOn `hasNoType` ''AT.FlattenState
+hinspect $ 'splitOn `hasNoType` ''D.ConcatMapUState
 
 -- | Split suffix on line feed.
 {-# INLINE splitOnSuffix #-}
@@ -267,6 +281,7 @@ splitOnSuffix inh =
 hinspect $ hasNoTypeClasses 'splitOnSuffix
 hinspect $ 'splitOnSuffix `hasNoType` ''Step
 hinspect $ 'splitOnSuffix `hasNoType` ''AT.FlattenState
+hinspect $ 'splitOnSuffix `hasNoType` ''D.ConcatMapUState
 
 -- | Words by space
 {-# INLINE wordsBy #-}
@@ -278,6 +293,7 @@ wordsBy inh =
 hinspect $ hasNoTypeClasses 'wordsBy
 hinspect $ 'wordsBy `hasNoType` ''Step
 hinspect $ 'wordsBy `hasNoType` ''AT.FlattenState
+hinspect $ 'wordsBy `hasNoType` ''D.ConcatMapUState
 
 -- | Split on a character sequence.
 {-# INLINE splitOnSeq #-}
@@ -289,6 +305,7 @@ splitOnSeq str inh =
 hinspect $ hasNoTypeClasses 'splitOnSeq
 -- hinspect $ 'splitOnSeq `hasNoType` ''Step
 -- hinspect $ 'splitOnSeq `hasNoType` ''AT.FlattenState
+-- hinspect $ 'splitOnSeq `hasNoType` ''D.ConcatMapUState
 
 -- | Split on suffix sequence.
 {-# INLINE splitOnSuffixSeq #-}
@@ -300,3 +317,4 @@ splitOnSuffixSeq str inh =
 hinspect $ hasNoTypeClasses 'splitOnSuffixSeq
 -- hinspect $ 'splitOnSuffixSeq `hasNoType` ''Step
 -- hinspect $ 'splitOnSuffixSeq `hasNoType` ''AT.FlattenState
+-- hinspect $ 'splitOnSuffixSeq `hasNoType` ''D.ConcatMapUState

--- a/src/Streamly/Benchmark/FileIO/Stream.hs
+++ b/src/Streamly/Benchmark/FileIO/Stream.hs
@@ -45,7 +45,6 @@ import Streamly.Benchmark.Inspection (hinspect)
 import qualified Streamly.Memory.Array.Types as AT
 
 import qualified Streamly.FileSystem.Handle as FH
-import qualified Streamly.FileSystem.Handle.Internal as FH
 import qualified Streamly.Memory.Array as A
 import qualified Streamly.Prelude.Internal as S
 import qualified Streamly.Fold as FL
@@ -170,8 +169,8 @@ chunksOf n inh =
 
 hinspect $ hasNoTypeClasses 'chunksOf
 hinspect $ 'chunksOf `hasNoType` ''Step
--- hinspect $ 'chunksOf `hasNoType` ''AT.FlattenState
--- hinspect $ 'chunksOf `hasNoType` ''GroupState
+hinspect $ 'chunksOf `hasNoType` ''AT.FlattenState
+hinspect $ 'chunksOf `hasNoType` ''GroupState
 
 -- This is to make sure that the concatMap in FH.read, groupsOf and foldlM'
 -- together can fuse.
@@ -186,8 +185,8 @@ chunksOfD n inh =
 
 hinspect $ hasNoTypeClasses 'chunksOf
 hinspect $ 'chunksOf `hasNoType` ''Step
--- hinspect $ 'chunksOfD `hasNoType` ''GroupState
--- hinspect $ 'chunksOfD `hasNoType` ''AT.FlattenState
+hinspect $ 'chunksOfD `hasNoType` ''GroupState
+hinspect $ 'chunksOfD `hasNoType` ''AT.FlattenState
 
 -- | Lines and unlines
 {-# INLINE linesUnlinesCopy #-}

--- a/src/Streamly/Benchmark/Prelude.hs
+++ b/src/Streamly/Benchmark/Prelude.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      : BenchmarkOps
+-- Module      : Streamly.Benchmark.Prelude
 -- Copyright   : (c) 2018 Harendra Kumar
 --
 -- License     : MIT
@@ -11,7 +11,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 
-module LinearOps where
+module Streamly.Benchmark.Prelude where
 
 import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO)

--- a/src/Streamly/FileSystem/FD.hs
+++ b/src/Streamly/FileSystem/FD.hs
@@ -150,6 +150,7 @@ import qualified Streamly.FileSystem.FDIO as RawIO hiding (write)
 -- import Streamly.String (encodeUtf8, decodeUtf8, foldLines)
 
 import qualified Streamly.Memory.Array as A
+import qualified Streamly.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Streams.StreamD.Type as D
 
@@ -399,7 +400,7 @@ _writevArraysPackedUpto n h xs =
 -- @since 0.7.0
 {-# INLINE writeInChunksOf #-}
 writeInChunksOf :: MonadIO m => Int -> Handle -> SerialT m Word8 -> m ()
-writeInChunksOf n h m = writeArrays h $ A.arraysOf n m
+writeInChunksOf n h m = writeArrays h $ AS.arraysOf n m
 
 -- > write = 'writeInChunksOf' A.defaultChunkSize
 --

--- a/src/Streamly/FileSystem/File.hs
+++ b/src/Streamly/FileSystem/File.hs
@@ -124,6 +124,7 @@ import Streamly.SVar (MonadAsync)
 
 import qualified Streamly.FileSystem.Handle as FH
 import qualified Streamly.Memory.Array as A
+import qualified Streamly.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
 
 -------------------------------------------------------------------------------
@@ -289,7 +290,7 @@ writeArrays = writeArraysMode WriteMode
 {-# INLINE writeInChunksOf #-}
 writeInChunksOf :: (MonadAsync m, MonadCatch m)
     => Int -> FilePath -> SerialT m Word8 -> m ()
-writeInChunksOf n file xs = writeArrays file $ A.arraysOf n xs
+writeInChunksOf n file xs = writeArrays file $ AS.arraysOf n xs
 
 -- > write = 'writeInChunksOf' defaultChunkSize
 --
@@ -325,7 +326,7 @@ appendArrays = writeArraysMode AppendMode
 {-# INLINE appendByChunks #-}
 appendByChunks :: (MonadAsync m, MonadCatch m)
     => Int -> FilePath -> SerialT m Word8 -> m ()
-appendByChunks n file xs = appendArrays file $ A.arraysOf n xs
+appendByChunks n file xs = appendArrays file $ AS.arraysOf n xs
 
 -- | Append a byte stream to a file. Combines the bytes in chunks of size up to
 -- 'A.defaultChunkSize' before writing.  If the file exists then the new data

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -237,7 +237,7 @@ readInChunksOf chunkSize h = A.concat $ readArraysOf chunkSize h
 -- Generate a stream of elements of the given type from a file 'Handle'.
 -- read :: (IsStream t, MonadIO m, Storable a) => Handle -> t m a
 --
--- > read = 'readByChunks' A.defaultChunkSize
+-- > read = 'readInChunksOf' A.defaultChunkSize
 -- | Generate a byte stream from a file 'Handle'.
 --
 -- @since 0.7.0

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -119,7 +119,7 @@ import System.IO (Handle, hGetBufSome)
 import Prelude hiding (read)
 
 import Streamly.FileSystem.Handle.Internal (writeArray)
-import Streamly.Memory.Array.Types (Array(..))
+import Streamly.Memory.Array.Types (Array(..), writeNUnsafe)
 import Streamly.Streams.StreamK.Type (IsStream, mkStream)
 import Streamly.Memory.Array.Types
        (defaultChunkSize, shrinkToFit, lpackArraysChunksOf)
@@ -283,7 +283,7 @@ writeArraysInChunksOf n h = lpackArraysChunksOf n (writeArrays h)
 -- @since 0.7.0
 {-# INLINE writeInChunksOf #-}
 writeInChunksOf :: MonadIO m => Int -> Handle -> Fold m Word8 ()
-writeInChunksOf n h = FL.lchunksOf n (A.writeN n) (writeArrays h)
+writeInChunksOf n h = FL.lchunksOf n (writeNUnsafe n) (writeArrays h)
 
 -- > write = 'writeInChunksOf' A.defaultChunkSize
 --

--- a/src/Streamly/FileSystem/Handle/Internal.hs
+++ b/src/Streamly/FileSystem/Handle/Internal.hs
@@ -91,16 +91,6 @@ writeSArraysInChunksOf :: (MonadIO m, Storable a)
     => Int -> Handle -> SerialT m (Array a) -> m ()
 writeSArraysInChunksOf n h xs = writeSArrays h $ AS.compact n xs
 
--- XXX Using custom array chunking with A.arraysOf, writeS gives 2x faster
--- readStream/catStream benchmark compared to S.arraysOf based writeS as well
--- as compared to the fold IO version of cat benchmark i.e. readStream/cat.
--- However, if we use the most optimal A.writeNUnsafe fold then the fold
--- version of cat is also as fast. But with the most optimal version of
--- A.writeNUnsafe, fusion breaks. Once GHC fusion problem gets fixed we should
--- be able to use that.
---
--- Until then we are keeping the custom A.arraysOf code.
---
 -- | @writeSInChunksOf chunkSize handle stream@ writes @stream@ to @handle@ in
 -- chunks of @chunkSize@.  A write is performed to the IO device as soon as we
 -- collect the required input size.
@@ -108,8 +98,8 @@ writeSArraysInChunksOf n h xs = writeSArrays h $ AS.compact n xs
 -- @since 0.7.0
 {-# INLINE writeSInChunksOf #-}
 writeSInChunksOf :: MonadIO m => Int -> Handle -> SerialT m Word8 -> m ()
--- writeSInChunksOf n h m = writeSArrays h $ S.arraysOf n m
-writeSInChunksOf n h m = writeSArrays h $ AS.arraysOf n m
+writeSInChunksOf n h m = writeSArrays h $ S.arraysOf n m
+-- writeSInChunksOf n h m = writeSArrays h $ AS.arraysOf n m
 
 -- > write = 'writeInChunksOf' A.defaultChunkSize
 --

--- a/src/Streamly/Internal.hs
+++ b/src/Streamly/Internal.hs
@@ -74,22 +74,15 @@ module Streamly.Internal
 
     -- * Streamly.Memory.Array
     , readU
-    , A.arraysOf
-    , writeNUnsafe
-
-    -- * Streamly.FileSystem.Handle
-    , writeS
     )
 where
 
 import Prelude hiding (break, span, splitAt)
 
-import Streamly.FileSystem.Handle.Internal (writeS)
-import Streamly.Memory.Array.Types (readU, writeNUnsafe)
+import Streamly.Memory.Array.Types (readU)
 import Streamly.Streams.Combinators (inspectMode)
 import Streamly.Streams.Parallel (tapAsync)
 import Streamly.Unfold.Types (Unfold(..))
 
-import qualified Streamly.Memory.ArrayStream as A
 import Streamly.Prelude.Internal
 import Streamly.Fold.Types

--- a/src/Streamly/Internal.hs
+++ b/src/Streamly/Internal.hs
@@ -41,6 +41,7 @@ module Streamly.Internal
     , break -- breakBefore
     , spanBy
     , spanByRolling
+    , arraysOf
     , splitOnSeq
     , splitOnSuffixSeq
     , splitBySeq

--- a/src/Streamly/Internal.hs
+++ b/src/Streamly/Internal.hs
@@ -75,6 +75,7 @@ module Streamly.Internal
     -- * Streamly.Memory.Array
     , readU
     , A.arraysOf
+    , writeNUnsafe
 
     -- * Streamly.FileSystem.Handle
     , writeS
@@ -84,7 +85,7 @@ where
 import Prelude hiding (break, span, splitAt)
 
 import Streamly.FileSystem.Handle.Internal (writeS)
-import Streamly.Memory.Array.Types (readU)
+import Streamly.Memory.Array.Types (readU, writeNUnsafe)
 import Streamly.Streams.Combinators (inspectMode)
 import Streamly.Streams.Parallel (tapAsync)
 import Streamly.Unfold.Types (Unfold(..))

--- a/src/Streamly/Internal.hs
+++ b/src/Streamly/Internal.hs
@@ -74,6 +74,7 @@ module Streamly.Internal
 
     -- * Streamly.Memory.Array
     , readU
+    , A.arraysOf
 
     -- * Streamly.FileSystem.Handle
     , writeS
@@ -88,5 +89,6 @@ import Streamly.Streams.Combinators (inspectMode)
 import Streamly.Streams.Parallel (tapAsync)
 import Streamly.Unfold.Types (Unfold(..))
 
+import qualified Streamly.Memory.ArrayStream as A
 import Streamly.Prelude.Internal
 import Streamly.Fold.Types

--- a/src/Streamly/Memory/Array.hs
+++ b/src/Streamly/Memory/Array.hs
@@ -121,8 +121,8 @@ module Streamly.Memory.Array
     -}
 
     -- * Streams of Arrays
-    -- ** Creation
-    , AS.arraysOf
+    -- -- ** Creation
+    -- , AS.arraysOf
 
     -- ** Elimination
     , AS.concat

--- a/src/Streamly/Memory/Array/Types.hs
+++ b/src/Streamly/Memory/Array/Types.hs
@@ -36,6 +36,7 @@ module Streamly.Memory.Array.Types
 
     -- * Streams of arrays
     , fromStreamDArraysOf
+    , FlattenState (..) -- for inspection testing
     , flattenArrays
     , flattenArraysRev
     , packArraysChunksOf

--- a/src/Streamly/Memory/ArrayStream.hs
+++ b/src/Streamly/Memory/ArrayStream.hs
@@ -67,9 +67,9 @@ import qualified Streamly.Streams.Prelude as P
 -- @since 0.7.0
 {-# INLINE concat #-}
 concat :: (IsStream t, MonadIO m, Storable a) => t m (Array a) -> t m a
-concat m = D.fromStreamD $ A.flattenArrays (D.toStreamD m)
+-- concat m = D.fromStreamD $ A.flattenArrays (D.toStreamD m)
 -- concat m = D.fromStreamD $ D.concatMap A.toStreamD (D.toStreamD m)
--- concat m = D.fromStreamD $ D.concatMapU A.readU (D.toStreamD m)
+concat m = D.fromStreamD $ D.concatMapU A.readU (D.toStreamD m)
 
 -- XXX should we have a reverseArrays API to reverse the stream of arrays
 -- instead?

--- a/src/Streamly/Network/Client.hs
+++ b/src/Streamly/Network/Client.hs
@@ -67,7 +67,7 @@ import qualified Network.Socket as Net
 
 import Streamly (MonadAsync)
 import Streamly.Fold.Types (Fold(..))
-import Streamly.Memory.Array.Types (Array(..), defaultChunkSize)
+import Streamly.Memory.Array.Types (Array(..), defaultChunkSize, writeNUnsafe)
 -- import Streamly.Streams.Serial (SerialT)
 import Streamly.Streams.StreamK.Type (IsStream)
 
@@ -179,7 +179,8 @@ writeInChunksOf
     -> (Word8, Word8, Word8, Word8)
     -> PortNumber
     -> Fold m Word8 ()
-writeInChunksOf n addr port = FL.lchunksOf n (A.writeN n) (writeArrays addr port)
+writeInChunksOf n addr port =
+    FL.lchunksOf n (writeNUnsafe n) (writeArrays addr port)
 
 {-
 -- | Write a stream to the supplied IPv4 host address and port number.

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -95,6 +95,7 @@ import Streamly.Fold (Fold)
 import qualified Streamly.Fold as FL
 import qualified Streamly.Fold.Types as FL
 import qualified Streamly.Memory.Array as A
+import qualified Streamly.Memory.ArrayStream as AS
 import qualified Streamly.Memory.Array.Types as A
 import qualified Streamly.Prelude as S
 
@@ -301,7 +302,7 @@ writeArrays h = FL.drainBy (liftIO . writeArray h)
 -- @since 0.7.0
 {-# INLINE writeInChunksOfS #-}
 writeInChunksOfS :: MonadIO m => Int -> Socket -> SerialT m Word8 -> m ()
-writeInChunksOfS n h m = writeArraysS h $ A.arraysOf n m
+writeInChunksOfS n h m = writeArraysS h $ AS.arraysOf n m
 
 -- | Write a byte stream to a socket. Accumulates the input in chunks of
 -- specified number of bytes before writing.
@@ -309,7 +310,7 @@ writeInChunksOfS n h m = writeArraysS h $ A.arraysOf n m
 -- @since 0.7.0
 {-# INLINE writeInChunksOf #-}
 writeInChunksOf :: MonadIO m => Int -> Socket -> Fold m Word8 ()
-writeInChunksOf n h = FL.lchunksOf n (A.writeN n) (writeArrays h)
+writeInChunksOf n h = FL.lchunksOf n (A.writeNUnsafe n) (writeArrays h)
 
 -- > write = 'writeInChunksOf' A.defaultChunkSize
 --

--- a/src/Streamly/Prelude/Internal.hs
+++ b/src/Streamly/Prelude/Internal.hs
@@ -1024,7 +1024,7 @@ runWhile = drainWhile
 -- @since 0.1.1
 {-# INLINE null #-}
 null :: Monad m => SerialT m a -> m Bool
-null = K.null
+null = S.null . toStreamS
 
 -- | Extract the first element of the stream, if any.
 --
@@ -1033,7 +1033,7 @@ null = K.null
 -- @since 0.1.0
 {-# INLINE head #-}
 head :: Monad m => SerialT m a -> m (Maybe a)
-head = K.head
+head = S.head . toStreamS
 
 -- |
 -- > tail = fmap (fmap snd) . uncons

--- a/src/Streamly/Streams/Parallel.hs
+++ b/src/Streamly/Streams/Parallel.hs
@@ -104,7 +104,9 @@ runOneLimited st m0 winfo = go m0
         then do
             liftIO $ decrementBufferLimit sv
             foldStreamShared st yieldk single stop m
-        else liftIO $ cleanupSVarFromWorker sv
+        else do
+            liftIO $ cleanupSVarFromWorker sv
+            liftIO $ sendStop sv winfo
 
     sv = fromJust $ streamVar st
 

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -648,7 +648,6 @@ drain (Stream step state) = go SPEC state
 null :: Monad m => Stream m a -> m Bool
 null m = foldrM (\_ _ -> return False) (return True) m
 
--- XXX SPEC?
 {-# INLINE_NORMAL head #-}
 head :: Monad m => Stream m a -> m (Maybe a)
 head m = foldrM (\x _ -> return (Just x)) (return Nothing) m

--- a/src/Streamly/Streams/StreamD/Type.hs
+++ b/src/Streamly/Streams/StreamD/Type.hs
@@ -60,6 +60,7 @@ module Streamly.Streams.StreamD.Type
     , eqBy
     , cmpBy
     , take
+    , GroupState (..) -- for inspection testing
     , groupsOf
     )
 where

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -1,3 +1,4 @@
+cabal-version:      2.2
 name:               streamly
 version:            0.6.1
 synopsis:           Beautiful Streaming, Concurrent and Reactive Composition
@@ -86,7 +87,7 @@ description:
 
 homepage:            https://github.com/composewell/streamly
 bug-reports:         https://github.com/composewell/streamly/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 tested-with:         GHC==7.10.3
                    , GHC==8.0.2
@@ -98,7 +99,6 @@ copyright:           2017 Harendra Kumar
 category:            Control, Concurrency, Streaming, Reactivity
 stability:           Experimental
 build-type:          Configure
-cabal-version:       >= 1.10
 
 extra-source-files:
     Changelog.md
@@ -172,10 +172,80 @@ flag examples-sdl
   default: False
 
 -------------------------------------------------------------------------------
+-- Common stanzas
+-------------------------------------------------------------------------------
+
+common compile-options
+    default-language: Haskell2010
+    if flag(streamk)
+      cpp-options:    -DUSE_STREAMK_ONLY
+
+    if flag(no-fusion)
+      cpp-options:    -DDISABLE_FUSION
+
+    if flag(dev)
+      cpp-options:    -DDEVBUILD
+
+    ghc-options:      -Wall
+
+    if flag(has-llvm)
+      ghc-options: -fllvm
+
+    if flag(dev)
+      ghc-options:    -Wmissed-specialisations
+                      -Wall-missed-specialisations
+                      -fno-ignore-asserts
+    if impl(ghc >= 8.0)
+      ghc-options:    -Wcompat
+                      -Wunrecognised-warning-flags
+                      -Widentities
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wnoncanonical-monad-instances
+                      -Wnoncanonical-monadfail-instances
+
+common optimization-options
+  ghc-options: -O2
+               -fspec-constr-recursive=10
+               -fmax-worker-args=16
+
+common threading-options
+  ghc-options:  -threaded
+                -with-rtsopts=-N
+
+-- We need optimization options here to optimize internal (non-inlined)
+-- versions of functions. Also, we have some benchmarking inspection tests
+-- part of the library when built with --benchmarks flag. Thos tests fail
+-- if we do not use optimization options here. It was observed that due to
+-- -O2 here some concurrent/nested benchmarks improved and others regressed.
+-- We can investigate a bit more here why the regression occurred.
+common lib-options
+  import: compile-options, optimization-options
+
+-- Compilation for coverage builds on CI machines takes too long without -O0
+-- XXX we should use coverage flag for that, -O0 may take too long to run tests
+-- in general.
+common test-options
+  import: compile-options, threading-options
+  ghc-options:  -O0
+                -fno-ignore-asserts
+
+-- Used by maxrate test, benchmarks and executables
+common exe-options
+  import: compile-options, optimization-options, threading-options
+
+-- Some benchmarks are threaded some are not
+common bench-options
+  import: compile-options, optimization-options
+  ghc-options: -with-rtsopts "-T"
+
+-------------------------------------------------------------------------------
 -- Library
 -------------------------------------------------------------------------------
 
 library
+    import: lib-options
     js-sources: jsbits/clock.js
     include-dirs:     src/Streamly/Time
                     , src/Streamly/Streams
@@ -260,42 +330,6 @@ library
                      , Streamly.Benchmark.FileIO.Array
                      , Streamly.Benchmark.FileIO.Stream
 
-    default-language: Haskell2010
-    -- We need optimization options here to optimize internal (non-inlined)
-    -- versions of functions. Also, we have some benchmarking inspection tests
-    -- part of the library when built with --benchmarks flag. Thos tests fail
-    -- if we do not use optimization options here. It was observed that due to
-    -- -O2 here some concurrent/nested benchmarks improved and others regressed.
-    -- We can investigate a bit more here why the regression occurred.
-    ghc-options:      -Wall
-                      -O2
-                      -fspec-constr-recursive=10
-                      -fmax-worker-args=16
-
-    if flag(has-llvm)
-      ghc-options: -fllvm
-
-    if flag(streamk)
-      cpp-options:    -DUSE_STREAMK_ONLY
-
-    if flag(no-fusion)
-      cpp-options:    -DDISABLE_FUSION
-
-    if flag(dev)
-      cpp-options:    -DDEVBUILD
-      ghc-options:    -Wmissed-specialisations
-                      -Wall-missed-specialisations
-                      -fno-ignore-asserts
-    if impl(ghc >= 8.0)
-      ghc-options:    -Wcompat
-                      -Wunrecognised-warning-flags
-                      -Widentities
-                      -Wincomplete-record-updates
-                      -Wincomplete-uni-patterns
-                      -Wredundant-constraints
-                      -Wnoncanonical-monad-instances
-                      -Wnoncanonical-monadfail-instances
-
     build-depends:     base              >= 4.8   &&  < 5
                      , ghc-prim          >= 0.2   && < 0.6
                      , deepseq           >= 1.4.1 && < 1.5
@@ -328,27 +362,12 @@ library
 -- Test suites
 -------------------------------------------------------------------------------
 
--- Compilation for coverage builds on CI machines takes too long without -O0
-
 test-suite test
+  import: test-options
   type: exitcode-stdio-1.0
   main-is: Main.hs
   js-sources: jsbits/clock.js
   hs-source-dirs: test
-  ghc-options:  -O0 -Wall -threaded -with-rtsopts=-N -fno-ignore-asserts
-  if flag(dev)
-    cpp-options:    -DDEVBUILD
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   build-depends:
       streamly
     , base              >= 4.8   && < 5
@@ -360,23 +379,10 @@ test-suite test
   default-language: Haskell2010
 
 test-suite pure-streams-base
+  import: test-options
   type: exitcode-stdio-1.0
   main-is: PureStreams.hs
   hs-source-dirs: test
-  ghc-options:  -Wall -threaded -with-rtsopts=-N -fno-ignore-asserts
-  if flag(dev)
-    cpp-options:    -DDEVBUILD
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   build-depends:
       streamly
     , base              >= 4.8   && < 5
@@ -385,23 +391,10 @@ test-suite pure-streams-base
 
 -- test-suite pure-streams-streamly
 --   type: exitcode-stdio-1.0
+--  import: test-options
 --   main-is: PureStreams.hs
 --   hs-source-dirs: test
 --   cpp-options:  -DUSE_STREAMLY_LIST
---   ghc-options:  -O0 -Wall -threaded -with-rtsopts=-N -fno-ignore-asserts
---   if flag(dev)
---     cpp-options:    -DDEVBUILD
---     ghc-options:    -Wmissed-specialisations
---                     -Wall-missed-specialisations
---   if impl(ghc >= 8.0)
---     ghc-options:    -Wcompat
---                     -Wunrecognised-warning-flags
---                     -Widentities
---                     -Wincomplete-record-updates
---                     -Wincomplete-uni-patterns
---                     -Wredundant-constraints
---                     -Wnoncanonical-monad-instances
---                     -Wnoncanonical-monadfail-instances
 --   build-depends:
 --       streamly
 --     , base              >= 4.8   && < 5
@@ -409,24 +402,11 @@ test-suite pure-streams-base
 --   default-language: Haskell2010
 
 test-suite properties
+  import: test-options
   type: exitcode-stdio-1.0
   main-is: Prop.hs
   js-sources: jsbits/clock.js
   hs-source-dirs: test
-  ghc-options:  -fno-ignore-asserts -Wall -O0 -threaded -with-rtsopts=-N
-  if flag(dev)
-    cpp-options:    -DDEVBUILD
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   build-depends:
       streamly
     , base              >= 4.8   && < 5
@@ -438,24 +418,11 @@ test-suite properties
   default-language: Haskell2010
 
 test-suite array-test
+  import: test-options
   type: exitcode-stdio-1.0
   main-is: Arrays.hs
   js-sources: jsbits/clock.js
   hs-source-dirs: test
-  ghc-options:  -fno-ignore-asserts -Wall -O0 -threaded -with-rtsopts=-N
-  if flag(dev)
-    cpp-options:    -DDEVBUILD
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   build-depends:
       streamly
     , base              >= 4.8   && < 5
@@ -467,24 +434,11 @@ test-suite array-test
   default-language: Haskell2010
 
 test-suite string-test
+  import: test-options
   type: exitcode-stdio-1.0
   main-is: String.hs
   js-sources: jsbits/clock.js
   hs-source-dirs: test
-  ghc-options:  -fno-ignore-asserts -Wall -O0 -threaded -with-rtsopts=-N
-  if flag(dev)
-    cpp-options:    -DDEVBUILD
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   build-depends:
       streamly
     , base              >= 4.8   && < 5
@@ -496,12 +450,12 @@ test-suite string-test
   default-language: Haskell2010
 
 test-suite maxrate
+  import: exe-options
   type: exitcode-stdio-1.0
   default-language: Haskell2010
   main-is: MaxRate.hs
   js-sources: jsbits/clock.js
   hs-source-dirs:  test
-  ghc-options:  -fno-ignore-asserts -O2 -Wall -threaded -with-rtsopts=-N
   if flag(dev)
     buildable: True
     build-Depends:
@@ -514,43 +468,43 @@ test-suite maxrate
     buildable: False
 
 test-suite loops
+  import: test-options
   type: exitcode-stdio-1.0
   default-language: Haskell2010
   main-is: loops.hs
   hs-source-dirs:  test
-  ghc-options:  -fno-ignore-asserts -O2 -Wall -threaded -with-rtsopts=-N
   build-Depends:
       streamly
     , base >= 4.8   && < 5
 
 test-suite nested-loops
+  import: test-options
   type: exitcode-stdio-1.0
   default-language: Haskell2010
   main-is: nested-loops.hs
   hs-source-dirs:  test
-  ghc-options:  -fno-ignore-asserts -O2 -Wall -threaded -with-rtsopts=-N
   build-Depends:
       streamly
     , base   >= 4.8   && < 5
     , random >= 1.0.0 && < 2
 
 test-suite parallel-loops
+  import: test-options
   type: exitcode-stdio-1.0
   default-language: Haskell2010
   main-is: parallel-loops.hs
   hs-source-dirs:  test
-  ghc-options:  -fno-ignore-asserts -O2 -Wall -threaded -with-rtsopts=-N
   build-Depends:
       streamly
     , base   >= 4.8   && < 5
     , random >= 1.0.0 && < 2
 
 test-suite inspection
+  import: test-options
   type: exitcode-stdio-1.0
   default-language: Haskell2010
   main-is: inspection.hs
   hs-source-dirs:  test
-  ghc-options:  -fno-ignore-asserts -O2 -Wall -threaded -with-rtsopts=-N
   build-Depends:
       streamly
     , base               >= 4.8   && < 5
@@ -566,33 +520,11 @@ test-suite inspection
 -------------------------------------------------------------------------------
 
 benchmark linear
+  import: bench-options
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: Linear.hs
   other-modules: LinearOps
-  default-language: Haskell2010
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
-
-  if flag(has-llvm)
-    ghc-options: -fllvm
-
-  if flag(dev)
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-                    -fno-ignore-asserts
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -604,34 +536,12 @@ benchmark linear
         transformers  >= 0.4 && < 0.6
 
 benchmark linear-async
+  import: bench-options
+  cpp-options: -DLINEAR_ASYNC
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: LinearAsync.hs
   other-modules: LinearOps
-  default-language: Haskell2010
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
-
-  if flag(has-llvm)
-    ghc-options: -fllvm
-
-  cpp-options: -DLINEAR_ASYNC
-  if flag(dev)
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-                    -fno-ignore-asserts
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -643,33 +553,11 @@ benchmark linear-async
         transformers  >= 0.4 && < 0.6
 
 benchmark linear-rate
+  import: bench-options
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: LinearRate.hs
   other-modules: LinearOps
-  default-language: Haskell2010
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
-
-  if flag(has-llvm)
-    ghc-options: -fllvm
-
-  if flag(dev)
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-                    -fno-ignore-asserts
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -681,34 +569,11 @@ benchmark linear-rate
         transformers  >= 0.4 && < 0.6
 
 benchmark nested
+  import: bench-options
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: Nested.hs
   other-modules: NestedOps
-  default-language: Haskell2010
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
-
-  if flag(has-llvm)
-    ghc-options: -fllvm
-
-  if flag(dev)
-    cpp-options:    -DDEVBUILD
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-                    -fno-ignore-asserts
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -720,34 +585,11 @@ benchmark nested
         transformers  >= 0.4 && < 0.6
 
 benchmark array
+  import: bench-options
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: Array.hs
   other-modules: ArrayOps
-  default-language: Haskell2010
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
-
-  if flag(has-llvm)
-    ghc-options: -fllvm
-
-  if flag(dev)
-    cpp-options:    -DDEVBUILD
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-                    -fno-ignore-asserts
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -759,33 +601,10 @@ benchmark array
         transformers  >= 0.4 && < 0.6
 
 benchmark fileio
+  import: bench-options
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: FileIO.hs
-  default-language: Haskell2010
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
-
-  if flag(has-llvm)
-    ghc-options: -fllvm
-
-  if flag(dev)
-    cpp-options:    -DDEVBUILD
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-                    -fno-ignore-asserts
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   if flag(benchmark)
     buildable: True
     build-depends:
@@ -799,33 +618,10 @@ benchmark fileio
     buildable: False
 
 benchmark concurrent
+  import: bench-options
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: Concurrent.hs
-  default-language: Haskell2010
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
-
-  if flag(has-llvm)
-    ghc-options: -fllvm
-
-  if flag(dev)
-    cpp-options:    -DDEVBUILD
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-                    -fno-ignore-asserts
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
   if flag(dev)
     buildable: True
     build-depends:
@@ -843,6 +639,7 @@ benchmark concurrent
 -- way to use unexposed modules from the library.
 
 benchmark base
+  import: bench-options
   type: exitcode-stdio-1.0
   include-dirs:     src/Streamly/Time
                   , src/Streamly/Streams
@@ -865,30 +662,6 @@ benchmark base
 
                    , StreamDOps
                    , StreamKOps
-
-  default-language: Haskell2010
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
-
-  if flag(has-llvm)
-    ghc-options: -fllvm
-
-  if flag(dev)
-    ghc-options:    -Wmissed-specialisations
-                    -Wall-missed-specialisations
-                    -fno-ignore-asserts
-  if impl(ghc >= 8.0)
-    ghc-options:    -Wcompat
-                    -Wunrecognised-warning-flags
-                    -Widentities
-                    -Wincomplete-record-updates
-                    -Wincomplete-uni-patterns
-                    -Wredundant-constraints
-                    -Wnoncanonical-monad-instances
-                    -Wnoncanonical-monadfail-instances
 
   if flag(dev)
     buildable: True
@@ -919,6 +692,7 @@ benchmark base
     buildable: False
 
 executable nano-bench
+  import: bench-options
   hs-source-dirs: benchmark, src
   include-dirs:     src/Streamly/Time
                   , src/Streamly/Streams
@@ -936,16 +710,6 @@ executable nano-bench
                    , Streamly.Streams.StreamD.Type
                    , Streamly.FileSystem.IOVec
                    , Streamly.Streams.StreamD
-  default-language: Haskell2010
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
-
-  if flag(has-llvm)
-    ghc-options: -fllvm
-
   if flag(dev)
     buildable: True
     build-depends:
@@ -970,18 +734,10 @@ executable nano-bench
     buildable: False
 
 executable adaptive
+  import: bench-options
   hs-source-dirs: benchmark
   main-is: Adaptive.hs
   default-language: Haskell2010
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
-
-  if flag(has-llvm)
-    ghc-options: -fllvm
-
   if flag(dev)
     buildable: True
     build-depends:
@@ -994,6 +750,7 @@ executable adaptive
 
 executable chart
   default-language: Haskell2010
+  ghc-options: -Wall
   hs-source-dirs: benchmark
   main-is: Chart.hs
   if flag(dev) && !flag(no-charts) && !impl(ghcjs)
@@ -1011,14 +768,9 @@ executable chart
 -------------------------------------------------------------------------------
 
 executable SearchQuery
-  default-language: Haskell2010
+  import: exe-options
   main-is: SearchQuery.hs
   hs-source-dirs:  examples
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
   if (flag(examples) || flag(examples-sdl)) && !impl(ghcjs)
     buildable: True
     build-Depends:
@@ -1029,14 +781,9 @@ executable SearchQuery
     buildable: False
 
 executable ListDir
-  default-language: Haskell2010
+  import: exe-options
   main-is: ListDir.hs
   hs-source-dirs:  examples
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
   if flag(examples) || flag(examples-sdl)
     buildable: True
     build-Depends:
@@ -1050,14 +797,9 @@ executable ListDir
     buildable: False
 
 executable MergeSort
-  default-language: Haskell2010
+  import: exe-options
   main-is: MergeSort.hs
   hs-source-dirs:  examples
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
   if flag(examples) || flag(examples-sdl)
     buildable: True
     build-Depends:
@@ -1068,14 +810,9 @@ executable MergeSort
     buildable: False
 
 executable AcidRain
-  default-language: Haskell2010
+  import: exe-options
   main-is: AcidRain.hs
   hs-source-dirs:  examples
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
   if flag(examples) || flag(examples-sdl)
     buildable: True
     build-Depends:
@@ -1090,14 +827,9 @@ executable AcidRain
     buildable: False
 
 executable CirclingSquare
-  default-language: Haskell2010
+  import: exe-options
   main-is: CirclingSquare.hs
   hs-source-dirs:  examples
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
   if flag(examples-sdl)
     buildable: True
     build-Depends:
@@ -1108,10 +840,9 @@ executable CirclingSquare
     buildable: False
 
 executable ControlFlow
-  default-language: Haskell2010
+  import: exe-options
   main-is: ControlFlow.hs
   hs-source-dirs:  examples
-  ghc-options: -Wall
   if flag(examples) || flag(examples-sdl)
     buildable: True
     build-Depends:
@@ -1127,14 +858,9 @@ executable ControlFlow
     buildable: False
 
 executable HandleIO
-  default-language: Haskell2010
+  import: exe-options
   main-is: HandleIO.hs
   hs-source-dirs:  examples
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
   if flag(examples) || flag(examples-sdl)
     buildable: True
     build-Depends:
@@ -1144,14 +870,9 @@ executable HandleIO
     buildable: False
 
 executable FileIOExamples
-  default-language: Haskell2010
+  import: exe-options
   main-is: FileIOExamples.hs
   hs-source-dirs:  examples
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
   if flag(examples) || flag(examples-sdl)
     buildable: False
     build-Depends:
@@ -1161,14 +882,9 @@ executable FileIOExamples
     buildable: False
 
 executable EchoServer
-  default-language: Haskell2010
+  import: exe-options
   main-is: EchoServer.hs
   hs-source-dirs:  examples
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
   if (flag(examples) || flag(examples-sdl)) && !impl(ghcjs)
     buildable: True
     build-Depends:
@@ -1178,14 +894,9 @@ executable EchoServer
     buildable: False
 
 executable FileSinkServer
-  default-language: Haskell2010
+  import: exe-options
   main-is: FileSinkServer.hs
   hs-source-dirs:  examples
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
   if (flag(examples) || flag(examples-sdl)) && !impl(ghcjs)
     buildable: True
     build-Depends:
@@ -1195,14 +906,9 @@ executable FileSinkServer
     buildable: False
 
 executable FromFileClient
-  default-language: Haskell2010
+  import: exe-options
   main-is: FromFileClient.hs
   hs-source-dirs:  examples
-  ghc-options:  -O2
-                -fspec-constr-recursive=10
-                -fmax-worker-args=16
-                -Wall
-                -with-rtsopts "-T"
   if (flag(examples) || flag(examples-sdl)) && !impl(ghcjs)
     buildable: True
     build-Depends:

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -261,7 +261,7 @@ library
                      , Streamly.Benchmark.FileIO.Stream
 
     default-language: Haskell2010
-    ghc-options:      -Wall -fspec-constr-recursive=10
+    ghc-options:      -Wall -O2 -fspec-constr-recursive=10
 
     if flag(has-llvm)
       ghc-options: -fllvm

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -329,6 +329,7 @@ library
                        Streamly.Benchmark.Inspection
                      , Streamly.Benchmark.FileIO.Array
                      , Streamly.Benchmark.FileIO.Stream
+                     , Streamly.Benchmark.Prelude
 
     build-depends:     base              >= 4.8   &&  < 5
                      , ghc-prim          >= 0.2   && < 0.6
@@ -524,16 +525,19 @@ benchmark linear
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: Linear.hs
-  other-modules: LinearOps
-  build-depends:
-      streamly
-    , base                >= 4.8   && < 5
-    , deepseq             >= 1.4.1 && < 1.5
-    , random              >= 1.0   && < 2.0
-    , gauge               >= 0.2.4 && < 0.3
-  if impl(ghc < 8.0)
+  if flag(benchmark)
+    buildable: True
     build-depends:
-        transformers  >= 0.4 && < 0.6
+        streamly
+      , base                >= 4.8   && < 5
+      , deepseq             >= 1.4.1 && < 1.5
+      , random              >= 1.0   && < 2.0
+      , gauge               >= 0.2.4 && < 0.3
+    if impl(ghc < 8.0)
+      build-depends:
+          transformers  >= 0.4 && < 0.6
+  else
+    buildable: False
 
 benchmark linear-async
   import: bench-options
@@ -541,32 +545,38 @@ benchmark linear-async
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: LinearAsync.hs
-  other-modules: LinearOps
-  build-depends:
-      streamly
-    , base                >= 4.8   && < 5
-    , deepseq             >= 1.4.1 && < 1.5
-    , random              >= 1.0   && < 2.0
-    , gauge               >= 0.2.4 && < 0.3
-  if impl(ghc < 8.0)
+  if flag(benchmark)
+    buildable: True
     build-depends:
-        transformers  >= 0.4 && < 0.6
+        streamly
+      , base                >= 4.8   && < 5
+      , deepseq             >= 1.4.1 && < 1.5
+      , random              >= 1.0   && < 2.0
+      , gauge               >= 0.2.4 && < 0.3
+    if impl(ghc < 8.0)
+      build-depends:
+          transformers  >= 0.4 && < 0.6
+  else
+    buildable: False
 
 benchmark linear-rate
   import: bench-options
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: LinearRate.hs
-  other-modules: LinearOps
-  build-depends:
-      streamly
-    , base                >= 4.8   && < 5
-    , deepseq             >= 1.4.1 && < 1.5
-    , random              >= 1.0   && < 2.0
-    , gauge               >= 0.2.4 && < 0.3
-  if impl(ghc < 8.0)
+  if flag(benchmark)
+    buildable: True
     build-depends:
-        transformers  >= 0.4 && < 0.6
+        streamly
+      , base                >= 4.8   && < 5
+      , deepseq             >= 1.4.1 && < 1.5
+      , random              >= 1.0   && < 2.0
+      , gauge               >= 0.2.4 && < 0.3
+    if impl(ghc < 8.0)
+      build-depends:
+          transformers  >= 0.4 && < 0.6
+  else
+    buildable: False
 
 benchmark nested
   import: bench-options

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -261,7 +261,16 @@ library
                      , Streamly.Benchmark.FileIO.Stream
 
     default-language: Haskell2010
-    ghc-options:      -Wall -O2 -fspec-constr-recursive=10
+    -- We need optimization options here to optimize internal (non-inlined)
+    -- versions of functions. Also, we have some benchmarking inspection tests
+    -- part of the library when built with --benchmarks flag. Thos tests fail
+    -- if we do not use optimization options here. It was observed that due to
+    -- -O2 here some concurrent/nested benchmarks improved and others regressed.
+    -- We can investigate a bit more here why the regression occurred.
+    ghc-options:      -Wall
+                      -O2
+                      -fspec-constr-recursive=10
+                      -fmax-worker-args=16
 
     if flag(has-llvm)
       ghc-options: -fllvm
@@ -562,7 +571,11 @@ benchmark linear
   main-is: Linear.hs
   other-modules: LinearOps
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall -with-rtsopts "-T" -fspec-constr-recursive=10
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
 
   if flag(has-llvm)
     ghc-options: -fllvm
@@ -596,7 +609,11 @@ benchmark linear-async
   main-is: LinearAsync.hs
   other-modules: LinearOps
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall -fspec-constr-recursive=10 -with-rtsopts "-T"
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
 
   if flag(has-llvm)
     ghc-options: -fllvm
@@ -631,7 +648,11 @@ benchmark linear-rate
   main-is: LinearRate.hs
   other-modules: LinearOps
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall -fspec-constr-recursive=10 -with-rtsopts "-T"
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
 
   if flag(has-llvm)
     ghc-options: -fllvm
@@ -665,7 +686,11 @@ benchmark nested
   main-is: Nested.hs
   other-modules: NestedOps
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall -fspec-constr-recursive=10 -with-rtsopts "-T"
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
 
   if flag(has-llvm)
     ghc-options: -fllvm
@@ -700,7 +725,11 @@ benchmark array
   main-is: Array.hs
   other-modules: ArrayOps
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall -with-rtsopts "-T" -fspec-constr-recursive=10
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
 
   if flag(has-llvm)
     ghc-options: -fllvm
@@ -734,7 +763,11 @@ benchmark fileio
   hs-source-dirs: benchmark
   main-is: FileIO.hs
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall -fspec-constr-recursive=10 -with-rtsopts "-T"
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
 
   if flag(has-llvm)
     ghc-options: -fllvm
@@ -770,7 +803,11 @@ benchmark concurrent
   hs-source-dirs: benchmark
   main-is: Concurrent.hs
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall -fspec-constr-recursive=10 -with-rtsopts "-T"
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
 
   if flag(has-llvm)
     ghc-options: -fllvm
@@ -830,7 +867,11 @@ benchmark base
                    , StreamKOps
 
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall -fspec-constr-recursive=10 -with-rtsopts "-T"
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
 
   if flag(has-llvm)
     ghc-options: -fllvm
@@ -896,7 +937,11 @@ executable nano-bench
                    , Streamly.FileSystem.IOVec
                    , Streamly.Streams.StreamD
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall -with-rtsopts "-T"
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
 
   if flag(has-llvm)
     ghc-options: -fllvm
@@ -928,7 +973,11 @@ executable adaptive
   hs-source-dirs: benchmark
   main-is: Adaptive.hs
   default-language: Haskell2010
-  ghc-options:  -O2 -Wall -with-rtsopts "-T"
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
 
   if flag(has-llvm)
     ghc-options: -fllvm
@@ -965,7 +1014,11 @@ executable SearchQuery
   default-language: Haskell2010
   main-is: SearchQuery.hs
   hs-source-dirs:  examples
-  ghc-options: -Wall
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
   if (flag(examples) || flag(examples-sdl)) && !impl(ghcjs)
     buildable: True
     build-Depends:
@@ -979,7 +1032,11 @@ executable ListDir
   default-language: Haskell2010
   main-is: ListDir.hs
   hs-source-dirs:  examples
-  ghc-options: -Wall
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
   if flag(examples) || flag(examples-sdl)
     buildable: True
     build-Depends:
@@ -996,7 +1053,11 @@ executable MergeSort
   default-language: Haskell2010
   main-is: MergeSort.hs
   hs-source-dirs:  examples
-  ghc-options: -Wall
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
   if flag(examples) || flag(examples-sdl)
     buildable: True
     build-Depends:
@@ -1010,7 +1071,11 @@ executable AcidRain
   default-language: Haskell2010
   main-is: AcidRain.hs
   hs-source-dirs:  examples
-  ghc-options: -Wall
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
   if flag(examples) || flag(examples-sdl)
     buildable: True
     build-Depends:
@@ -1028,7 +1093,11 @@ executable CirclingSquare
   default-language: Haskell2010
   main-is: CirclingSquare.hs
   hs-source-dirs:  examples
-  ghc-options: -Wall
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
   if flag(examples-sdl)
     buildable: True
     build-Depends:
@@ -1061,7 +1130,11 @@ executable HandleIO
   default-language: Haskell2010
   main-is: HandleIO.hs
   hs-source-dirs:  examples
-  ghc-options: -Wall
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
   if flag(examples) || flag(examples-sdl)
     buildable: True
     build-Depends:
@@ -1074,7 +1147,11 @@ executable FileIOExamples
   default-language: Haskell2010
   main-is: FileIOExamples.hs
   hs-source-dirs:  examples
-  ghc-options: -Wall
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
   if flag(examples) || flag(examples-sdl)
     buildable: False
     build-Depends:
@@ -1087,7 +1164,11 @@ executable EchoServer
   default-language: Haskell2010
   main-is: EchoServer.hs
   hs-source-dirs:  examples
-  ghc-options: -Wall
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
   if (flag(examples) || flag(examples-sdl)) && !impl(ghcjs)
     buildable: True
     build-Depends:
@@ -1100,7 +1181,11 @@ executable FileSinkServer
   default-language: Haskell2010
   main-is: FileSinkServer.hs
   hs-source-dirs:  examples
-  ghc-options: -Wall
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
   if (flag(examples) || flag(examples-sdl)) && !impl(ghcjs)
     buildable: True
     build-Depends:
@@ -1113,7 +1198,11 @@ executable FromFileClient
   default-language: Haskell2010
   main-is: FromFileClient.hs
   hs-source-dirs:  examples
-  ghc-options: -Wall
+  ghc-options:  -O2
+                -fspec-constr-recursive=10
+                -fmax-worker-args=16
+                -Wall
+                -with-rtsopts "-T"
   if (flag(examples) || flag(examples-sdl)) && !impl(ghcjs)
     buildable: True
     build-Depends:

--- a/test/Arrays.hs
+++ b/test/Arrays.hs
@@ -13,6 +13,7 @@ import Test.Hspec as H
 
 import qualified Streamly.Memory.Array as A
 import qualified Streamly.Prelude as S
+import qualified Streamly.Internal as Internal
 
 -- Coverage build takes too long with default number of tests
 maxTestCount :: Int
@@ -74,7 +75,7 @@ testArraysOf =
             monadicIO $ do
                 xs <- S.toList
                     $ S.concatMap A.read
-                    $ A.arraysOf 240
+                    $ Internal.arraysOf 240
                     $ S.fromList list
                 assert (xs == list)
 
@@ -85,7 +86,7 @@ testFlattenArrays =
             monadicIO $ do
                 xs <- S.toList
                     $ A.concat
-                    $ A.arraysOf 240
+                    $ Internal.arraysOf 240
                     $ S.fromList list
                 assert (xs == list)
 


### PR DESCRIPTION
* Reimplement groupsOf for better fusion
* Use A.writeNUnsafe for better fusion with groupsOf

Now we can use chunksOf/groupsOf to implement arraysOf with equivalent
performance. This commit hides the arraysOf from the Array module and export it
via Streamly.Internal because in one case (writeS) it still is faster. This can
be resolved once GHC issue is resolved. Even though writeS is not an officially
exported API, this case indicates that there may potentially be more such cases
which do not fuse well, so we are keeping this as a backup for such cases for
now.