### PR TITLE
Reorganize Unicode string handling modules

### DIFF
--- a/benchmark/FileIO.hs
+++ b/benchmark/FileIO.hs
@@ -155,12 +155,12 @@ main = do
            , mkBench "read-word8" href $ do
                Handles inh _ <- readIORef href
                BFS.readWord8 inh
-           , mkBench "read-char8" href $ do
+           , mkBench "read-latin1" href $ do
                Handles inh _ <- readIORef href
-               BFS.decodeChar8 inh
+               BFS.decodeLatin1 inh
            , mkBench "read-utf8" href $ do
                Handles inh _ <- readIORef href
-               BFS.decodeUtf8Lenient inh
+               BFS.decodeUtf8Lax inh
             ]
         , bgroup "copyArray"
             [ mkBench "copy" href $ do
@@ -176,7 +176,7 @@ main = do
             ]
         -- This needs an ascii file, as decode just errors out.
         , bgroup "decode-encode"
-           [ mkBench "char8" href $ do
+           [ mkBench "latin1" href $ do
                Handles inh outh <- readIORef href
                BFS.copyCodecChar8 inh outh
            , mkBench "utf8-arrays" href $ do

--- a/examples/FileSinkServer.hs
+++ b/examples/FileSinkServer.hs
@@ -10,7 +10,7 @@ import Network.Socket (close)
 import System.Environment (getArgs)
 
 import Streamly
-import Streamly.Data.String
+import Streamly.Data.Unicode.Stream
 import qualified Streamly.FileSystem.Handle as FH
 import qualified Streamly.Memory.Array as A
 import qualified Streamly.Network.Socket as NS

--- a/examples/FileSinkServer.hs
+++ b/examples/FileSinkServer.hs
@@ -24,7 +24,7 @@ main = do
     file <- fmap head getArgs
     withFile file AppendMode
         (\src -> S.fold (FH.write src)
-        $ encodeChar8Unchecked
+        $ encodeLatin1Lax
         $ S.concatUnfold A.read
         $ S.concatMapWith parallel use
         $ S.unfold TCP.acceptOnPort 8090)
@@ -34,5 +34,5 @@ main = do
     use sk = S.finally (liftIO $ close sk) (recv sk)
     recv =
           S.splitWithSuffix (== '\n') A.write
-        . decodeChar8
+        . decodeLatin1
         . S.unfold NS.read

--- a/examples/WordClassifier.hs
+++ b/examples/WordClassifier.hs
@@ -16,7 +16,7 @@ import           Data.IORef
 import qualified Data.List as List
 import qualified Data.Ord as Ord
 import           Foreign.Storable (Storable(..))
-import qualified Streamly.Data.String as Streamly
+import qualified Streamly.Data.Unicode.Stream as Streamly
 import qualified Streamly.FileSystem.Handle as FH
 import qualified Streamly.Data.Fold as FL
 import qualified Streamly.Internal.Data.Fold as IFL

--- a/examples/WordClassifier.hs
+++ b/examples/WordClassifier.hs
@@ -17,6 +17,7 @@ import qualified Data.List as List
 import qualified Data.Ord as Ord
 import           Foreign.Storable (Storable(..))
 import qualified Streamly.Data.Unicode.Stream as Streamly
+import qualified Streamly.Internal.Data.Unicode.Stream as Streamly
 import qualified Streamly.FileSystem.Handle as FH
 import qualified Streamly.Data.Fold as FL
 import qualified Streamly.Internal.Data.Fold as IFL
@@ -56,9 +57,9 @@ main =
         name <- fmap head getArgs
         src <- openFile name ReadMode
         Streamly.unfold FH.read src     -- SerialT IO Word8
-         & Streamly.decodeChar8         -- SerialT IO Char
+         & Streamly.decodeLatin1         -- SerialT IO Char
          & Streamly.map toLower         -- SerialT IO Char
-         & Streamly.foldWords FL.toList -- SerialT IO String
+         & Streamly.words FL.toList -- SerialT IO String
          & Streamly.filter (all isAlpha)
          & Streamly.foldlM' (flip (Map.alterF alter)) Map.empty
          & fmap Map.toList

--- a/examples/WordCount.hs
+++ b/examples/WordCount.hs
@@ -38,7 +38,7 @@ import System.Environment (getArgs)
 import System.IO (Handle, openFile, IOMode(..))
 
 import qualified Streamly as S
-import qualified Streamly.Data.String as S
+import qualified Streamly.Data.Unicode.Stream as S
 import qualified Streamly.FileSystem.Handle as FH
 import qualified Streamly.Memory.Array as A
 import qualified Streamly.Prelude as S

--- a/examples/WordCount.hs
+++ b/examples/WordCount.hs
@@ -336,7 +336,7 @@ countCharSerial (Counts l w c wasSpace) ch =
 _wc_mwl_serial :: Handle -> IO ()
 _wc_mwl_serial src = print =<< (
       S.foldl' countCharSerial (Counts 0 0 0 True)
-    $ S.decodeUtf8Lenient
+    $ S.decodeUtf8Lax
     $ S.unfold FH.read src)
 
 -------------------------------------------------------------------------------

--- a/src/Streamly/Benchmark/FileIO/Array.hs
+++ b/src/Streamly/Benchmark/FileIO/Array.hs
@@ -45,7 +45,7 @@ import Prelude hiding (last)
 import qualified Streamly.FileSystem.Handle as FH
 import qualified Streamly.Memory.Array as A
 import qualified Streamly.Prelude as S
-import qualified Streamly.Data.String as SS
+import qualified Streamly.Data.Unicode.Stream as SS
 
 import qualified Streamly.Internal.FileSystem.Handle as IFH
 import qualified Streamly.Internal.Memory.Array as IA

--- a/src/Streamly/Benchmark/FileIO/Array.hs
+++ b/src/Streamly/Benchmark/FileIO/Array.hs
@@ -46,6 +46,7 @@ import qualified Streamly.FileSystem.Handle as FH
 import qualified Streamly.Memory.Array as A
 import qualified Streamly.Prelude as S
 import qualified Streamly.Data.Unicode.Stream as SS
+import qualified Streamly.Internal.Data.Unicode.Stream as IUS
 
 import qualified Streamly.Internal.FileSystem.Handle as IFH
 import qualified Streamly.Internal.Memory.Array as IA
@@ -214,7 +215,7 @@ inspect $ hasNoTypeClassesExcept 'wordsUnwordsCopy [''Storable]
 decodeUtf8Lenient :: Handle -> IO ()
 decodeUtf8Lenient inh =
    S.drain
-     $ SS.decodeUtf8ArraysLenient
+     $ IUS.decodeUtf8ArraysLenient
      $ IFH.toStreamArraysOf (1024*1024) inh
 
 #ifdef INSPECTION
@@ -230,7 +231,7 @@ copyCodecUtf8Lenient :: Handle -> Handle -> IO ()
 copyCodecUtf8Lenient inh outh =
    S.fold (FH.write outh)
      $ SS.encodeUtf8
-     $ SS.decodeUtf8ArraysLenient
+     $ IUS.decodeUtf8ArraysLenient
      $ IFH.toStreamArraysOf (1024*1024) inh
 
 #ifdef INSPECTION

--- a/src/Streamly/Benchmark/FileIO/Stream.hs
+++ b/src/Streamly/Benchmark/FileIO/Stream.hs
@@ -77,7 +77,7 @@ import qualified Streamly.Internal.Memory.Array.Types as AT
 import qualified Streamly.Prelude as S
 import qualified Streamly.Data.Fold as FL
 -- import qualified Streamly.Internal.Data.Fold as IFL
-import qualified Streamly.Data.String as SS
+import qualified Streamly.Data.Unicode.Stream as SS
 import qualified Streamly.Internal.Data.Unfold as IUF
 import qualified Streamly.Internal.Prelude as IP
 import qualified Streamly.Streams.StreamD as D

--- a/src/Streamly/Benchmark/FileIO/Stream.hs
+++ b/src/Streamly/Benchmark/FileIO/Stream.hs
@@ -78,6 +78,7 @@ import qualified Streamly.Prelude as S
 import qualified Streamly.Data.Fold as FL
 -- import qualified Streamly.Internal.Data.Fold as IFL
 import qualified Streamly.Data.Unicode.Stream as SS
+import qualified Streamly.Internal.Data.Unicode.Stream as IUS
 import qualified Streamly.Internal.Data.Unfold as IUF
 import qualified Streamly.Internal.Prelude as IP
 import qualified Streamly.Streams.StreamD as D
@@ -431,8 +432,8 @@ linesUnlinesArrayCharCopy :: Handle -> Handle -> IO ()
 linesUnlinesArrayCharCopy inh outh =
     S.fold (FH.write outh)
       $ SS.encodeChar8
-      $ SS.unlines
-      $ SS.lines
+      $ IUS.unlines
+      $ IUS.lines
       $ SS.decodeChar8
       $ S.unfold FH.read inh
 
@@ -525,8 +526,8 @@ wordsUnwordsCharArrayCopy :: Handle -> Handle -> IO ()
 wordsUnwordsCharArrayCopy inh outh =
     S.fold (FH.write outh)
       $ SS.encodeChar8
-      $ SS.unwords
-      $ SS.words
+      $ IUS.unwords
+      $ IUS.words
       $ SS.decodeChar8
       $ S.unfold FH.read inh
 
@@ -597,7 +598,7 @@ inspect $ hasNoTypeClasses 'splitOnSeq
 splitOnSeqUtf8 :: String -> Handle -> IO Int
 splitOnSeqUtf8 str inh =
     (S.length $ IP.splitOnSeq (A.fromList str) FL.drain
-        $ SS.decodeUtf8ArraysLenient
+        $ IUS.decodeUtf8ArraysLenient
         $ IFH.toStreamArrays inh) -- >>= print
 
 -- | Split on suffix sequence.

--- a/src/Streamly/Data/Unicode/Stream.hs
+++ b/src/Streamly/Data/Unicode/Stream.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE FlexibleContexts #-}
+-- |
+-- Module      : Streamly.Data.Unicode.Stream
+-- Copyright   : (c) 2018 Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : streamly@composewell.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- A unicode string can be represented either as a stream of 'Char' e.g.
+-- 'SerialT' 'Identity' 'Char' or as 'Array' 'Char'.  Unicode text processing
+-- can be done efficiently by applying stream operations and folds on the
+-- stream of 'Char'. When using 'Array' 'Char' direct array operations can be
+-- applied where available or the array can be read into a stream and then
+-- processed using stream operations. Use 'Array' 'Char' when you need to store
+-- or buffer strings temporarily in memory.  Streams in 'Identity' monad and
+-- 'Array' 'Char' are instances of 'IsString' and 'IsList', therefore,
+-- 'OverloadedStrings' and 'OverloadedLists' extensions can be used for
+-- convenience.
+--
+-- 'Array' 'Char' is usually perfectly fine to buffer short to medium or even
+-- large amounts of text in memory. Also, it is computationally efficient as
+-- there is no encoding/decoding involved.  We recommend using true streaming
+-- operations to avoid buffering large amounts of data as long as possible e.g.
+-- use `foldLines` instead of `lines`. However, if for some reason you are
+-- buffering very large amounts of text in memory and are worried about space
+-- efficiency you can use 'encodeUtf8' on the stream to convert it to a utf8
+-- encoded 'Array' 'Word8'.
+--
+-- Please note the following:
+--
+-- * Case conversion: Some unicode characters translate to more than one code
+-- point on case conversion. The 'toUpper' and 'toLower' functions in @base@
+-- package do not handle such characters. Therefore, operations like @map
+-- toUpper@ on a character stream or character array may not always perform
+-- correct conversion.
+-- * String comparison: In some cases, visually identical strings may have
+-- different unicode representations, therefore, a character stream or
+-- character array cannot be directly compared. A normalized comparison may be
+-- needed to check string equivalence correctly.
+
+module Streamly.Data.Unicode.Stream
+    (
+    -- * Construction (Decoding)
+      decodeChar8
+    , decodeUtf8
+    , decodeUtf8Lenient
+    , D.DecodeError(..)
+    , D.DecodeState
+    , D.CodePoint
+    , decodeUtf8Either
+    , resumeDecodeUtf8Either
+    , decodeUtf8Arrays
+    , decodeUtf8ArraysLenient
+
+    -- * Elimination (Encoding)
+    , encodeChar8
+    , encodeChar8Unchecked
+    , encodeUtf8
+{-
+    -- * Unicode aware operations
+    , toCaseFold
+    , toLower
+    , toUpper
+    , toTitle
+
+    -- * Operations on character strings
+    , strip -- (dropAround isSpace)
+    , stripEnd-}
+    -- * Transformation
+    , stripStart
+    , foldLines
+    , foldWords
+    , unfoldLines
+    , unfoldWords
+
+    -- * Streams of Strings
+    , lines
+    , words
+    , unlines
+    , unwords
+    )
+where
+
+import Streamly.Internal.Data.Unicode.Stream
+import Prelude hiding (lines, words, unlines, unwords)
+import qualified Streamly.Streams.StreamD as D

--- a/src/Streamly/Data/Unicode/Stream.hs
+++ b/src/Streamly/Data/Unicode/Stream.hs
@@ -46,40 +46,22 @@ module Streamly.Data.Unicode.Stream
       decodeChar8
     , decodeUtf8
     , decodeUtf8Lenient
-    , D.DecodeError(..)
-    , D.DecodeState
-    , D.CodePoint
-    , decodeUtf8Either
-    , resumeDecodeUtf8Either
-    , decodeUtf8Arrays
-    , decodeUtf8ArraysLenient
 
     -- * Elimination (Encoding)
     , encodeChar8
     , encodeChar8Unchecked
     , encodeUtf8
-{-
-    -- * Unicode aware operations
-    , toCaseFold
-    , toLower
-    , toUpper
-    , toTitle
-
+    {-
     -- * Operations on character strings
     , strip -- (dropAround isSpace)
-    , stripEnd-}
-    -- * Transformation
+    , stripEnd
     , stripStart
+    -}
+    -- * Transformation
     , foldLines
     , foldWords
     , unfoldLines
     , unfoldWords
-
-    -- * Streams of Strings
-    , lines
-    , words
-    , unlines
-    , unwords
     )
 where
 

--- a/src/Streamly/Data/Unicode/Stream.hs
+++ b/src/Streamly/Data/Unicode/Stream.hs
@@ -8,25 +8,21 @@
 -- Stability   : experimental
 -- Portability : GHC
 --
--- A unicode string can be represented either as a stream of 'Char' e.g.
--- 'SerialT' 'Identity' 'Char' or as 'Array' 'Char'.  Unicode text processing
--- can be done efficiently by applying stream operations and folds on the
--- stream of 'Char'. When using 'Array' 'Char' direct array operations can be
--- applied where available or the array can be read into a stream and then
--- processed using stream operations. Use 'Array' 'Char' when you need to store
--- or buffer strings temporarily in memory.  Streams in 'Identity' monad and
--- 'Array' 'Char' are instances of 'IsString' and 'IsList', therefore,
+-- A byte stream of Unicode text can be decoded into a stream of 'Char' and
+-- processed efficiently using regular stream processing operations. A stream
+-- of 'Char' can be encoded into a byte stream using UTF formats and written to
+-- IO devices.
+--
+-- If you have to store a unicode string in memory you can either write it as a
+-- pure stream "SerialT Identity Char" or write the 'Char' stream as "Array
+-- Char". If space efficiency is a concern you can UTF8 encode the 'Char'
+-- stream and then write it as "Array Word8".  "SerialT Identity Char" and
+-- "Array Char" are instances of 'IsString' and 'IsList', therefore,
 -- 'OverloadedStrings' and 'OverloadedLists' extensions can be used for
 -- convenience.
 --
--- 'Array' 'Char' is usually perfectly fine to buffer short to medium or even
--- large amounts of text in memory. Also, it is computationally efficient as
--- there is no encoding/decoding involved.  We recommend using true streaming
--- operations to avoid buffering large amounts of data as long as possible e.g.
--- use `foldLines` instead of `lines`. However, if for some reason you are
--- buffering very large amounts of text in memory and are worried about space
--- efficiency you can use 'encodeUtf8' on the stream to convert it to a utf8
--- encoded 'Array' 'Word8'.
+-- Some experimental APIs to conveniently process text using "Array Char"
+-- represenation can be found in "Streamly.Internal.Unicode.Array".
 --
 -- Please note the following:
 --
@@ -43,13 +39,13 @@
 module Streamly.Data.Unicode.Stream
     (
     -- * Construction (Decoding)
-      decodeChar8
+      decodeLatin1
     , decodeUtf8
-    , decodeUtf8Lenient
+    , decodeUtf8Lax
 
     -- * Elimination (Encoding)
-    , encodeChar8
-    , encodeChar8Unchecked
+    , encodeLatin1
+    , encodeLatin1Lax
     , encodeUtf8
     {-
     -- * Operations on character strings
@@ -57,14 +53,15 @@ module Streamly.Data.Unicode.Stream
     , stripEnd
     , stripStart
     -}
-    -- * Transformation
-    , foldLines
-    , foldWords
-    , unfoldLines
-    , unfoldWords
+    -- Not exposing these yet as we have consider these with respect to Unicode
+    -- segmentation routines which are yet to be implemented.
+    -- -- * Transformation
+    -- , lines
+    -- , words
+    -- , unlines
+    -- , unwords
     )
 where
 
 import Streamly.Internal.Data.Unicode.Stream
 import Prelude hiding (lines, words, unlines, unwords)
-import qualified Streamly.Streams.StreamD as D

--- a/src/Streamly/Internal/Data/Unicode/Char.hs
+++ b/src/Streamly/Internal/Data/Unicode/Char.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE FlexibleContexts #-}
+-- |
+-- Module      : Streamly.Data.Internal.Unicode.Char
+-- Copyright   : (c) 2018 Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : streamly@composewell.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+module Streamly.Internal.Data.Unicode.Char
+    (
+    -- * Unicode aware operations
+    {-
+      toCaseFold
+    , toLower
+    , toUpper
+    , toTitle
+    -}
+    )
+where
+
+-- import Streamly (IsStream)
+
+-------------------------------------------------------------------------------
+-- Unicode aware operations on strings
+-------------------------------------------------------------------------------
+
+{-
+-- |
+-- /undefined/
+toCaseFold :: IsStream t => Char -> t m Char
+toCaseFold = undefined
+
+-- |
+-- /undefined/
+toLower :: IsStream t => Char -> t m Char
+toLower = undefined
+
+-- |
+-- /undefined/
+toUpper :: IsStream t => Char -> t m Char
+toUpper = undefined
+
+-- |
+-- /undefined/
+toTitle :: IsStream t => Char -> t m Char
+toTitle = undefined
+-}

--- a/src/Streamly/Internal/Data/Unicode/Stream.hs
+++ b/src/Streamly/Internal/Data/Unicode/Stream.hs
@@ -1,52 +1,14 @@
 {-# LANGUAGE FlexibleContexts #-}
 -- |
--- Module      : Streamly.Data.String
+-- Module      : Streamly.Data.Internal.Unicode.Stream
 -- Copyright   : (c) 2018 Composewell Technologies
 --
 -- License     : BSD3
--- Maintainer  : harendra.kumar@gmail.com
+-- Maintainer  : streamly@composewell.com
 -- Stability   : experimental
 -- Portability : GHC
 --
--- A unicode string can be represented either as a stream of 'Char' e.g.
--- 'SerialT' 'Identity' 'Char' or as 'Array' 'Char'.  Unicode text processing
--- can be done efficiently by applying stream operations and folds on the
--- stream of 'Char'. When using 'Array' 'Char' direct array operations can be
--- applied where available or the array can be read into a stream and then
--- processed using stream operations. Use 'Array' 'Char' when you need to store
--- or buffer strings temporarily in memory.  Streams in 'Identity' monad and
--- 'Array' 'Char' are instances of 'IsString' and 'IsList', therefore,
--- 'OverloadedStrings' and 'OverloadedLists' extensions can be used for
--- convenience.
---
--- 'Array' 'Char' is usually perfectly fine to buffer short to medium or even
--- large amounts of text in memory. Also, it is computationally efficient as
--- there is no encoding/decoding involved.  We recommend using true streaming
--- operations to avoid buffering large amounts of data as long as possible e.g.
--- use `foldLines` instead of `lines`. However, if for some reason you are
--- buffering very large amounts of text in memory and are worried about space
--- efficiency you can use 'encodeUtf8' on the stream to convert it to a utf8
--- encoded 'Array' 'Word8'.
---
--- Please note the following:
---
--- * Case conversion: Some unicode characters translate to more than one code
--- point on case conversion. The 'toUpper' and 'toLower' functions in @base@
--- package do not handle such characters. Therefore, operations like @map
--- toUpper@ on a character stream or character array may not always perform
--- correct conversion.
--- * String comparison: In some cases, visually identical strings may have
--- different unicode representations, therefore, a character stream or
--- character array cannot be directly compared. A normalized comparison may be
--- needed to check string equivalence correctly.
-
--- See "Streamly.Internal.Data.List", <src/docs/streamly-vs-lists.md> for more details and
--- <src/test/PureStreams.hs> for comprehensive usage examples.
-
--- TBD write a note on performance comparison with text, bytestrings, lists and
--- vector.
---
-module Streamly.Data.String
+module Streamly.Internal.Data.Unicode.Stream
     (
     -- * Construction (Decoding)
       decodeChar8

--- a/src/Streamly/Internal/Data/Unicode/Stream.hs
+++ b/src/Streamly/Internal/Data/Unicode/Stream.hs
@@ -11,9 +11,9 @@
 module Streamly.Internal.Data.Unicode.Stream
     (
     -- * Construction (Decoding)
-      decodeChar8
+      decodeLatin1
     , decodeUtf8
-    , decodeUtf8Lenient
+    , decodeUtf8Lax
     , D.DecodeError(..)
     , D.DecodeState
     , D.CodePoint
@@ -23,27 +23,16 @@ module Streamly.Internal.Data.Unicode.Stream
     , decodeUtf8ArraysLenient
 
     -- * Elimination (Encoding)
-    , encodeChar8
-    , encodeChar8Unchecked
+    , encodeLatin1
+    , encodeLatin1Lax
     , encodeUtf8
-{-
-    -- * Unicode aware operations
-    , toCaseFold
-    , toLower
-    , toUpper
-    , toTitle
-
+    {-
     -- * Operations on character strings
     , strip -- (dropAround isSpace)
-    , stripEnd-}
+    , stripEnd
+    -}
     -- * Transformation
     , stripStart
-    , foldLines
-    , foldWords
-    , unfoldLines
-    , unfoldWords
-
-    -- * Streams of Strings
     , lines
     , words
     , unlines
@@ -55,24 +44,14 @@ import Control.Monad.IO.Class (MonadIO)
 import Data.Char (ord)
 import Data.Word (Word8)
 import GHC.Base (unsafeChr)
-import Streamly (IsStream, MonadAsync)
+import Streamly (IsStream)
 import Prelude hiding (String, lines, words, unlines, unwords)
 import Streamly.Data.Fold (Fold)
 import Streamly.Memory.Array (Array)
 import Streamly.Internal.Data.Unfold (Unfold)
 
 import qualified Streamly.Internal.Prelude as S
-import qualified Streamly.Memory.Array as A
 import qualified Streamly.Streams.StreamD as D
-
--- type String = List Char
-
--------------------------------------------------------------------------------
--- Encoding/Decoding Characters
--------------------------------------------------------------------------------
-
--- decodeWith :: TextEncoding -> t m Word8 -> t m Char
--- decodeWith = undefined
 
 -------------------------------------------------------------------------------
 -- Encoding/Decoding Unicode Characters
@@ -80,37 +59,48 @@ import qualified Streamly.Streams.StreamD as D
 
 -- | Decode a stream of bytes to Unicode characters by mapping each byte to a
 -- corresponding Unicode 'Char' in 0-255 range.
-{-# INLINE decodeChar8 #-}
-decodeChar8 :: (IsStream t, Monad m) => t m Word8 -> t m Char
-decodeChar8 = S.map (unsafeChr . fromIntegral)
+--
+-- /Since: 0.7.0/
+{-# INLINE decodeLatin1 #-}
+decodeLatin1 :: (IsStream t, Monad m) => t m Word8 -> t m Char
+decodeLatin1 = S.map (unsafeChr . fromIntegral)
 
 -- | Encode a stream of Unicode characters to bytes by mapping each character
 -- to a byte in 0-255 range. Throws an error if the input stream contains
 -- characters beyond 255.
-{-# INLINE encodeChar8 #-}
-encodeChar8 :: (IsStream t, Monad m) => t m Char -> t m Word8
-encodeChar8 = S.map convert
+--
+-- /Since: 0.7.0/
+{-# INLINE encodeLatin1 #-}
+encodeLatin1 :: (IsStream t, Monad m) => t m Char -> t m Word8
+encodeLatin1 = S.map convert
     where
     convert c =
         let codepoint = ord c
         in if codepoint > 255
-           then error $ "Streamly.String.encodeChar8 invalid \
+           then error $ "Streamly.String.encodeLatin1 invalid \
                     \input char codepoint " ++ show codepoint
            else fromIntegral codepoint
 
--- | Like 'encodeChar8' but silently truncates and maps input characters beyond
+-- | Like 'encodeLatin1' but silently truncates and maps input characters beyond
 -- 255 to (incorrect) chars in 0-255 range. No error or exception is thrown
 -- when such truncation occurs.
-{-# INLINE encodeChar8Unchecked #-}
-encodeChar8Unchecked :: (IsStream t, Monad m) => t m Char -> t m Word8
-encodeChar8Unchecked = S.map (fromIntegral . ord)
+--
+-- /Since: 0.7.0/
+{-# INLINE encodeLatin1Lax #-}
+encodeLatin1Lax :: (IsStream t, Monad m) => t m Char -> t m Word8
+encodeLatin1Lax = S.map (fromIntegral . ord)
 
 -- | Decode a UTF-8 encoded bytestream to a stream of Unicode characters.
 -- The incoming stream is truncated if an invalid codepoint is encountered.
+--
+-- /Since: 0.7.0/
 {-# INLINE decodeUtf8 #-}
 decodeUtf8 :: (Monad m, IsStream t) => t m Word8 -> t m Char
 decodeUtf8 = D.fromStreamD . D.decodeUtf8 . D.toStreamD
 
+-- |
+--
+-- /Internal/
 {-# INLINE decodeUtf8Arrays #-}
 decodeUtf8Arrays :: (MonadIO m, IsStream t) => t m (Array Word8) -> t m Char
 decodeUtf8Arrays = D.fromStreamD . D.decodeUtf8Arrays . D.toStreamD
@@ -118,15 +108,23 @@ decodeUtf8Arrays = D.fromStreamD . D.decodeUtf8Arrays . D.toStreamD
 -- | Decode a UTF-8 encoded bytestream to a stream of Unicode characters.
 -- Any invalid codepoint encountered is replaced with the unicode replacement
 -- character.
-{-# INLINE decodeUtf8Lenient #-}
-decodeUtf8Lenient :: (Monad m, IsStream t) => t m Word8 -> t m Char
-decodeUtf8Lenient = D.fromStreamD . D.decodeUtf8Lenient . D.toStreamD
+--
+-- /Since: 0.7.0/
+{-# INLINE decodeUtf8Lax #-}
+decodeUtf8Lax :: (Monad m, IsStream t) => t m Word8 -> t m Char
+decodeUtf8Lax = D.fromStreamD . D.decodeUtf8Lenient . D.toStreamD
 
+-- |
+--
+-- /Internal/
 {-# INLINE decodeUtf8Either #-}
 decodeUtf8Either :: (Monad m, IsStream t)
     => t m Word8 -> t m (Either D.DecodeError Char)
 decodeUtf8Either = D.fromStreamD . D.decodeUtf8Either . D.toStreamD
 
+-- |
+--
+-- /Internal/
 {-# INLINE resumeDecodeUtf8Either #-}
 resumeDecodeUtf8Either
     :: (Monad m, IsStream t)
@@ -137,6 +135,9 @@ resumeDecodeUtf8Either
 resumeDecodeUtf8Either st cp =
     D.fromStreamD . D.resumeDecodeUtf8Either st cp . D.toStreamD
 
+-- |
+--
+-- /Internal/
 {-# INLINE decodeUtf8ArraysLenient #-}
 decodeUtf8ArraysLenient ::
        (MonadIO m, IsStream t) => t m (Array Word8) -> t m Char
@@ -144,27 +145,13 @@ decodeUtf8ArraysLenient =
     D.fromStreamD . D.decodeUtf8ArraysLenient . D.toStreamD
 
 -- | Encode a stream of Unicode characters to a UTF-8 encoded bytestream.
+--
+-- /Since: 0.7.0/
 {-# INLINE encodeUtf8 #-}
 encodeUtf8 :: (Monad m, IsStream t) => t m Char -> t m Word8
 encodeUtf8 = D.fromStreamD . D.encodeUtf8 . D.toStreamD
 
 {-
--------------------------------------------------------------------------------
--- Unicode aware operations on strings
--------------------------------------------------------------------------------
-
-toCaseFold :: IsStream t => t m Char -> t m Char
-toCaseFold = undefined
-
-toLower :: IsStream t => t m Char -> t m Char
-toLower = undefined
-
-toUpper :: IsStream t => t m Char -> t m Char
-toUpper = undefined
-
-toTitle :: IsStream t => t m Char -> t m Char
-toTitle = undefined
-
 -------------------------------------------------------------------------------
 -- Utility operations on strings
 -------------------------------------------------------------------------------
@@ -179,6 +166,8 @@ stripEnd = undefined
 -- | Remove leading whitespace from a string.
 --
 -- > stripStart = S.dropWhile isSpace
+--
+-- /Internal/
 {-# INLINE stripStart #-}
 stripStart :: (Monad m, IsStream t) => t m Char -> t m Char
 stripStart = S.dropWhile isSpace
@@ -186,26 +175,15 @@ stripStart = S.dropWhile isSpace
 -- | Fold each line of the stream using the supplied 'Fold'
 -- and stream the result.
 --
--- >>> S.toList $ foldLines FL.toList (S.fromList "lines\nthis\nstring\n\n\n")
+-- >>> S.toList $ lines FL.toList (S.fromList "lines\nthis\nstring\n\n\n")
 -- ["lines", "this", "string", "", ""]
 --
--- > foldLines = S.splitOnSuffix (== '\n')
+-- > lines = S.splitOnSuffix (== '\n')
 --
-{-# INLINE foldLines #-}
-foldLines :: (Monad m, IsStream t) => Fold m Char b -> t m Char -> t m b
-foldLines = S.splitOnSuffix (== '\n')
-
--- | Fold each word of the stream using the supplied 'Fold'
--- and stream the result.
---
--- >>>  S.toList $ foldWords FL.toList (S.fromList "fold these     words")
--- ["fold", "these", "words"]
---
--- > foldWords = S.wordsBy isSpace
---
-{-# INLINE foldWords #-}
-foldWords :: (Monad m, IsStream t) => Fold m Char b -> t m Char -> t m b
-foldWords = S.wordsBy isSpace
+-- /Internal/
+{-# INLINE lines #-}
+lines :: (Monad m, IsStream t) => Fold m Char b -> t m Char -> t m b
+lines = S.splitOnSuffix (== '\n')
 
 foreign import ccall unsafe "u_iswspace"
   iswspace :: Int -> Int
@@ -219,79 +197,32 @@ isSpace c
   where
     uc = fromIntegral (ord c) :: Word
 
--- | Break a string up into a stream of strings at newline characters.
--- The resulting strings do not contain newlines.
+-- | Fold each word of the stream using the supplied 'Fold'
+-- and stream the result.
 --
--- > lines = foldLines A.write
+-- >>>  S.toList $ words FL.toList (S.fromList "fold these     words")
+-- ["fold", "these", "words"]
 --
--- >>> S.toList $ lines $ S.fromList "lines\nthis\nstring\n\n\n"
--- ["lines","this","string","",""]
+-- > words = S.wordsBy isSpace
 --
--- If you're dealing with lines of massive length, consider using
--- 'foldLines' instead to avoid buffering the data in 'Array'.
-{-# INLINE lines #-}
-lines :: (MonadIO m, IsStream t) => t m Char -> t m (Array Char)
-lines = foldLines A.write
-
--- | Break a string up into a stream of strings, which were delimited
--- by characters representing white space.
---
--- > words = foldWords A.write
---
--- >>> S.toList $ words $ S.fromList "A  newline\nis considered white space?"
--- ["A", "newline", "is", "considered", "white", "space?"]
---
--- If you're dealing with words of massive length, consider using
--- 'foldWords' instead to avoid buffering the data in 'Array'.
+-- /Internal/
 {-# INLINE words #-}
-words :: (MonadIO m, IsStream t) => t m Char -> t m (Array Char)
-words = foldWords A.write
+words :: (Monad m, IsStream t) => Fold m Char b -> t m Char -> t m b
+words = S.wordsBy isSpace
 
 -- | Unfold a stream to character streams using the supplied 'Unfold'
 -- and concat the results suffixing a newline character @\\n@ to each stream.
 --
-{-# INLINE unfoldLines #-}
-unfoldLines :: (MonadIO m, IsStream t) => Unfold m a Char -> t m a -> t m Char
-unfoldLines = S.interposeSuffix '\n'
-
--- | Flattens the stream of @Array Char@, after appending a terminating
--- newline to each string.
---
--- 'unlines' is an inverse operation to 'lines'.
---
--- >>> S.toList $ unlines $ S.fromList ["lines", "this", "string"]
--- "lines\nthis\nstring\n"
---
--- > unlines = unfoldLines A.read
---
--- Note that, in general
---
--- > unlines . lines /= id
+-- /Internal/
 {-# INLINE unlines #-}
-unlines :: (MonadIO m, IsStream t) => t m (Array Char) -> t m Char
-unlines = unfoldLines A.read
+unlines :: (MonadIO m, IsStream t) => Unfold m a Char -> t m a -> t m Char
+unlines = S.interposeSuffix '\n'
 
 -- | Unfold the elements of a stream to character streams using the supplied
 -- 'Unfold' and concat the results with a whitespace character infixed between
 -- the streams.
 --
-{-# INLINE unfoldWords #-}
-unfoldWords :: (MonadIO m, IsStream t) => Unfold m a Char -> t m a -> t m Char
-unfoldWords = S.interpose ' '
-
--- | Flattens the stream of @Array Char@, after appending a separating
--- space to each string.
---
--- 'unwords' is an inverse operation to 'words'.
---
--- >>> S.toList $ unwords $ S.fromList ["unwords", "this", "string"]
--- "unwords this string"
---
--- > unwords = unfoldWords A.read
---
--- Note that, in general
---
--- > unwords . words /= id
+-- /Internal/
 {-# INLINE unwords #-}
-unwords :: (MonadAsync m, IsStream t) => t m (Array Char) -> t m Char
-unwords = unfoldWords A.read
+unwords :: (MonadIO m, IsStream t) => Unfold m a Char -> t m a -> t m Char
+unwords = S.interpose ' '

--- a/src/Streamly/Internal/Memory/Unicode/Array.hs
+++ b/src/Streamly/Internal/Memory/Unicode/Array.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE FlexibleContexts #-}
+-- |
+-- Module      : Streamly.Memory.Internal.Unicode.Array
+-- Copyright   : (c) 2018 Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : streamly@composewell.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+module Streamly.Internal.Memory.Unicode.Array
+    (
+    -- * Streams of Strings
+      lines
+    , words
+    , unlines
+    , unwords
+    )
+where
+
+import Control.Monad.IO.Class (MonadIO)
+import Streamly (IsStream, MonadAsync)
+import Prelude hiding (String, lines, words, unlines, unwords)
+import Streamly.Memory.Array (Array)
+
+import qualified Streamly.Internal.Data.Unicode.Stream as S
+import qualified Streamly.Memory.Array as A
+
+-- | Break a string up into a stream of strings at newline characters.
+-- The resulting strings do not contain newlines.
+--
+-- > lines = S.lines A.write
+--
+-- >>> S.toList $ lines $ S.fromList "lines\nthis\nstring\n\n\n"
+-- ["lines","this","string","",""]
+--
+{-# INLINE lines #-}
+lines :: (MonadIO m, IsStream t) => t m Char -> t m (Array Char)
+lines = S.lines A.write
+
+-- | Break a string up into a stream of strings, which were delimited
+-- by characters representing white space.
+--
+-- > words = S.words A.write
+--
+-- >>> S.toList $ words $ S.fromList "A  newline\nis considered white space?"
+-- ["A", "newline", "is", "considered", "white", "space?"]
+--
+{-# INLINE words #-}
+words :: (MonadIO m, IsStream t) => t m Char -> t m (Array Char)
+words = S.words A.write
+
+-- | Flattens the stream of @Array Char@, after appending a terminating
+-- newline to each string.
+--
+-- 'unlines' is an inverse operation to 'lines'.
+--
+-- >>> S.toList $ unlines $ S.fromList ["lines", "this", "string"]
+-- "lines\nthis\nstring\n"
+--
+-- > unlines = S.unlines A.read
+--
+-- Note that, in general
+--
+-- > unlines . lines /= id
+{-# INLINE unlines #-}
+unlines :: (MonadIO m, IsStream t) => t m (Array Char) -> t m Char
+unlines = S.unlines A.read
+
+-- | Flattens the stream of @Array Char@, after appending a separating
+-- space to each string.
+--
+-- 'unwords' is an inverse operation to 'words'.
+--
+-- >>> S.toList $ unwords $ S.fromList ["unwords", "this", "string"]
+-- "unwords this string"
+--
+-- > unwords = S.unwords A.read
+--
+-- Note that, in general
+--
+-- > unwords . words /= id
+{-# INLINE unwords #-}
+unwords :: (MonadAsync m, IsStream t) => t m (Array Char) -> t m Char
+unwords = S.unwords A.read

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -283,7 +283,7 @@ library
     exposed-modules:   Streamly.Prelude
                      , Streamly
                      , Streamly.Data.Fold
-                     , Streamly.Data.String
+                     , Streamly.Data.Unicode.Stream
 
                     -- IO devices
                      , Streamly.Memory.Array
@@ -312,6 +312,7 @@ library
                      , Streamly.Internal.Data.List
                      , Streamly.Internal.FileSystem.Handle
                      , Streamly.Internal.FileSystem.File
+                     , Streamly.Internal.Data.Unicode.Stream
                      , Streamly.Internal.Prelude
     if !impl(ghcjs)
        exposed-modules:

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -313,6 +313,8 @@ library
                      , Streamly.Internal.FileSystem.Handle
                      , Streamly.Internal.FileSystem.File
                      , Streamly.Internal.Data.Unicode.Stream
+                     , Streamly.Internal.Data.Unicode.Char
+                     , Streamly.Internal.Memory.Unicode.Array
                      , Streamly.Internal.Prelude
     if !impl(ghcjs)
        exposed-modules:

--- a/test/String.hs
+++ b/test/String.hs
@@ -15,7 +15,7 @@ import           Test.Hspec as H
 import qualified Streamly.Memory.Array as A
 import qualified Streamly.Internal.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
-import qualified Streamly.Data.String as SS
+import qualified Streamly.Data.Unicode.Stream as SS
 
 -- Coverage build takes too long with default number of tests
 {-

--- a/test/String.hs
+++ b/test/String.hs
@@ -16,6 +16,7 @@ import qualified Streamly.Memory.Array as A
 import qualified Streamly.Internal.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Data.Unicode.Stream as SS
+import qualified Streamly.Internal.Data.Unicode.Stream as IUS
 
 -- Coverage build takes too long with default number of tests
 {-
@@ -56,7 +57,7 @@ propDecodeEncodeIdArrays =
     forAll genUnicode $ \list ->
         monadicIO $ do
             let wrds = SS.encodeUtf8 $ S.fromList list
-            chrs <- S.toList $ SS.decodeUtf8ArraysLenient
+            chrs <- S.toList $ IUS.decodeUtf8ArraysLenient
                                     (S.fold A.write wrds)
             assert (chrs == list)
 
@@ -66,7 +67,7 @@ testLines =
         monadicIO $ do
             xs <- S.toList
                 $ S.map A.toList
-                $ SS.lines
+                $ IUS.lines
                 $ S.fromList list
             assert (xs == lines list)
 
@@ -87,7 +88,7 @@ testWords =
         monadicIO $ do
             xs <- S.toList
                 $ S.map A.toList
-                $ SS.words
+                $ IUS.words
                 $ S.fromList list
             assert (xs == words list)
 
@@ -96,8 +97,8 @@ testUnlines =
   forAll genUnicode $ \list ->
       monadicIO $ do
           xs <- S.toList
-              $ SS.unlines
-              $ SS.lines
+              $ IUS.unlines
+              $ IUS.lines
               $ S.fromList list
           assert (xs == unlines (lines list))
 
@@ -107,8 +108,8 @@ testUnwords =
       monadicIO $ do
           xs <- run
               $ S.toList
-              $ SS.unwords
-              $ SS.words
+              $ IUS.unwords
+              $ IUS.words
               $ S.fromList list
           assert (xs == unwords (words list))
 

--- a/test/String.hs
+++ b/test/String.hs
@@ -17,6 +17,7 @@ import qualified Streamly.Internal.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Data.Unicode.Stream as SS
 import qualified Streamly.Internal.Data.Unicode.Stream as IUS
+import qualified Streamly.Internal.Memory.Unicode.Array as IUA
 
 -- Coverage build takes too long with default number of tests
 {-
@@ -49,7 +50,7 @@ propDecodeEncodeIdLenient =
     forAll genUnicode $ \list ->
         monadicIO $ do
             let wrds = SS.encodeUtf8 $ S.fromList list
-            chrs <- S.toList $ SS.decodeUtf8Lenient wrds
+            chrs <- S.toList $ SS.decodeUtf8Lax wrds
             assert (chrs == list)
 
 propDecodeEncodeIdArrays :: Property
@@ -67,7 +68,7 @@ testLines =
         monadicIO $ do
             xs <- S.toList
                 $ S.map A.toList
-                $ IUS.lines
+                $ IUA.lines
                 $ S.fromList list
             assert (xs == lines list)
 
@@ -88,7 +89,7 @@ testWords =
         monadicIO $ do
             xs <- S.toList
                 $ S.map A.toList
-                $ IUS.words
+                $ IUA.words
                 $ S.fromList list
             assert (xs == words list)
 
@@ -97,8 +98,8 @@ testUnlines =
   forAll genUnicode $ \list ->
       monadicIO $ do
           xs <- S.toList
-              $ IUS.unlines
-              $ IUS.lines
+              $ IUA.unlines
+              $ IUA.lines
               $ S.fromList list
           assert (xs == unlines (lines list))
 
@@ -108,8 +109,8 @@ testUnwords =
       monadicIO $ do
           xs <- run
               $ S.toList
-              $ IUS.unwords
-              $ IUS.words
+              $ IUA.unwords
+              $ IUA.words
               $ S.fromList list
           assert (xs == unwords (words list))
 
@@ -120,7 +121,7 @@ main = hspec
     $ do
     describe "UTF8 - Encoding / Decoding" $ do
         prop "decodeUtf8 . encodeUtf8 == id" $ propDecodeEncodeId
-        prop "decodeUtf8Lenient . encodeUtf8 == id" $ propDecodeEncodeIdLenient
+        prop "decodeUtf8Lax . encodeUtf8 == id" $ propDecodeEncodeIdLenient
         prop "decodeUtf8ArraysLenient . encodeUtf8 == id"
                 $ propDecodeEncodeIdArrays
         prop "Streamly.Data.String.lines == Prelude.lines" $ testLines


### PR DESCRIPTION
We will have at least two modules for unicode string handling APIs

1) `Streamly.Data.Unicode.Stream` - for converting utf8/16/32 encoded Word8 streams to Char streams and vice-versa. It will also have unicode stream segmentation and collation routines ultimately.
2) `Streamly.Data.Unicode.Char` - for Unicode character properties, character transformations etc.

For Storage of unicode strings in memory we can have:

1) `Streamly.Memory.Unicode.Utf8/Utf16LE/Utf16BE/Utf32LE/Utf32BE` etc. these could be newtypes representing arrays containing Utf8/16/32 format strings in memory.