### PR TITLE
Add inspection testing for fileio benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ matrix:
   #- env: BUILD=stack RESOLVER=nightly
   #  addons: {apt: {packages: [cabal-install-1.24], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack RESOLVER=lts-13 GHCVER=8.6 STACK_BUILD_OPTIONS="--flag streamly:examples-sdl"
+  - env: BUILD=stack RESOLVER=lts-13 GHCVER=8.6 STACK_BUILD_OPTIONS="--flag streamly:examples-sdl --flag streamly:benchmark"
     addons: {apt: {packages: [cabal-install-2.4,libsdl1.2-dev], sources: [hvr-ghc]}}
 
   #- env: BUILD=stack RESOLVER=lts-12 GHCVER=8.4

--- a/src/Streamly/Benchmark/FileIO/Array.hs
+++ b/src/Streamly/Benchmark/FileIO/Array.hs
@@ -1,0 +1,112 @@
+-- |
+-- Module      : Streamly.Benchmark.FileIO.Array
+-- Copyright   : (c) 2019 Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : harendra.kumar@gmail.com
+-- Stability   : experimental
+-- Portability : GHC
+
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -fplugin Test.Inspection.Plugin #-}
+
+module Streamly.Benchmark.FileIO.Array
+    (
+      last
+    , countBytes
+    , countLines
+    , sumBytes
+    , cat
+    , copy
+    , linesUnlinesCopy
+    )
+where
+
+import Data.Functor.Identity (runIdentity)
+import Data.Word (Word8)
+import System.IO (Handle)
+import Prelude hiding (last)
+
+import Streamly.Benchmark.Inspection (hinspect)
+import Streamly.Streams.StreamD.Type (Step(..))
+
+import qualified Streamly.FileSystem.Handle as FH
+import qualified Streamly.Memory.Array as A
+import qualified Streamly.Prelude as S
+import qualified Streamly.Internal as Internal
+
+import Test.Inspection
+
+-- | Get the last byte from a file bytestream.
+{-# INLINE last #-}
+last :: Handle -> IO (Maybe Word8)
+last inh = do
+    let s = FH.readArrays inh
+    larr <- S.last s
+    return $ case larr of
+        Nothing -> Nothing
+        Just arr -> A.readIndex arr (A.length arr - 1)
+
+hinspect $ hasNoTypeClasses 'last
+hinspect $ 'last `hasNoType` ''Step
+
+-- | Count the number of bytes in a file.
+{-# INLINE countBytes #-}
+countBytes :: Handle -> IO Int
+countBytes inh =
+    let s = FH.readArrays inh
+    in S.sum (S.map A.length s)
+
+hinspect $ hasNoTypeClasses 'countBytes
+hinspect $ 'countBytes `hasNoType` ''Step
+
+-- | Count the number of lines in a file.
+{-# INLINE countLines #-}
+countLines :: Handle -> IO Int
+countLines = S.length . A.splitOn 10 . FH.readArrays
+
+hinspect $ hasNoTypeClasses 'countLines
+hinspect $ 'countLines `hasNoType` ''Step
+
+-- | Sum the bytes in a file.
+{-# INLINE sumBytes #-}
+sumBytes :: Handle -> IO Word8
+sumBytes inh = do
+    let foldlArr' f z = runIdentity . S.foldl' f z . A.read
+    let s = FH.readArrays inh
+    S.foldl' (\acc arr -> acc + foldlArr' (+) 0 arr) 0 s
+
+hinspect $ hasNoTypeClasses 'sumBytes
+hinspect $ 'sumBytes `hasNoType` ''Step
+
+-- | Send the file contents to /dev/null
+{-# INLINE cat #-}
+cat :: Handle -> Handle -> IO ()
+cat devNull inh =
+    S.runFold (FH.writeArrays devNull) $ FH.readArraysOf (256*1024) inh
+
+hinspect $ hasNoTypeClasses 'cat
+hinspect $ 'cat `hasNoType` ''Step
+
+-- | Copy file
+{-# INLINE copy #-}
+copy :: Handle -> Handle -> IO ()
+copy inh outh =
+    let s = FH.readArrays inh
+    in S.runFold (FH.writeArrays outh) s
+
+hinspect $ hasNoTypeClasses 'copy
+hinspect $ 'copy `hasNoType` ''Step
+
+-- | Lines and unlines
+{-# INLINE linesUnlinesCopy #-}
+linesUnlinesCopy :: Handle -> Handle -> IO ()
+linesUnlinesCopy inh outh =
+    S.runFold (FH.writeArraysInChunksOf (1024*1024) outh)
+        $ Internal.insertAfterEach (return $ A.fromList [10])
+        $ A.splitOn 10
+        $ FH.readArraysOf (1024*1024) inh
+
+-- hinspect $ hasNoTypeClasses 'linesUnlinesCopy
+-- hinspect $ 'linesUnlinesCopy `hasNoType` ''Step

--- a/src/Streamly/Benchmark/FileIO/Stream.hs
+++ b/src/Streamly/Benchmark/FileIO/Stream.hs
@@ -1,0 +1,263 @@
+-- |
+-- Module      : Streamly.Benchmark.FileIO.Stream
+-- Copyright   : (c) 2019 Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : harendra.kumar@gmail.com
+-- Stability   : experimental
+-- Portability : GHC
+
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -fplugin Test.Inspection.Plugin #-}
+
+module Streamly.Benchmark.FileIO.Stream
+    (
+    -- * FileIO
+      last
+    , countBytes
+    , countLines
+    , countLinesU
+    , sumBytes
+    , cat
+    , catStreamWrite
+    , copy
+    , linesUnlinesCopy
+    , wordsUnwordsCopy
+    , copyCodecChar8
+    , copyCodecUtf8
+    , chunksOf
+    , splitOn
+    , splitOnSuffix
+    , wordsBy
+    , splitOnSeq
+    , splitOnSuffixSeq
+    )
+where
+
+import Data.Char (ord, chr)
+import Data.Word (Word8)
+import System.IO (Handle)
+import Prelude hiding (last, length)
+
+import Streamly.Streams.StreamD.Type (Step(..))
+import Streamly.Benchmark.Inspection (hinspect)
+
+import qualified Streamly.FileSystem.Handle as FH
+import qualified Streamly.Memory.Array as A
+import qualified Streamly.Prelude as S
+import qualified Streamly.Fold as FL
+import qualified Streamly.Data.String as SS
+import qualified Streamly.Internal as Internal
+
+import Test.Inspection
+
+-- | Get the last byte from a file bytestream.
+{-# INLINE last #-}
+last :: Handle -> IO (Maybe Word8)
+last = S.last . FH.read
+
+hinspect $ hasNoTypeClasses 'last
+hinspect $ 'last `hasNoType` ''Step
+
+-- | Count the number of bytes in a file.
+{-# INLINE countBytes #-}
+countBytes :: Handle -> IO Int
+countBytes = S.length . FH.read
+
+hinspect $ hasNoTypeClasses 'countBytes
+hinspect $ 'countBytes `hasNoType` ''Step
+
+-- | Count the number of lines in a file.
+{-# INLINE countLines #-}
+countLines :: Handle -> IO Int
+countLines =
+    S.length
+        . SS.foldLines FL.drain
+        . SS.decodeChar8
+        . FH.read
+
+hinspect $ hasNoTypeClasses 'countLines
+hinspect $ 'countLines `hasNoType` ''Step
+
+-- | Count the number of lines in a file.
+{-# INLINE countLinesU #-}
+countLinesU :: Handle -> IO Int
+countLinesU inh =
+    S.length
+        $ SS.foldLines FL.drain
+        $ SS.decodeChar8
+        $ Internal.concatMapU Internal.readU (FH.readArrays inh)
+
+hinspect $ hasNoTypeClasses 'countLinesU
+hinspect $ 'countLinesU `hasNoType` ''Step
+
+-- | Sum the bytes in a file.
+{-# INLINE sumBytes #-}
+sumBytes :: Handle -> IO Word8
+sumBytes = S.sum . FH.read
+
+hinspect $ hasNoTypeClasses 'sumBytes
+hinspect $ 'sumBytes `hasNoType` ''Step
+
+-- | Send the file contents to /dev/null
+{-# INLINE cat #-}
+cat :: Handle -> Handle -> IO ()
+cat devNull inh = S.runFold (FH.write devNull) $ FH.read inh
+
+hinspect $ hasNoTypeClasses 'cat
+hinspect $ 'cat `hasNoType` ''Step
+
+-- | Send the file contents to /dev/null
+{-# INLINE catStreamWrite #-}
+catStreamWrite :: Handle -> Handle -> IO ()
+catStreamWrite devNull inh = Internal.writeS devNull $ FH.read inh
+
+hinspect $ hasNoTypeClasses 'catStreamWrite
+hinspect $ 'catStreamWrite `hasNoType` ''Step
+
+-- | Copy file
+{-# INLINE copy #-}
+copy :: Handle -> Handle -> IO ()
+copy inh outh = S.runFold (FH.write outh) (FH.read inh)
+
+hinspect $ hasNoTypeClasses 'copy
+hinspect $ 'copy `hasNoType` ''Step
+
+-- | Copy file
+{-# INLINE copyCodecChar8 #-}
+copyCodecChar8 :: Handle -> Handle -> IO ()
+copyCodecChar8 inh outh =
+   S.runFold (FH.write outh)
+     $ SS.encodeChar8
+     $ SS.decodeChar8
+     $ FH.read inh
+
+hinspect $ hasNoTypeClasses 'copyCodecChar8
+hinspect $ 'copyCodecChar8 `hasNoType` ''Step
+
+-- | Copy file
+{-# INLINE copyCodecUtf8 #-}
+copyCodecUtf8 :: Handle -> Handle -> IO ()
+copyCodecUtf8 inh outh =
+   S.runFold (FH.write outh)
+     $ SS.encodeUtf8
+     $ SS.decodeUtf8
+     $ FH.read inh
+
+hinspect $ hasNoTypeClasses 'copyCodecUtf8
+-- hinspect $ 'copyCodecUtf8 `hasNoType` ''Step
+
+-- | Slice in chunks of size n and get the count of chunks.
+{-# INLINE chunksOf #-}
+chunksOf :: Int -> Handle -> IO Int
+chunksOf n inh =
+    S.length $ S.chunksOf n (A.writeN n) (FH.read inh)
+
+hinspect $ hasNoTypeClasses 'chunksOf
+-- hinspect $ 'chunksOf `hasNoType` ''Step
+
+-- | Lines and unlines
+{-# INLINE linesUnlinesCopy #-}
+linesUnlinesCopy :: Handle -> Handle -> IO ()
+linesUnlinesCopy inh outh =
+    S.runFold (FH.write outh)
+      $ SS.encodeChar8
+      $ SS.unlines
+      $ SS.lines
+      $ SS.decodeChar8
+      $ FH.read inh
+
+-- hinspect $ hasNoTypeClasses 'linesUnlinesCopy
+-- hinspect $ 'linesUnlinesCopy `hasNoType` ''Step
+
+-- | Word, unwords and copy
+{-# INLINE wordsUnwordsCopy #-}
+wordsUnwordsCopy :: Handle -> Handle -> IO ()
+wordsUnwordsCopy inh outh =
+    S.runFold (FH.write outh)
+      $ SS.encodeChar8
+      $ SS.unwords
+      $ SS.words
+      $ SS.decodeChar8
+      $ FH.read inh
+
+-- hinspect $ hasNoTypeClasses 'wordsUnwordsCopy
+-- hinspect $ 'wordsUnwordsCopy `hasNoType` ''Step
+
+lf :: Word8
+lf = fromIntegral (ord '\n')
+
+toarr :: String -> A.Array Word8
+toarr = A.fromList . map (fromIntegral . ord)
+
+foreign import ccall unsafe "u_iswspace"
+  iswspace :: Int -> Int
+
+-- Code copied from base/Data.Char to INLINE it
+{-# INLINE isSpace #-}
+isSpace                 :: Char -> Bool
+-- isSpace includes non-breaking space
+-- The magic 0x377 isn't really that magical. As of 2014, all the codepoints
+-- at or below 0x377 have been assigned, so we shouldn't have to worry about
+-- any new spaces appearing below there. It would probably be best to
+-- use branchless ||, but currently the eqLit transformation will undo that,
+-- so we'll do it like this until there's a way around that.
+isSpace c
+  | uc <= 0x377 = uc == 32 || uc - 0x9 <= 4 || uc == 0xa0
+  | otherwise = iswspace (ord c) /= 0
+  where
+    uc = fromIntegral (ord c) :: Word
+
+isSp :: Word8 -> Bool
+isSp = isSpace . chr . fromIntegral
+
+-- | Split on line feed.
+{-# INLINE splitOn #-}
+splitOn :: Handle -> IO Int
+splitOn inh =
+    (S.length $ S.splitOn (== lf) FL.drain
+        $ FH.read inh) -- >>= print
+
+hinspect $ hasNoTypeClasses 'splitOn
+hinspect $ 'splitOn `hasNoType` ''Step
+
+-- | Split suffix on line feed.
+{-# INLINE splitOnSuffix #-}
+splitOnSuffix :: Handle -> IO Int
+splitOnSuffix inh =
+    (S.length $ S.splitOnSuffix (== lf) FL.drain
+        $ FH.read inh) -- >>= print
+
+hinspect $ hasNoTypeClasses 'splitOnSuffix
+hinspect $ 'splitOnSuffix `hasNoType` ''Step
+
+-- | Words by space
+{-# INLINE wordsBy #-}
+wordsBy :: Handle -> IO Int
+wordsBy inh =
+    (S.length $ S.wordsBy isSp FL.drain
+        $ FH.read inh) -- >>= print
+
+hinspect $ hasNoTypeClasses 'wordsBy
+hinspect $ 'wordsBy `hasNoType` ''Step
+
+-- | Split on a character sequence.
+{-# INLINE splitOnSeq #-}
+splitOnSeq :: String -> Handle -> IO Int
+splitOnSeq str inh =
+    (S.length $ Internal.splitOnSeq (toarr str) FL.drain
+        $ FH.read inh) -- >>= print
+
+hinspect $ hasNoTypeClasses 'splitOnSeq
+-- hinspect $ 'splitOnSeq `hasNoType` ''Step
+
+-- | Split on suffix sequence.
+{-# INLINE splitOnSuffixSeq #-}
+splitOnSuffixSeq :: String -> Handle -> IO Int
+splitOnSuffixSeq str inh =
+    (S.length $ Internal.splitOnSuffixSeq (toarr str) FL.drain
+        $ FH.read inh) -- >>= print
+
+hinspect $ hasNoTypeClasses 'splitOnSuffixSeq
+-- hinspect $ 'splitOnSuffixSeq `hasNoType` ''Step

--- a/src/Streamly/Benchmark/Inspection.hs
+++ b/src/Streamly/Benchmark/Inspection.hs
@@ -1,0 +1,29 @@
+-- |
+-- Module      : Streamly.Benchmark.Inspection
+-- Copyright   : (c) 2019 Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : harendra.kumar@gmail.com
+-- Stability   : experimental
+-- Portability : GHC
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -fplugin Test.Inspection.Plugin #-}
+
+module Streamly.Benchmark.Inspection
+    (
+      hinspect
+    )
+where
+
+import Test.Inspection
+import Language.Haskell.TH (Q, Dec)
+
+hinspect :: Obligation -> Q [Dec]
+#ifdef __HADDOCK_VERSION__
+hinspect _ = return []
+#else
+hinspect = inspect
+#endif

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -131,6 +131,11 @@ source-repository head
     type: git
     location: https://github.com/composewell/streamly
 
+flag benchmark
+  description: Benchmark build
+  manual: True
+  default: False
+
 flag dev
   description: Development build
   manual: True
@@ -244,10 +249,16 @@ library
                      , Streamly.Tutorial
                      , Streamly.Internal
     if !impl(ghcjs)
-       exposed-modules:                      
+       exposed-modules:
                        Streamly.Network.Socket
                      , Streamly.Network.Server
                      , Streamly.Network.Client
+
+    if flag(benchmark)
+       exposed-modules:
+                       Streamly.Benchmark.Inspection
+                     , Streamly.Benchmark.FileIO.Array
+                     , Streamly.Benchmark.FileIO.Stream
 
     default-language: Haskell2010
     ghc-options:      -Wall -fspec-constr-recursive=10
@@ -292,6 +303,10 @@ library
                      , mtl               >= 2.2   && < 3
                      , transformers      >= 0.4   && < 0.6
                      , transformers-base >= 0.4   && < 0.5
+
+  if flag(benchmark)
+    build-depends:     inspection-testing >= 0.4   && < 0.5
+                     , template-haskell   >= 2.14  && < 2.15
 
   if !impl(ghcjs)
     build-depends:
@@ -738,12 +753,17 @@ benchmark fileio
                     -Wredundant-constraints
                     -Wnoncanonical-monad-instances
                     -Wnoncanonical-monadfail-instances
-  build-depends:
-      streamly
-    , base                >= 4.8   && < 5
-    , gauge               >= 0.2.4 && < 0.3
-    , typed-process       >= 0.2.3 && < 0.3
-    , deepseq             >= 1.4.1 && < 1.5
+  if flag(benchmark)
+    buildable: True
+    build-depends:
+        streamly
+      , base                >= 4.8   && < 5
+      , gauge               >= 0.2.4 && < 0.3
+      , inspection-testing  >= 0.4   && < 0.5
+      , typed-process       >= 0.2.3 && < 0.3
+      , deepseq             >= 1.4.1 && < 1.5
+  else
+    buildable: False
 
 benchmark concurrent
   type: exitcode-stdio-1.0


### PR DESCRIPTION
Added two benchmark modules to the library that are enabled by the `benchmark` build flag. These modules build benchmark functions along with inspection tests, these same functions are used by the `fileio` benchmarks. The `fileio` benchmark can now be built only with this flag. 