### PR TITLE
rename "runFold" to "fold"

### DIFF
--- a/benchmark/ArrayOps.hs
+++ b/benchmark/ArrayOps.hs
@@ -49,7 +49,7 @@ type Stream = A.Array
 
 {-# INLINE sourceUnfoldr #-}
 sourceUnfoldr :: MonadIO m => Int -> m (Stream Int)
-sourceUnfoldr n = S.runFold (A.writeN value) $ S.unfoldr step n
+sourceUnfoldr n = S.fold (A.writeN value) $ S.unfoldr step n
     where
     step cnt =
         if cnt > n + value
@@ -58,18 +58,18 @@ sourceUnfoldr n = S.runFold (A.writeN value) $ S.unfoldr step n
 
 {-# INLINE sourceIntFromTo #-}
 sourceIntFromTo :: MonadIO m => Int -> m (Stream Int)
-sourceIntFromTo n = S.runFold (A.writeN value) $ S.enumerateFromTo n (n + value)
+sourceIntFromTo n = S.fold (A.writeN value) $ S.enumerateFromTo n (n + value)
 
 {-# INLINE sourceIntFromToFromStream #-}
 sourceIntFromToFromStream :: MonadIO m => Int -> m (Stream Int)
-sourceIntFromToFromStream n = S.runFold A.write $ S.enumerateFromTo n (n + value)
+sourceIntFromToFromStream n = S.fold A.write $ S.enumerateFromTo n (n + value)
 
 sourceIntFromToFromList :: MonadIO m => Int -> m (Stream Int)
 sourceIntFromToFromList n = P.return $ A.fromList $ [n..n + value]
 
 {-# INLINE sourceFromList #-}
 sourceFromList :: MonadIO m => Int -> m (Stream Int)
-sourceFromList n = S.runFold (A.writeN value) $ S.fromList [n..n+value]
+sourceFromList n = S.fold (A.writeN value) $ S.fromList [n..n+value]
 
 {-# INLINE sourceIsList #-}
 sourceIsList :: Int -> Stream Int
@@ -280,7 +280,7 @@ onArray
     :: MonadIO m => (S.SerialT m Int -> S.SerialT m Int)
     -> Stream Int
     -> m (Stream Int)
-onArray f arr = S.runFold (A.writeN value) $ f $ A.read arr
+onArray f arr = S.fold (A.writeN value) $ f $ A.read arr
 
 scanl'        n = composeN n $ onArray $ S.scanl' (+) 0
 scanl1'       n = composeN n $ onArray $ S.scanl1' (+)

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -219,42 +219,42 @@ main =
         , benchIOSink "toListRev" Ops.toListRev
         ]
       , bgroup "folds"
-        [ benchIOSink "drain" (S.runFold FL.drain)
-        , benchIOSink "sink" (S.runFold $ Sink.toFold Sink.drain)
-        , benchIOSink "last" (S.runFold FL.last)
-        , benchIOSink "length" (S.runFold FL.length)
-        , benchIOSink "sum" (S.runFold FL.sum)
-        , benchIOSink "product" (S.runFold FL.product)
-        , benchIOSink "maximumBy" (S.runFold (FL.maximumBy compare))
-        , benchIOSink "maximum" (S.runFold FL.maximum)
-        , benchIOSink "minimumBy" (S.runFold (FL.minimumBy compare))
-        , benchIOSink "minimum" (S.runFold FL.minimum)
-        , benchIOSink "mean" (\s -> S.runFold FL.mean (S.map (fromIntegral :: Int -> Double) s))
-        , benchIOSink "variance" (\s -> S.runFold FL.variance (S.map (fromIntegral :: Int -> Double) s))
-        , benchIOSink "stdDev" (\s -> S.runFold FL.stdDev (S.map (fromIntegral :: Int -> Double) s))
+        [ benchIOSink "drain" (S.fold FL.drain)
+        , benchIOSink "sink" (S.fold $ Sink.toFold Sink.drain)
+        , benchIOSink "last" (S.fold FL.last)
+        , benchIOSink "length" (S.fold FL.length)
+        , benchIOSink "sum" (S.fold FL.sum)
+        , benchIOSink "product" (S.fold FL.product)
+        , benchIOSink "maximumBy" (S.fold (FL.maximumBy compare))
+        , benchIOSink "maximum" (S.fold FL.maximum)
+        , benchIOSink "minimumBy" (S.fold (FL.minimumBy compare))
+        , benchIOSink "minimum" (S.fold FL.minimum)
+        , benchIOSink "mean" (\s -> S.fold FL.mean (S.map (fromIntegral :: Int -> Double) s))
+        , benchIOSink "variance" (\s -> S.fold FL.variance (S.map (fromIntegral :: Int -> Double) s))
+        , benchIOSink "stdDev" (\s -> S.fold FL.stdDev (S.map (fromIntegral :: Int -> Double) s))
 
-        , benchIOSink "mconcat" (S.runFold FL.mconcat . (S.map (Last . Just)))
-        , benchIOSink "foldMap" (S.runFold (FL.foldMap (Last . Just)))
+        , benchIOSink "mconcat" (S.fold FL.mconcat . (S.map (Last . Just)))
+        , benchIOSink "foldMap" (S.fold (FL.foldMap (Last . Just)))
 
-        , benchIOSink "toList" (S.runFold FL.toList)
-        , benchIOSink "toListRevF" (S.runFold IFL.toListRevF)
-        , benchIOSink "toStream" (S.runFold IP.toStream)
-        , benchIOSink "toStreamRev" (S.runFold IP.toStreamRev)
-        , benchIOSink "writeN" (S.runFold (A.writeN Ops.value))
+        , benchIOSink "toList" (S.fold FL.toList)
+        , benchIOSink "toListRevF" (S.fold IFL.toListRevF)
+        , benchIOSink "toStream" (S.fold IP.toStream)
+        , benchIOSink "toStreamRev" (S.fold IP.toStreamRev)
+        , benchIOSink "writeN" (S.fold (A.writeN Ops.value))
 
-        , benchIOSink "index" (S.runFold (FL.index Ops.maxValue))
-        , benchIOSink "head" (S.runFold FL.head)
-        , benchIOSink "find" (S.runFold (FL.find (== Ops.maxValue)))
-        , benchIOSink "findIndex" (S.runFold (FL.findIndex (== Ops.maxValue)))
-        , benchIOSink "elemIndex" (S.runFold (FL.elemIndex Ops.maxValue))
+        , benchIOSink "index" (S.fold (FL.index Ops.maxValue))
+        , benchIOSink "head" (S.fold FL.head)
+        , benchIOSink "find" (S.fold (FL.find (== Ops.maxValue)))
+        , benchIOSink "findIndex" (S.fold (FL.findIndex (== Ops.maxValue)))
+        , benchIOSink "elemIndex" (S.fold (FL.elemIndex Ops.maxValue))
 
-        , benchIOSink "null" (S.runFold FL.null)
-        , benchIOSink "elem" (S.runFold (FL.elem Ops.maxValue))
-        , benchIOSink "notElem" (S.runFold (FL.notElem Ops.maxValue))
-        , benchIOSink "all" (S.runFold (FL.all (<= Ops.maxValue)))
-        , benchIOSink "any" (S.runFold (FL.any (> Ops.maxValue)))
-        , benchIOSink "and" (\s -> S.runFold FL.and (S.map (<= Ops.maxValue) s))
-        , benchIOSink "or" (\s -> S.runFold FL.or (S.map (> Ops.maxValue) s))
+        , benchIOSink "null" (S.fold FL.null)
+        , benchIOSink "elem" (S.fold (FL.elem Ops.maxValue))
+        , benchIOSink "notElem" (S.fold (FL.notElem Ops.maxValue))
+        , benchIOSink "all" (S.fold (FL.all (<= Ops.maxValue)))
+        , benchIOSink "any" (S.fold (FL.any (> Ops.maxValue)))
+        , benchIOSink "and" (\s -> S.fold FL.and (S.map (<= Ops.maxValue) s))
+        , benchIOSink "or" (\s -> S.fold FL.or (S.map (> Ops.maxValue) s))
         ]
       , bgroup "fold-multi-stream"
         [ benchIOSink1 "eqBy" Ops.eqBy
@@ -264,16 +264,16 @@ main =
         , benchIOSink "stripPrefix" Ops.stripPrefix
         ]
       , bgroup "folds-transforms"
-        [ benchIOSink "drain" (S.runFold FL.drain)
-        , benchIOSink "lmap" (S.runFold (IFL.lmap (+1) FL.drain))
+        [ benchIOSink "drain" (S.fold FL.drain)
+        , benchIOSink "lmap" (S.fold (IFL.lmap (+1) FL.drain))
         , benchIOSink "pipe-mapM"
-             (S.runFold (IFL.transform (Pipe.mapM (\x -> return $ x + 1)) FL.drain))
+             (S.fold (IFL.transform (Pipe.mapM (\x -> return $ x + 1)) FL.drain))
         ]
       , bgroup "folds-compositions" -- Applicative
         [
-          benchIOSink "all,any"    (S.runFold ((,) <$> FL.all (<= Ops.maxValue)
+          benchIOSink "all,any"    (S.fold ((,) <$> FL.all (<= Ops.maxValue)
                                                   <*> FL.any (> Ops.maxValue)))
-        , benchIOSink "sum,length" (S.runFold ((,) <$> FL.sum <*> FL.length))
+        , benchIOSink "sum,length" (S.fold ((,) <$> FL.sum <*> FL.length))
         ]
       , bgroup "pipes"
         [ benchIOSink "mapM" (Ops.transformMapM serially 1)

--- a/examples/EchoServer.hs
+++ b/examples/EchoServer.hs
@@ -9,4 +9,4 @@ main :: IO ()
 main = S.drain
     $ parallely $ S.mapM (flip withSocket echo)
     $ serially $ connectionsOnAllAddrs 8090
-    where echo sk = S.runFold (writeArrays sk) $ readArrays sk
+    where echo sk = S.fold (writeArrays sk) $ readArrays sk

--- a/examples/FileIOExamples.hs
+++ b/examples/FileIOExamples.hs
@@ -30,14 +30,14 @@ grepc pat src = print . (subtract 1) =<< (S.length
     $ File.read src)
 
 avgll :: FilePath -> IO ()
-avgll src = print =<< (S.runFold avg
+avgll src = print =<< (S.fold avg
     $ S.splitOnSuffix (== ord' '\n') FL.length
     $ File.read src)
     where avg = (/) <$> toDouble FL.sum <*> toDouble FL.length
           toDouble = fmap (fromIntegral :: Int -> Double)
 
 llhisto :: FilePath -> IO ()
-llhisto src = print =<< (S.runFold (FL.classify FL.length)
+llhisto src = print =<< (S.fold (FL.classify FL.length)
     $ S.map bucket
     $ S.splitOnSuffix (== ord' '\n') FL.length
     $ File.read src)

--- a/examples/FileSinkServer.hs
+++ b/examples/FileSinkServer.hs
@@ -21,7 +21,7 @@ main :: IO ()
 main = do
     file <- fmap head getArgs
     withFile file AppendMode
-        (\src -> S.runFold (FH.write src)
+        (\src -> S.fold (FH.write src)
         $ encodeChar8Unchecked
         $ S.concatMap A.read
         $ S.concatMapWith parallel (flip NS.withSocketS recv)

--- a/examples/FromFileClient.hs
+++ b/examples/FromFileClient.hs
@@ -16,6 +16,6 @@ main :: IO ()
 main =
     let sendFile file =
             withFile file ReadMode $ \src ->
-                  S.runFold (Client.writeArrays (127, 0, 0, 1) 8090)
+                  S.fold (Client.writeArrays (127, 0, 0, 1) 8090)
                 $ FH.readArrays src
      in getArgs >>= S.drain . parallely . S.mapM sendFile . S.fromList

--- a/examples/HandleIO.hs
+++ b/examples/HandleIO.hs
@@ -12,14 +12,14 @@ import System.Environment (getArgs)
 import System.IO (IOMode(..), hSeek, SeekMode(..))
 
 cat :: FH.Handle -> IO ()
-cat src = S.runFold (FH.writeArrays FH.stdout) $ FH.readArraysOf (256*1024) src
+cat src = S.fold (FH.writeArrays FH.stdout) $ FH.readArraysOf (256*1024) src
 -- byte stream version
--- cat src = S.runFold (FH.write FH.stdout) $ FH.read src
+-- cat src = S.fold (FH.write FH.stdout) $ FH.read src
 
 cp :: FH.Handle -> FH.Handle -> IO ()
-cp src dst = S.runFold (FH.writeArrays dst) $ FH.readArraysOf (256*1024) src
+cp src dst = S.fold (FH.writeArrays dst) $ FH.readArraysOf (256*1024) src
 -- byte stream version
--- cp src dst = S.runFold (FH.write dst) $ FH.read src
+-- cp src dst = S.fold (FH.write dst) $ FH.read src
 
 ord' :: Num a => Char -> a
 ord' = (fromIntegral . ord)
@@ -44,14 +44,14 @@ grepc pat src = print . (subtract 1) =<< (S.length
 -}
 
 avgll :: FH.Handle -> IO ()
-avgll src = print =<< (S.runFold avg
+avgll src = print =<< (S.fold avg
     $ S.splitWithSuffix (== ord' '\n') FL.length
     $ FH.read src)
     where avg = (/) <$> toDouble FL.sum <*> toDouble FL.length
           toDouble = fmap (fromIntegral :: Int -> Double)
 
 llhisto :: FH.Handle -> IO ()
-llhisto src = print =<< (S.runFold (FL.classify FL.length)
+llhisto src = print =<< (S.fold (FL.classify FL.length)
     $ S.map bucket
     $ S.splitWithSuffix (== ord' '\n') FL.length
     $ FH.read src)

--- a/examples/WordClassifier.hs
+++ b/examples/WordClassifier.hs
@@ -26,9 +26,9 @@ import           System.Environment (getArgs)
 import           System.IO (openFile, IOMode(..))
 
 instance (Enum a, Storable a) => Hashable (A.Array a) where
-    hash arr = runIdentity $ Streamly.runFold Internal.rollingHash (A.read arr)
+    hash arr = runIdentity $ Streamly.fold Internal.rollingHash (A.read arr)
     hashWithSalt salt arr = runIdentity $
-        Streamly.runFold (Internal.rollingHashWithSalt salt) (A.read arr)
+        Streamly.fold (Internal.rollingHashWithSalt salt) (A.read arr)
 
 {-# INLINE toLower #-}
 toLower :: Char -> Char

--- a/src/Streamly/Benchmark/FileIO/Array.hs
+++ b/src/Streamly/Benchmark/FileIO/Array.hs
@@ -117,7 +117,7 @@ inspect $ 'sumBytes `hasNoType` ''Step
 {-# INLINE cat #-}
 cat :: Handle -> Handle -> IO ()
 cat devNull inh =
-    S.runFold (FH.writeArrays devNull) $ FH.readArraysOf (256*1024) inh
+    S.fold (FH.writeArrays devNull) $ FH.readArraysOf (256*1024) inh
 
 #ifdef INSPECTION
 inspect $ hasNoTypeClasses 'cat
@@ -129,7 +129,7 @@ inspect $ 'cat `hasNoType` ''Step
 copy :: Handle -> Handle -> IO ()
 copy inh outh =
     let s = FH.readArrays inh
-    in S.runFold (FH.writeArrays outh) s
+    in S.fold (FH.writeArrays outh) s
 
 #ifdef INSPECTION
 inspect $ hasNoTypeClasses 'copy
@@ -140,7 +140,7 @@ inspect $ 'copy `hasNoType` ''Step
 {-# INLINE linesUnlinesCopy #-}
 linesUnlinesCopy :: Handle -> Handle -> IO ()
 linesUnlinesCopy inh outh =
-    S.runFold (FH.writeArraysInChunksOf (1024*1024) outh)
+    S.fold (FH.writeArraysInChunksOf (1024*1024) outh)
         $ Internal.insertAfterEach (return $ A.fromList [10])
         $ AS.splitOnSuffix 10
         $ FH.readArraysOf (1024*1024) inh
@@ -154,7 +154,7 @@ inspect $ hasNoTypeClassesExcept 'linesUnlinesCopy [''Storable]
 {-# INLINE wordsUnwordsCopy #-}
 wordsUnwordsCopy :: Handle -> Handle -> IO ()
 wordsUnwordsCopy inh outh =
-    S.runFold (FH.writeArraysInChunksOf (1024*1024) outh)
+    S.fold (FH.writeArraysInChunksOf (1024*1024) outh)
         $ S.intersperse (A.fromList [32])
         -- XXX use a word splitting combinator
         $ AS.splitOn 32
@@ -183,7 +183,7 @@ inspect $ hasNoTypeClasses 'decodeUtf8Lenient
 {-# INLINE copyCodecUtf8Lenient #-}
 copyCodecUtf8Lenient :: Handle -> Handle -> IO ()
 copyCodecUtf8Lenient inh outh =
-   S.runFold (FH.write outh)
+   S.fold (FH.write outh)
      $ SS.encodeUtf8
      $ SS.decodeUtf8ArraysLenient
      $ FH.readArraysOf (1024*1024) inh

--- a/src/Streamly/Benchmark/FileIO/Stream.hs
+++ b/src/Streamly/Benchmark/FileIO/Stream.hs
@@ -158,7 +158,7 @@ inspect $ 'sumBytes `hasNoType` ''D.ConcatMapUState
 -- | Send the file contents to /dev/null
 {-# INLINE cat #-}
 cat :: Handle -> Handle -> IO ()
-cat devNull inh = S.runFold (FH.write devNull) $ FH.read inh
+cat devNull inh = S.fold (FH.write devNull) $ FH.read inh
 
 #ifdef INSPECTION
 inspect $ hasNoTypeClasses 'cat
@@ -182,7 +182,7 @@ inspect $ 'catStreamWrite `hasNoType` ''D.ConcatMapUState
 -- | Copy file
 {-# INLINE copy #-}
 copy :: Handle -> Handle -> IO ()
-copy inh outh = S.runFold (FH.write outh) (FH.read inh)
+copy inh outh = S.fold (FH.write outh) (FH.read inh)
 
 #ifdef INSPECTION
 inspect $ hasNoTypeClasses 'copy
@@ -206,7 +206,7 @@ decodeChar8 inh =
 {-# INLINE copyCodecChar8 #-}
 copyCodecChar8 :: Handle -> Handle -> IO ()
 copyCodecChar8 inh outh =
-   S.runFold (FH.write outh)
+   S.fold (FH.write outh)
      $ SS.encodeChar8
      $ SS.decodeChar8
      $ FH.read inh
@@ -236,7 +236,7 @@ inspect $ hasNoTypeClasses 'decodeUtf8Lenient
 {-# INLINE copyCodecUtf8 #-}
 copyCodecUtf8 :: Handle -> Handle -> IO ()
 copyCodecUtf8 inh outh =
-   S.runFold (FH.write outh)
+   S.fold (FH.write outh)
      $ SS.encodeUtf8
      $ SS.decodeUtf8
      $ FH.read inh
@@ -252,7 +252,7 @@ inspect $ hasNoTypeClasses 'copyCodecUtf8
 {-# INLINE copyCodecUtf8Lenient #-}
 copyCodecUtf8Lenient :: Handle -> Handle -> IO ()
 copyCodecUtf8Lenient inh outh =
-   S.runFold (FH.write outh)
+   S.fold (FH.write outh)
      $ SS.encodeUtf8
      $ SS.decodeUtf8Lenient
      $ FH.read inh
@@ -303,7 +303,7 @@ inspect $ 'chunksOfD `hasNoType` ''D.ConcatMapUState
 {-# INLINE linesUnlinesCopy #-}
 linesUnlinesCopy :: Handle -> Handle -> IO ()
 linesUnlinesCopy inh outh =
-    S.runFold (FH.write outh)
+    S.fold (FH.write outh)
       $ SS.encodeChar8
       $ SS.unlines
       $ SS.lines
@@ -343,7 +343,7 @@ isSp = isSpace . chr . fromIntegral
 {-# INLINE wordsUnwordsCopyWord8 #-}
 wordsUnwordsCopyWord8 :: Handle -> Handle -> IO ()
 wordsUnwordsCopyWord8 inh outh =
-    S.runFold (FH.write outh)
+    S.fold (FH.write outh)
         $ IP.concatMapU IUF.fromList
         $ S.intersperse [32]
         $ S.wordsBy isSp FL.toList
@@ -359,7 +359,7 @@ inspect $ hasNoTypeClasses 'wordsUnwordsCopyWord8
 {-# INLINE wordsUnwordsCopy #-}
 wordsUnwordsCopy :: Handle -> Handle -> IO ()
 wordsUnwordsCopy inh outh =
-    S.runFold (FH.write outh)
+    S.fold (FH.write outh)
       $ SS.encodeChar8
       $ IP.concatMapU IUF.fromList
       $ S.intersperse " "

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -149,8 +149,8 @@ module Streamly.Internal.Prelude
     , scanl1M'
 
     -- ** Scan Using Fold
-    , runScan
-    , runPostscan
+    , scan
+    , postscan
 
     -- , lscanl'
     -- , lscanlM'
@@ -1568,16 +1568,16 @@ scanl1' step m = fromStreamD $ D.scanl1' step $ toStreamD m
 -- | Scan a stream using the given monadic fold.
 --
 -- @since 0.7.0
-{-# INLINE runScan #-}
-runScan :: Monad m => Fold m a b -> SerialT m a -> SerialT m b
-runScan (Fold step begin done) = P.scanlMx' step begin done
+{-# INLINE scan #-}
+scan :: Monad m => Fold m a b -> SerialT m a -> SerialT m b
+scan (Fold step begin done) = P.scanlMx' step begin done
 
 -- | Postscan a stream using the given monadic fold.
 --
 -- @since 0.7.0
-{-# INLINE runPostscan #-}
-runPostscan :: Monad m => Fold m a b -> SerialT m a -> SerialT m b
-runPostscan (Fold step begin done) = P.postscanlMx' step begin done
+{-# INLINE postscan #-}
+postscan :: Monad m => Fold m a b -> SerialT m a -> SerialT m b
+postscan (Fold step begin done) = P.postscanlMx' step begin done
 
 -- XXX runPrescan
 

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -77,7 +77,7 @@ module Streamly.Internal.Prelude
     , foldlM'
 
     -- ** Composable Left Folds
-    , runFold
+    , fold
 
     -- ** Full Folds
 
@@ -968,13 +968,13 @@ foldlM' step begin m = S.foldlM' step begin $ toStreamS m
 
 -- | Fold a stream using the supplied left fold.
 --
--- >>> S.runFold FL.sum (S.enumerateFromTo 1 100)
+-- >>> S.fold FL.sum (S.enumerateFromTo 1 100)
 -- 5050
 --
 -- @since 0.7.0
-{-# INLINE runFold #-}
-runFold :: Monad m => Fold m a b -> SerialT m a -> m b
-runFold = P.runFold
+{-# INLINE fold #-}
+fold :: Monad m => Fold m a b -> SerialT m a -> m b
+fold = P.runFold
 
 ------------------------------------------------------------------------------
 -- Running a sink
@@ -984,7 +984,7 @@ runFold = P.runFold
 -- | Drain a stream to a 'Sink'.
 {-# INLINE runSink #-}
 runSink :: Monad m => Sink m a -> SerialT m a -> m ()
-runSink = runFold . toFold
+runSink = fold . toFold
 -}
 
 ------------------------------------------------------------------------------
@@ -2275,7 +2275,7 @@ intercalateSuffix suffix seed unf str =
 -- elements of its input are consumed by fold @f1@ and the rest of the stream
 -- is consumed by fold @f2@.
 --
--- > let splitAt_ n xs = S.runFold (FL.splitAt n FL.toList FL.toList) $ S.fromList xs
+-- > let splitAt_ n xs = S.fold (FL.splitAt n FL.toList FL.toList) $ S.fromList xs
 --
 -- >>> splitAt_ 6 "Hello World!"
 -- > ("Hello ","World!")
@@ -2452,7 +2452,7 @@ spanBy cmp (Fold stepL initialL extractL) (Fold stepR initialR extractR) =
 -- input as long as the predicate @p@ is 'True'.  @f2@ consumes the rest of the
 -- input.
 --
--- > let span_ p xs = S.runFold (S.span p FL.toList FL.toList) $ S.fromList xs
+-- > let span_ p xs = S.fold (S.span p FL.toList FL.toList) $ S.fromList xs
 --
 -- >>> span_ (< 1) [1,2,3]
 -- > ([],[1,2,3])
@@ -2497,7 +2497,7 @@ span p (Fold stepL initialL extractL) (Fold stepR initialR extractR) =
 --
 -- This is the binary version of 'splitBy'.
 --
--- > let break_ p xs = S.runFold (S.break p FL.toList FL.toList) $ S.fromList xs
+-- > let break_ p xs = S.fold (S.break p FL.toList FL.toList) $ S.fromList xs
 --
 -- >>> break_ (< 1) [3,2,1]
 -- > ([3,2,1],[])
@@ -2611,7 +2611,7 @@ groups = groupsBy (==)
 -- stream before the sequence and the second part consisting of the sequence
 -- and the rest of the stream.
 --
--- > let breakOn_ pat xs = S.runFold (S.breakOn pat FL.toList FL.toList) $ S.fromList xs
+-- > let breakOn_ pat xs = S.fold (S.breakOn pat FL.toList FL.toList) $ S.fromList xs
 --
 -- >>> breakOn_ "dear" "Hello dear world!"
 -- > ("Hello ","dear world!")
@@ -2988,7 +2988,7 @@ wordsOn subseq f m = undefined -- D.fromStreamD $ D.wordsOn f subseq (D.toStream
 splitBySeq
     :: (IsStream t, MonadAsync m, Storable a, Enum a, Eq a)
     => Array a -> Fold m a b -> t m a -> t m b
-splitBySeq patt f m = intersperseM (runFold f (A.read patt)) $ splitOnSeq patt f m
+splitBySeq patt f m = intersperseM (fold f (A.read patt)) $ splitOnSeq patt f m
 
 -- | Like 'splitSuffixOn' but keeps the suffix intact in the splits.
 --

--- a/src/Streamly/Prelude.hs
+++ b/src/Streamly/Prelude.hs
@@ -186,7 +186,7 @@ module Streamly.Prelude
     -- ** Composable Left Folds
     -- $runningfolds
 
-    , runFold
+    , fold
 
     -- ** Full Folds
     -- | Folds that are guaranteed to evaluate the whole stream.
@@ -885,11 +885,11 @@ import Streamly.Internal.Prelude
 -- $runningfolds
 --
 -- "Streamly.Data.Fold" module defines composable left folds which can be combined
--- together in many interesting ways. Those folds can be run using 'runFold'.
+-- together in many interesting ways. Those folds can be run using 'fold'.
 -- The following two ways of folding are equivalent in functionality and
 -- performance,
 --
--- >>> S.runFold FL.sum (S.enumerateFromTo 1 100)
+-- >>> S.fold FL.sum (S.enumerateFromTo 1 100)
 -- 5050
 -- >>> S.sum (S.enumerateFromTo 1 100)
 -- 5050
@@ -905,7 +905,7 @@ import Streamly.Internal.Prelude
 --
 -- >>> S.head (1 `S.cons` undefined)
 -- Just 1
--- >>> S.runFold FL.head (1 `S.cons` undefined)
+-- >>> S.fold FL.head (1 `S.cons` undefined)
 -- *** Exception: Prelude.undefined
 --
 -- However, we can wrap the fold in a scan to convert it into a lazy stream of

--- a/src/Streamly/Prelude.hs
+++ b/src/Streamly/Prelude.hs
@@ -348,8 +348,8 @@ module Streamly.Prelude
     , scanl1M'
 
     -- ** Scan Using Fold
-    , runScan
-    , runPostscan
+    , scan
+    , postscan
 
     -- , lscanl'
     -- , lscanlM'
@@ -911,7 +911,7 @@ import Streamly.Internal.Prelude
 -- However, we can wrap the fold in a scan to convert it into a lazy stream of
 -- fold steps. We can then terminate the stream whenever we want.  For example,
 --
--- >>> S.toList $ S.take 1 $ S.runScan FL.head (1 `S.cons` undefined)
+-- >>> S.toList $ S.take 1 $ S.scan FL.head (1 `S.cons` undefined)
 -- [Nothing]
 --
 -- The following example extracts the input stream up to a point where the
@@ -921,7 +921,7 @@ import Streamly.Internal.Prelude
 -- > S.toList
 --   $ S.map (fromJust . fst)
 --   $ S.takeWhile (\\(_,x) -> x <= 10)
---   $ S.runPostscan ((,) \<$> FL.last \<*> avg) (S.enumerateFromTo 1.0 100.0)
+--   $ S.postscan ((,) \<$> FL.last \<*> avg) (S.enumerateFromTo 1.0 100.0)
 -- @
 -- @
 --  [1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0,11.0,12.0,13.0,14.0,15.0,16.0,17.0,18.0,19.0]

--- a/test/Arrays.hs
+++ b/test/Arrays.hs
@@ -43,7 +43,7 @@ testLength =
     forAll (choose (0, maxArrLen)) $ \len ->
         forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
             monadicIO $ do
-                arr <-  S.runFold (A.writeN len)
+                arr <-  S.fold (A.writeN len)
                       $ S.fromList list
                 assert (A.length arr == len)
 
@@ -52,7 +52,7 @@ testFromToStreamN =
     forAll (choose (0, maxArrLen)) $ \len ->
         forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
             monadicIO $ do
-                arr <- S.runFold (A.writeN len)
+                arr <- S.fold (A.writeN len)
                      $ S.fromList list
                 xs <- S.toList
                     $ A.read arr
@@ -63,7 +63,7 @@ testToStreamRev =
     forAll (choose (0, maxArrLen)) $ \len ->
         forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
             monadicIO $ do
-                arr <- S.runFold (A.writeN len)
+                arr <- S.fold (A.writeN len)
                      $ S.fromList list
                 xs <- S.toList
                     $ A.readRev arr
@@ -96,7 +96,7 @@ testFromToStream =
     forAll (choose (0, maxArrLen)) $ \len ->
         forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
             monadicIO $ do
-                arr <- S.runFold A.write $ S.fromList list
+                arr <- S.fold A.write $ S.fromList list
                 xs <- S.toList
                     $ A.read arr
                 assert (xs == list)

--- a/test/String.hs
+++ b/test/String.hs
@@ -57,7 +57,7 @@ propDecodeEncodeIdArrays =
         monadicIO $ do
             let wrds = SS.encodeUtf8 $ S.fromList list
             chrs <- S.toList $ SS.decodeUtf8ArraysLenient
-                                    (S.runFold A.write wrds)
+                                    (S.fold A.write wrds)
             assert (chrs == list)
 
 testLines :: Property


### PR DESCRIPTION
* we are using "unfold" for unfolding, runUnfold is longer and sounds a bit
      weird. So similar to "unfold" we should use "fold" for folding.
* Another reason is that "runFold" sound ends in "unfold" so can sound
      confusing.
