### PR TITLE
Rename some IO APIs and update documentation

### DIFF
--- a/examples/EchoServer.hs
+++ b/examples/EchoServer.hs
@@ -12,5 +12,8 @@ main :: IO ()
 main = S.drain
     $ parallely $ S.mapM (useWith echo)
     $ serially $ S.unfold TCP.acceptOnPort 8090
-    where echo sk = S.fold (writeArrays sk) $ S.unfold readArraysOf (32768, sk)
-          useWith f sk = finally (liftIO (Net.close sk)) (f sk)
+    where
+    echo sk =
+          S.fold (writeChunks sk)
+        $ S.unfold readChunksRequestsOf (32768, sk)
+    useWith f sk = finally (liftIO (Net.close sk)) (f sk)

--- a/examples/FileIOExamples.hs
+++ b/examples/FileIOExamples.hs
@@ -8,13 +8,19 @@ import Data.Char (ord)
 import System.Environment (getArgs)
 
 cat :: FilePath -> IO ()
-cat src = File.writeArrays "/dev/stdout" $ File.toStreamArraysOf (256*1024) src
+cat src =
+      File.writeChunks "/dev/stdout"
+    $ File.toChunksRequestsOf (256*1024) src
 
 cp :: FilePath -> FilePath -> IO ()
-cp src dst = File.writeArrays dst $ File.toStreamArraysOf (256*1024) src
+cp src dst =
+      File.writeChunks dst
+    $ File.toChunksRequestsOf (256*1024) src
 
 append :: FilePath -> FilePath -> IO ()
-append src dst = File.appendArrays dst $ File.toStreamArraysOf (256*1024) src
+append src dst =
+      File.appendChunks dst
+    $ File.toChunksRequestsOf (256*1024) src
 
 ord' :: Num a => Char -> a
 ord' = (fromIntegral . ord)

--- a/examples/FromFileClient.hs
+++ b/examples/FromFileClient.hs
@@ -16,6 +16,6 @@ main :: IO ()
 main =
     let sendFile file =
             withFile file ReadMode $ \src ->
-                  S.fold (TCP.writeArrays (127, 0, 0, 1) 8090)
-                $ IFH.toStreamArrays src
+                  S.fold (TCP.writeChunks (127, 0, 0, 1) 8090)
+                $ IFH.toChunks src
      in getArgs >>= S.drain . parallely . S.mapM sendFile . S.fromList

--- a/examples/HandleIO.hs
+++ b/examples/HandleIO.hs
@@ -6,19 +6,23 @@ import qualified Streamly.Internal.FileSystem.Handle as IFH
 import qualified Streamly.FileSystem.Handle as FH
 import qualified System.IO as FH
 -- import qualified Streamly.FileSystem.FD as FH
--- import qualified Streamly.String as SS
+-- import qualified Streamly.Data.Unicode.Stream as US
 
 import Data.Char (ord)
 import System.Environment (getArgs)
 import System.IO (IOMode(..), hSeek, SeekMode(..))
 
 cat :: FH.Handle -> IO ()
-cat src = S.fold (IFH.writeArrays FH.stdout) $ IFH.toStreamArraysOf (256*1024) src
+cat src =
+      S.fold (FH.writeChunks FH.stdout)
+    $ IFH.toChunksRequestsOf (256*1024) src
 -- byte stream version
 -- cat src = S.fold (FH.write FH.stdout) $ FH.read src
 
 cp :: FH.Handle -> FH.Handle -> IO ()
-cp src dst = S.fold (IFH.writeArrays dst) $ IFH.toStreamArraysOf (256*1024) src
+cp src dst =
+      S.fold (FH.writeChunks dst)
+    $ IFH.toChunksRequestsOf (256*1024) src
 -- byte stream version
 -- cp src dst = S.fold (FH.write dst) $ FH.read src
 
