### PR TITLE
Add nested unfold operations and benchmarks

### DIFF
--- a/benchmark/NestedUnfold.hs
+++ b/benchmark/NestedUnfold.hs
@@ -1,0 +1,32 @@
+-- |
+-- Module      : NestedUnfold
+-- Copyright   : (c) 2019 Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : streamly@composewell.com
+
+import Control.DeepSeq (NFData)
+import System.Random (randomRIO)
+
+import qualified NestedUnfoldOps as Ops
+
+import Gauge
+
+benchIO :: (NFData b) => String -> (Int -> IO b) -> Benchmark
+benchIO name f = bench name $ nfIO $ randomRIO (1,1) >>= f
+
+main :: IO ()
+main =
+  defaultMain
+    [ bgroup "unfold"
+      [ benchIO "toNull"         $ Ops.toNull
+      , benchIO "toNull3"        $ Ops.toNull3
+      , benchIO "concat"         $ Ops.concat
+      , benchIO "toList"         $ Ops.toList
+      , benchIO "toListSome"     $ Ops.toListSome
+      , benchIO "filterAllOut"   $ Ops.filterAllOut
+      , benchIO "filterAllIn"    $ Ops.filterAllIn
+      , benchIO "filterSome"     $ Ops.filterSome
+      , benchIO "breakAfterSome" $ Ops.breakAfterSome
+      ]
+    ]

