### PR TITLE
Some tweaks for encodeUtf8 perf

### DIFF
--- a/docs/Build.md
+++ b/docs/Build.md
@@ -2,7 +2,7 @@
 
 Recommended GHC options are: 
 
-  `-O2 -fspec-constr-recursive=10 -fmax-worker-args=16`
+  `-O2 -fspec-constr-recursive=16 -fmax-worker-args=16`
 
 `-fspec-constr-recursive` is needed for better stream fusion by enabling
 the `SpecConstr` optimization in more cases.

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -205,7 +205,7 @@ common compile-options
 
 common optimization-options
   ghc-options: -O2
-               -fspec-constr-recursive=10
+               -fspec-constr-recursive=16
                -fmax-worker-args=16
 
 common threading-options


### PR DESCRIPTION
* Use a fast path yield point for ascii encoding
* bump up the spec-constr-recusrive limit

We still need our GHC plugin for full fusion of decode/encode pipeline.