@@ -28,12 +32,12 @@ ord' = (fromIntegral . ord)
 wcl :: FH.Handle -> IO ()
 wcl src = print =<< (S.length
     $ AS.splitOn 10
-    $ IFH.toStreamArrays src)
+    $ IFH.toChunks src)
 {-
 -- Char stream version
 wcl src = print =<< (S.length
-    $ flip SS.foldLines FL.drain
-    $ SS.decodeChar8
+    $ flip US.lines FL.drain
+    $ US.decodeLatin1
     $ FH.read src)
 -}
 

--- a/examples/WordCount.hs
+++ b/examples/WordCount.hs
@@ -608,7 +608,7 @@ wc_mwl_parallel src n = do
         $ S.aheadly
         $ S.maxThreads numCapabilities
         $ S.mapM (countArray)
-        $ S.unfold FH.readArraysOf (n, src)
+        $ S.unfold FH.readChunksRequestsOf (n, src)
 
 -------------------------------------------------------------------------------
 -- Main

--- a/src/Streamly/Benchmark/FileIO/Stream.hs
+++ b/src/Streamly/Benchmark/FileIO/Stream.hs
@@ -153,7 +153,7 @@ countLinesU inh =
     S.length
         $ IUS.lines FL.drain
         $ SS.decodeLatin1
-        $ S.concatUnfold A.read (IFH.toStreamArrays inh)
+        $ S.concatUnfold A.read (IFH.toChunks inh)
 
 #ifdef INSPECTION
 inspect $ hasNoTypeClasses 'countLinesU
@@ -600,7 +600,7 @@ splitOnSeqUtf8 :: String -> Handle -> IO Int
 splitOnSeqUtf8 str inh =
     (S.length $ IP.splitOnSeq (A.fromList str) FL.drain
         $ IUS.decodeUtf8ArraysLenient
-        $ IFH.toStreamArrays inh) -- >>= print
+        $ IFH.toChunks inh) -- >>= print
 
 -- | Split on suffix sequence.
 {-# INLINE splitOnSuffixSeq #-}

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -25,8 +25,20 @@
 -- 'NewLineMode', and 'Buffering' options of the underlying handle provided by
 -- GHC are not needed and ignored.
 --
+-- = Programmer Notes
+--
 -- > import qualified Streamly.FileSystem.Handle as FH
 --
+-- For additional, experimental APIs take a look at
+-- "Streamly.Internal.FileSystem.Handle" module.
+--
+-- = Performance Notes
+--
+-- In some cases the stream type based APIs in the
+-- "Streamly.Internal.FileSystem.Handle" module may be more efficient compared
+-- to the unfold/fold based APIs exposed from this module because of better
+-- fusion by GHC. However, with the streamly fusion GHC plugin (upcoming) these
+-- APIs would perform as well as the stream based APIs in all cases.
 
 -- IO APIs are divided into two categories, sequential streaming IO APIs and
 -- random access IO APIs.
@@ -37,12 +49,14 @@ module Streamly.FileSystem.Handle
     -- | Stream data to or from a file or device sequentially.  When reading,
     -- the stream is lazy and generated on-demand as the consumer consumes it.
     -- Read IO requests to the IO device are performed in chunks limited to a
-    -- maximum size of 32KiB, this is referred to as @defaultChunkSize@ in the
+    -- maximum size of 32KiB, this is referred to as
+    -- 'Streamly.Internal.Memory.Array.Types.defaultChunkSize' in the
     -- documentation. One IO request may or may not read the full
     -- chunk. If the whole stream is not consumed, it is possible that we may
     -- read slightly more from the IO device than what the consumer needed.
     -- Unless specified otherwise in the API, writes are collected into chunks
-    -- of @defaultChunkSize@ before they are written to the IO device.
+    -- of 'Streamly.Internal.Memory.Array.Types.defaultChunkSize' before they
+    -- are written to the IO device.
 
     -- Streaming APIs work for all kind of devices, seekable or non-seekable;
     -- including disks, files, memory devices, terminals, pipes, sockets and
@@ -57,49 +71,20 @@ module Streamly.FileSystem.Handle
     -- position of the file handle. The stream ends as soon as EOF is
     -- encountered.
 
-    -- XXX once we have APIs to read any type 'a' the array stream
-    -- reading/writing APIs can be expressed in terms of the polymorphic API.
       read
-    -- , readUtf8
-    -- , readLines
-    -- , readFrames
-    , readInChunksOf
-    , readArraysOf
-    , readArrays
+    , readRequestsOf
+    , readChunks
+    , readChunksRequestsOf
 
     -- ** Write to Handle
     -- | 'TextEncoding', 'NewLineMode', and 'Buffering' options of the
     -- underlying handle are ignored. The write occurs from the current seek
     -- position of the file handle.  The write behavior depends on the 'IOMode'
     -- of the handle.
-    --
+
     , write
-    -- , writeUtf8
-    -- , writeUtf8ByLines
-    -- , writeByFrames
-    , writeInChunksOf
-    , writeArrays
-
-    -- -- * Random Access (Seek)
-    -- -- | Unlike the streaming APIs listed above, these APIs apply to devices or
-    -- files that have random access or seek capability.  This type of devices
-    -- include disks, files, memory devices and exclude terminals, pipes,
-    -- sockets and fifos.
-    --
-    -- , readIndex
-    --  XXX we can make the names consistent with the enumerate APIs. For
-    --  example, readFromTo, readFromToUp, readFromToDn, readFrom etc.
-    -- , readSlice
-    -- , readSliceRev
-    -- , readAt -- read from a given position to th end of file
-    -- , readSliceArrayUpto
-    -- , readSliceArrayOf
-
-    -- , writeIndex
-    -- , writeSlice
-    -- , writeSliceRev
-    -- , writeAt -- start writing at the given position
-    -- , writeSliceArray
+    , writeRequestsOf
+    , writeChunks
     )
 where
 

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -15,15 +15,18 @@
 -- for connected sockets do not need to explicitly specify the remote endpoint.
 -- APIs for unconnected sockets need to explicitly specify the remote endpoint.
 --