--- a/benchmark/NestedUnfoldOps.hs
+++ b/benchmark/NestedUnfoldOps.hs
@@ -1,0 +1,128 @@
+-- |
+-- Module      : NestedUnfoldOps
+-- Copyright   : (c) 2019 Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : streamly@composewell.com
+
+module NestedUnfoldOps where
+
+import Control.Monad.IO.Class (MonadIO (..))
+import Streamly.Internal.Data.Unfold (Unfold)
+
+import qualified Streamly.Internal.Data.Unfold as UF
+import qualified Streamly.Internal.Data.Fold as FL
+
+linearCount :: Int
+linearCount = 100000
+
+-- n * (n + 1) / 2 == linearCount
+concatCount :: Int
+concatCount = 450
+
+-- double nested loop
+nestedCount2 :: Int
+nestedCount2 = round (fromIntegral linearCount**(1/2::Double))
+
+-- triple nested loop
+nestedCount3 :: Int
+nestedCount3 = round (fromIntegral linearCount**(1/3::Double))
+
+-------------------------------------------------------------------------------
+-- Stream generation and elimination
+-------------------------------------------------------------------------------
+
+-- generate numbers up to the argument value
+{-# INLINE source #-}
+source :: Monad m => Int -> Unfold m Int Int
+source n = UF.enumerateFromToIntegral n
+
+-------------------------------------------------------------------------------
+-- Benchmark ops
+-------------------------------------------------------------------------------
+
+{-# INLINE toNull #-}
+toNull :: MonadIO m => Int -> m ()
+toNull start = do
+    let end = start + nestedCount2
+    UF.fold
+        (UF.map (\(x, y) -> x + y)
+        $ UF.outerProduct (source end) (source end))
+        FL.drain (start, start)
+
+{-# INLINE toNull3 #-}
+toNull3 :: MonadIO m => Int -> m ()
+toNull3 start = do
+    let end = start + nestedCount3
+    UF.fold
+            (UF.map (\(x, y) -> x + y)
+            $ UF.outerProduct (source end)
+                ((UF.map (\(x, y) -> x + y)
+                $ UF.outerProduct (source end) (source end))))
+            FL.drain (start, (start, start))
+
+{-# INLINE concat #-}
+concat :: MonadIO m => Int -> m ()
+concat start = do
+    let end = start + concatCount
+    UF.fold
+        (UF.concat (source end) (source end))
+        FL.drain start
+
+{-# INLINE toList #-}
+toList :: MonadIO m => Int -> m [Int]
+toList start = do
+    let end = start + nestedCount2
+    UF.fold
+        (UF.map (\(x, y) -> x + y)
+        $ UF.outerProduct (source end) (source end))
+        FL.toList (start, start)
+
+{-# INLINE toListSome #-}
+toListSome :: MonadIO m => Int -> m [Int]
+toListSome start = do
+    let end = start + nestedCount2
+    UF.fold
+        (UF.take 1000 $ (UF.map (\(x, y) -> x + y)
+            $ UF.outerProduct (source end) (source end)))
+        FL.toList (start, start)
+
+{-# INLINE filterAllOut #-}
+filterAllOut :: MonadIO m => Int -> m ()
+filterAllOut start = do
+    let end = start + nestedCount2
+    UF.fold
+        (UF.filter (< 0)
+        $ UF.map (\(x, y) -> x + y)
+        $ UF.outerProduct (source end) (source end))
+        FL.drain (start, start)
+
+{-# INLINE filterAllIn #-}
+filterAllIn :: MonadIO m => Int -> m ()
+filterAllIn start = do
+    let end = start + nestedCount2
+    UF.fold
+        (UF.filter (> 0)
+        $ UF.map (\(x, y) -> x + y)
+        $ UF.outerProduct (source end) (source end))
+        FL.drain (start, start)
+
+{-# INLINE filterSome #-}
+filterSome :: MonadIO m => Int -> m ()
+filterSome start = do
+    let end = start + nestedCount2
+    UF.fold
+        (UF.filter (> 1100000)
+        $ UF.map (\(x, y) -> x + y)
+        $ UF.outerProduct (source end) (source end))
+        FL.drain (start, start)
+
+{-# INLINE breakAfterSome #-}
+breakAfterSome :: MonadIO m => Int -> m ()
+breakAfterSome start = do
+    let end = start + nestedCount2
+    UF.fold
+        (UF.takeWhile (<= 1100000)
+        $ UF.map (\(x, y) -> x + y)
+        $ UF.outerProduct (source end) (source end))
+        FL.drain (start, start)

--- a/src/Streamly/Internal/Data/Unfold.hs
+++ b/src/Streamly/Internal/Data/Unfold.hs
@@ -39,6 +39,14 @@
 -- these are stream consumers that reduce the stream to a single value, these
 -- consumers can be composed such that a stream can be split over multiple
 -- consumers.
+--
+-- Performance:
+--
+-- Composing a tree or graph of computations with unfolds can be much more
+-- efficient compared to composing with the Monad instance.  The reason is that
+-- unfolds allow the compiler to statically know the state and optimize it
+-- using stream fusion whereas it is not possible with the monad bind because
+-- the state is determined dynamically.
 
 -- Open control flow style streams can also have two representations. StreamK
 -- is a producer style representation. We can also have a consumer style
@@ -55,22 +63,55 @@ module Streamly.Internal.Data.Unfold
 
       Unfold
     , unfold
-    , fold
 
-    -- ** Unfolds
+    -- * Operations on Input
+    , close
+    , first
+    , second
+    , lmap
+    -- coapply
+    -- comonad
+
+    -- * Operations on Output
+    , fold
+    -- pipe
+
+    -- * Unfolds
     , singleton
     , replicateM
     , fromList
+    , enumerateFromStepIntegral
+    , enumerateFromToIntegral
+    , enumerateFromIntegral
+
+    -- * Transformations
+    , map
+
+    -- * Filtering
+    , takeWhileM
+    , takeWhile
+    , take
+    , filter
+    , filterM
+
+    -- * Nesting
+    , concat
+    , concatMapM
+    , outerProduct
     )
 where
 
+import Data.Void (Void)
 import GHC.Types (SPEC(..))
+import Prelude hiding (concat, map, takeWhile, take, filter)
+
 import Streamly.Streams.StreamD.Type (Stream(..), Step(..))
 #if __GLASGOW_HASKELL__ < 800
 import Streamly.Streams.StreamD.Type (pattern Stream)
 #endif
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
 import Streamly.Internal.Data.Fold.Types (Fold(..))
+import Streamly.Internal.Data.SVar (defState)
 
 -------------------------------------------------------------------------------
 -- Running unfolds
@@ -94,6 +135,48 @@ unfold seed (Unfold ustep inject) = Stream step Nothing
             Skip s    -> Skip (Just s)
             Stop      -> Stop
 
+-------------------------------------------------------------------------------
+-- Input operations
+-------------------------------------------------------------------------------
+
+-- | Supply the seed to an unfold closing the input end of the unfold.
+--
+-- /Internal/
+--
+{-# INLINE_NORMAL close #-}
+close :: Unfold m a b -> a -> Unfold m Void b
+close (Unfold ustep uinject) a = Unfold ustep (const $ uinject a)
+
+-- XXX rename to closeFst/closeSnd
+--
+-- | Supply the first component of the tuple to an unfold that accepts a tuple
+-- as a seed resulting in a fold that accepts the second component of the tuple
+-- as a seed.
+--
+-- /Internal/
+--
+{-# INLINE_NORMAL first #-}
+first :: Unfold m (a, b) c -> a -> Unfold m b c
+first (Unfold ustep uinject) a = Unfold ustep (\b -> uinject (a, b))
+
+-- | Supply the second component of the tuple to an unfold that accepts a tuple
+-- as a seed resulting in a fold that accepts the first component of the tuple
+-- as a seed.
+--
+-- /Internal/
+--
+{-# INLINE_NORMAL second #-}
+second :: Unfold m (a, b) c -> b -> Unfold m a c
+second (Unfold ustep uinject) b = Unfold ustep (\a -> uinject (a, b))
+
+{-# INLINE_NORMAL lmap #-}
+lmap :: (a -> c) -> Unfold m c b -> Unfold m a b
+lmap f (Unfold ustep uinject) = Unfold ustep (\x -> uinject $ f x)
+
+-------------------------------------------------------------------------------
+-- Output operations
+-------------------------------------------------------------------------------
+
 -- | Compose an 'Unfold' and a 'Fold'. Given an @Unfold m a b@ and a
 -- @Fold m b c@, returns a monadic action @a -> m c@ representing the
 -- application of the fold on the unfolded stream.
@@ -115,6 +198,18 @@ fold (Unfold ustep inject) (Fold fstep initial extract) a =
                 go SPEC acc' s
             Skip s -> go SPEC acc s
             Stop   -> extract acc
+
+{-# INLINE_NORMAL map #-}
+map :: Monad m => (b -> c) -> Unfold m a b -> Unfold m a c
+map f (Unfold ustep uinject) = Unfold step uinject
+    where
+    {-# INLINE_LATE step #-}
+    step st = do
+        r <- ustep st
+        return $ case r of
+            Yield x s -> Yield (f x) s
+            Skip s    -> Skip s
+            Stop      -> Stop
 
 -------------------------------------------------------------------------------
 -- Unfolds
@@ -156,3 +251,176 @@ fromList = Unfold step inject
     {-# INLINE_LATE step #-}
     step (x:xs) = return $ Yield x xs
     step []     = return Stop
+
+-------------------------------------------------------------------------------
+-- Filtering
+-------------------------------------------------------------------------------
+
+{-# INLINE_NORMAL take #-}
+take :: Monad m => Int -> Unfold m a b -> Unfold m a b
+take n (Unfold step1 inject1) = Unfold step inject
+  where
+    inject x = do
+        s <- inject1 x
+        return (s, 0)
+    {-# INLINE_LATE step #-}
+    step (st, i) | i < n = do
+        r <- step1 st
+        return $ case r of
+            Yield x s -> Yield x (s, i + 1)
+            Skip s -> Skip (s, i)
+            Stop   -> Stop
+    step (_, _) = return Stop
+
+{-# INLINE_NORMAL takeWhileM #-}
+takeWhileM :: Monad m => (b -> m Bool) -> Unfold m a b -> Unfold m a b
+takeWhileM f (Unfold step1 inject1) = Unfold step inject1
+  where
+    {-# INLINE_LATE step #-}
+    step st = do
+        r <- step1 st
+        case r of
+            Yield x s -> do
+                b <- f x
+                return $ if b then Yield x s else Stop
+            Skip s -> return $ Skip s
+            Stop   -> return Stop
+
+{-# INLINE takeWhile #-}
+takeWhile :: Monad m => (b -> Bool) -> Unfold m a b -> Unfold m a b
+takeWhile f = takeWhileM (return . f)
+
+{-# INLINE_NORMAL filterM #-}
+filterM :: Monad m => (b -> m Bool) -> Unfold m a b -> Unfold m a b
+filterM f (Unfold step1 inject1) = Unfold step inject1
+  where
+    {-# INLINE_LATE step #-}
+    step st = do
+        r <- step1 st
+        case r of
+            Yield x s -> do
+                b <- f x
+                return $ if b then Yield x s else Skip s
+            Skip s -> return $ Skip s
+            Stop   -> return Stop
+
+{-# INLINE filter #-}
+filter :: Monad m => (b -> Bool) -> Unfold m a b -> Unfold m a b
+filter f = filterM (return . f)
+
+-------------------------------------------------------------------------------
+-- Enumeration
+-------------------------------------------------------------------------------
+
+-- | Can be used to enumerate unbounded integrals. This does not check for
+-- overflow or underflow for bounded integrals.
+{-# INLINE_NORMAL enumerateFromStepIntegral #-}
+enumerateFromStepIntegral :: (Integral a, Monad m) => Unfold m (a, a) a
+enumerateFromStepIntegral = Unfold step inject
+    where
+    inject (from, stride) = from `seq` stride `seq` return (from, stride)
+    {-# INLINE_LATE step #-}
+    step !(x, stride) = return $ Yield x $! (x + stride, stride)
+
+-- We are assuming that "to" is constrained by the type to be within
+-- max/min bounds.
+{-# INLINE enumerateFromToIntegral #-}
+enumerateFromToIntegral :: (Monad m, Integral a) => a -> Unfold m a a
+enumerateFromToIntegral to =
+    takeWhile (<= to) $ second enumerateFromStepIntegral 1
+
+{-# INLINE enumerateFromIntegral #-}
+enumerateFromIntegral :: (Monad m, Integral a, Bounded a) => Unfold m a a
+enumerateFromIntegral = enumerateFromToIntegral maxBound
+
+-------------------------------------------------------------------------------
+-- Nested
+-------------------------------------------------------------------------------
+
+data ConcatState s1 s2 = ConcatOuter s1 | ConcatInner s1 s2
+
+{-# INLINE_NORMAL concat #-}
+concat :: Monad m => Unfold m a b -> Unfold m b c -> Unfold m a c
+concat (Unfold step1 inject1) (Unfold step2 inject2) = Unfold step inject
+    where
+    inject x = do
+        s <- inject1 x
+        return $ ConcatOuter s
+
+    {-# INLINE_LATE step #-}
+    step (ConcatOuter st) = do
+        r <- step1 st
+        case r of
+            Yield x s -> do
+                innerSt <- inject2 x
+                return $ Skip (ConcatInner s innerSt)
+            Skip s    -> return $ Skip (ConcatOuter s)
+            Stop      -> return Stop
+
+    step (ConcatInner ost ist) = do
+        r <- step2 ist
+        return $ case r of
+            Yield x s -> Yield x (ConcatInner ost s)
+            Skip s    -> Skip (ConcatInner ost s)
+            Stop      -> Skip (ConcatOuter ost)
+
+data OuterProductState s1 s2 sy x y =
+    OuterProductOuter s1 y | OuterProductInner s1 sy s2 x
+
+{-# INLINE_NORMAL outerProduct #-}
+outerProduct :: Monad m
+    => Unfold m a b -> Unfold m c d -> Unfold m (a, c) (b, d)
+outerProduct (Unfold step1 inject1) (Unfold step2 inject2) = Unfold step inject
+    where
+    inject (x, y) = do
+        s1 <- inject1 x
+        return $ OuterProductOuter s1 y
+
+    {-# INLINE_LATE step #-}
+    step (OuterProductOuter st1 sy) = do
+        r <- step1 st1
+        case r of
+            Yield x s -> do
+                s2 <- inject2 sy
+                return $ Skip (OuterProductInner s sy s2 x)
+            Skip s    -> return $ Skip (OuterProductOuter s sy)
+            Stop      -> return Stop
+
+    step (OuterProductInner ost sy ist x) = do
+        r <- step2 ist
+        return $ case r of
+            Yield y s -> Yield (x, y) (OuterProductInner ost sy s x)
+            Skip s    -> Skip (OuterProductInner ost sy s x)
+            Stop      -> Skip (OuterProductOuter ost sy)
+
+-- XXX This can be used to implement a Monad instance for "Unfold m ()".
+
+data ConcatMapState s1 s2 = ConcatMapOuter s1 | ConcatMapInner s1 s2
+
+{-# INLINE_NORMAL concatMapM #-}
+concatMapM :: Monad m
+    => (b -> m (Unfold m () c)) -> Unfold m a b -> Unfold m a c
+concatMapM f (Unfold step1 inject1) = Unfold step inject
+    where
+    inject x = do
+        s <- inject1 x
+        return $ ConcatMapOuter s
+
+    {-# INLINE_LATE step #-}
+    step (ConcatMapOuter st) = do
+        r <- step1 st
+        case r of
+            Yield x s -> do
+                Unfold step2 inject2 <- f x
+                innerSt <- inject2 ()
+                return $ Skip (ConcatMapInner s (Stream (\_ ss -> step2 ss)
+                                                        innerSt))
+            Skip s    -> return $ Skip (ConcatMapOuter s)
+            Stop      -> return Stop
+
+    step (ConcatMapInner ost (Stream istep ist)) = do
+        r <- istep defState ist
+        return $ case r of
+            Yield x s -> Yield x (ConcatMapInner ost (Stream istep s))
+            Skip s    -> Skip (ConcatMapInner ost (Stream istep s))
+            Stop      -> Skip (ConcatMapOuter ost)

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -571,6 +571,22 @@ benchmark nested
     build-depends:
         transformers  >= 0.4 && < 0.6
 
+benchmark nestedUnfold
+  import: bench-options
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmark
+  main-is: NestedUnfold.hs
+  other-modules: NestedUnfoldOps
+  build-depends:
+      streamly
+    , base                >= 4.8   && < 5
+    , deepseq             >= 1.4.1 && < 1.5
+    , random              >= 1.0   && < 2.0
+    , gauge               >= 0.2.4 && < 0.3
+  if impl(ghc < 8.0)
+    build-depends:
+        transformers  >= 0.4 && < 0.6
+
 benchmark array
   import: bench-options
   type: exitcode-stdio-1.0


### PR DESCRIPTION
Especially add chaining of unfolds (`concat`) and `outerProduct` operations. `outerProduct` is
just the cartesian product of two streams, it is like the concatMap/bind for
streams. In contrast to concatMap, the unfold nested looping operations are
amenable to complete fusion providing us amazing performance equivalent to
linear stream operations.