### PR TITLE
Add unfoldWords/interpose/intercalate etc.

### DIFF
--- a/benchmark/FileIO.hs
+++ b/benchmark/FileIO.hs
@@ -201,20 +201,32 @@ main = do
                 Handles inh _ <- readIORef href
                 BFS.chunksOf 1000 inh
             ]
-        , bgroup "group-ungroup"
-            [ mkBench "lines-unlines" href $ do
+        , bgroup "group-ungroup-stream"
+            [ mkBench "lines-unlines-[Char]" href $ do
                 Handles inh outh <- readIORef href
                 BFS.linesUnlinesCopy inh outh
-            , mkBench "lines-unlines-arrays" href $ do
+            , mkBench "lines-unlines-Word8Array" href $ do
                 Handles inh outh <- readIORef href
-                BFA.linesUnlinesCopy inh outh
-            , mkBench "words-unwords" href $ do
+                BFS.linesUnlinesArrayWord8Copy inh outh
+            , mkBench "lines-unlines-CharArray" href $ do
                 Handles inh outh <- readIORef href
-                BFS.wordsUnwordsCopy inh outh
-            , mkBench "words-unwords-word8" href $ do
+                BFS.linesUnlinesArrayCharCopy inh outh
+            , mkBench "words-unwords-[Word8]" href $ do
                 Handles inh outh <- readIORef href
                 BFS.wordsUnwordsCopyWord8 inh outh
-            , mkBench "words-unwords-arrays" href $ do
+            , mkBench "words-unwords-[Char]" href $ do
+                Handles inh outh <- readIORef href
+                BFS.wordsUnwordsCopy inh outh
+            , mkBench "words-unwords-CharArray" href $ do
+                Handles inh outh <- readIORef href
+                BFS.wordsUnwordsCharArrayCopy inh outh
+            ]
+
+        , bgroup "group-ungroup-array-stream"
+            [ mkBench "lines-unlines-Word8Array" href $ do
+                Handles inh outh <- readIORef href
+                BFA.linesUnlinesCopy inh outh
+            , mkBench "words-unwords-Word8Array" href $ do
                 Handles inh outh <- readIORef href
                 BFA.wordsUnwordsCopy inh outh
             ]

--- a/src/Streamly/Benchmark/FileIO/Array.hs
+++ b/src/Streamly/Benchmark/FileIO/Array.hs
@@ -48,7 +48,6 @@ import qualified Streamly.Prelude as S
 import qualified Streamly.Data.String as SS
 
 import qualified Streamly.Internal.FileSystem.Handle as IFH
-import qualified Streamly.Internal.Prelude as Internal
 import qualified Streamly.Internal.Memory.Array as IA
 import qualified Streamly.Internal.Memory.ArrayStream as AS
 import qualified Streamly.Internal.Data.Unfold as IUF
@@ -186,8 +185,8 @@ inspect $ 'copy `hasNoType` ''Step
 {-# INLINE linesUnlinesCopy #-}
 linesUnlinesCopy :: Handle -> Handle -> IO ()
 linesUnlinesCopy inh outh =
-    S.fold (IFH.writeArraysInChunksOf (1024*1024) outh)
-        $ Internal.insertAfterEach (return $ A.fromList [10])
+    S.fold (IFH.writeInChunksOf (1024*1024) outh)
+        $ AS.interposeSuffix 10
         $ AS.splitOnSuffix 10
         $ IFH.toStreamArraysOf (1024*1024) inh
 
@@ -200,9 +199,9 @@ inspect $ hasNoTypeClassesExcept 'linesUnlinesCopy [''Storable]
 {-# INLINE wordsUnwordsCopy #-}
 wordsUnwordsCopy :: Handle -> Handle -> IO ()
 wordsUnwordsCopy inh outh =
-    S.fold (IFH.writeArraysInChunksOf (1024*1024) outh)
-        $ S.intersperse (A.fromList [32])
-        -- XXX use a word splitting combinator
+    S.fold (IFH.writeInChunksOf (1024*1024) outh)
+        $ AS.interpose 32
+        -- XXX this is not correct word splitting combinator
         $ AS.splitOn 32
         $ IFH.toStreamArraysOf (1024*1024) inh
 

--- a/src/Streamly/Streams/StreamK.hs
+++ b/src/Streamly/Streams/StreamK.hs
@@ -62,6 +62,7 @@ module Streamly.Streams.StreamK
 
     -- ** Specialized Generation
     , repeat
+    , repeatM
     , replicate
     , replicateM
     , fromIndices
@@ -268,9 +269,16 @@ once = yieldM
 -- repeatM = cycle1 . yield
 -- @
 --
+-- Generate an infinite stream by repeating a monadic value.
+--
+-- /Internal/
+repeatM :: (IsStream t, MonadAsync m) => m a -> t m a
+repeatM = go
+    where go m = m |: go m
+
 -- Generate an infinite stream by repeating a pure value.
 --
--- @since 0.4.0
+-- /Internal/
 {-# INLINE repeat #-}
 repeat :: IsStream t => a -> t m a
 repeat a = let x = cons a x in x


### PR DESCRIPTION
* Rearrange, update benchmarks for words/unwords, lines/unlines
* Add interpose/intercalate/interleaveInfix/interleaveSuffix to Prelude
* Add unfoldWords to Data.String

Use the newly added rotuines to write words/unwords and lines/unlines more
idiomatically and with improved performance.