+-- = Programmer Notes
+--
 -- Read IO requests to connected stream sockets are performed in chunks of
--- 32KiB, this is referred to as @defaultChunkSize@ in the documentation. One
--- IO request may or may not read the full chunk.  Unless specified otherwise
--- in the API, writes are collected into chunks of @defaultChunkSize@ before
--- they are written to the socket. APIs are provided to control the chunking
--- and framing behavior.
+-- 'Streamly.Internal.Memory.Array.Types.defaultChunkSize'.  Unless specified
+-- otherwise in the API, writes are collected into chunks of
+-- 'Streamly.Internal.Memory.Array.Types.defaultChunkSize' before they are
+-- written to the socket. APIs are provided to control the chunking behavior.
 --
 -- > import qualified Streamly.Network.Socket as SK
 --
+-- For additional, experimental APIs take a look at
+-- "Streamly.Internal.Network.Socket" module.
 
 -- By design, connected socket IO APIs are similar to
 -- "Streamly.Memory.Array" read write APIs. They are almost identical to the
@@ -39,31 +42,14 @@ module Streamly.Network.Socket
 
     -- * Read
     , read
-    -- , readUtf8
-    -- , readLines
-    -- , readFrames
-    -- , readByChunks
-
-    -- -- * Array Read
-    -- , readArrayUpto
-    -- , readArrayOf
-
-    -- , readArraysUpto
-    , readArraysOf
-    -- , readArrays
+    , readRequestsOf
+    , readChunks
+    , readChunksRequestsOf
 
     -- * Write
     , write
-    -- , writeUtf8
-    -- , writeUtf8ByLines
-    -- , writeByFrames
-    -- , writeInChunksOf
-
-    -- -- * Array Write
-    -- , writeArray
-    , writeArrays
-
-    -- reading/writing datagrams
+    , writeRequestsOf
+    , writeChunks
     )
 where
 


### PR DESCRIPTION
* Renamed "Array" with a more generic "Chunk", because these APIs may apply to cases where our data structure may not be named "Array" and "Chunk" sounds more high level, not specific to a particular data structure.

* I was confused with `readInChunksOf` etc, made it explicitly `readRequestsOf` to denote that we are referring to the IO request sent to the device or the OS and not to what we are reading.