### PR TITLE
Add a pitfall note on concurrency control parameters

### DIFF
--- a/docs/Build.md
+++ b/docs/Build.md
@@ -2,7 +2,7 @@
 
 Recommended GHC options are: 
 
-  `-O2 -fspec-constr-recursive=10 -fmax-worker-args=16`
+  `-O2 -fspec-constr-recursive=16 -fmax-worker-args=16`
 
 `-fspec-constr-recursive` is needed for better stream fusion by enabling
 the `SpecConstr` optimization in more cases.

--- a/src/Streamly.hs
+++ b/src/Streamly.hs
@@ -568,10 +568,33 @@ forEachWith = P.forEachWith
 -- $concurrency
 --
 -- These combinators can be used at any point in a stream composition to set
--- parameters to control the concurrency of the enclosed stream.  A parameter
--- set at any point remains effective for any concurrent combinators used
--- downstream until it is reset.  These control parameters have no effect on
--- non-concurrent combinators in the stream, or on non-concurrent streams.
+-- parameters to control the concurrency of the /argument stream/.  A control
+-- parameter set at any point remains effective for any concurrent combinators
+-- used in the argument stream until it is reset by using the combinator again.
+-- These control parameters have no effect on non-concurrent combinators in the
+-- stream, or on non-concurrent streams.
+--
+-- /Pitfall:/ Remember that 'maxBuffer' in the following example applies to
+-- 'mapM' and any other combinators that may follow it, and it does not apply
+-- to the combinators before it:
+--
+-- @
+--  ...
+--  $ maxBuffer 10
+--  $ S.mapM ...
+--  ...
+-- @
+--
+-- If we use '&' instead of '$' the situation will reverse, in the following
+-- example, 'maxBuffer' does not apply to 'mapM', it applies to combinators
+-- that come before it, because those are the arguments to 'maxBuffer':
+--
+-- @
+--  ...
+--  & maxBuffer 10
+--  & S.mapM ...
+--  ...
+-- @
 
 -- $adapters
 --

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -205,7 +205,7 @@ common compile-options
 
 common optimization-options
   ghc-options: -O2
-               -fspec-constr-recursive=10
+               -fspec-constr-recursive=16
                -fmax-worker-args=16
 
 common threading-options


### PR DESCRIPTION
People often confuse whether "maxBuffer" and other such combinators apply to
combinators that follow them or to  combinators that precede them.

The examples that wrote can be improved.