### PR TITLE
Hide internal modules in the Haddocks.

### DIFF
--- a/src/Streamly/Internal/Data/Atomics.hs
+++ b/src/Streamly/Internal/Data/Atomics.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP    #-}
+{-# OPTIONS_HADDOCK hide #-}
+{-# LANGUAGE CPP         #-}
 
 -- |
 -- Module      : Streamly.Internal.Data.Atomics

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -1,10 +1,11 @@
+{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
 
 -- |
 -- Module      : Streamly.Internal.Data.Fold

--- a/src/Streamly/Internal/Data/Fold/Types.hs
+++ b/src/Streamly/Internal/Data/Fold/Types.hs
@@ -1,6 +1,7 @@
+{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE CPP                       #-}
-{-# LANGUAGE ExistentialQuantification          #-}
-{-# LANGUAGE FlexibleContexts                   #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
 
 -- |
 -- Module      : Streamly.Internal.Data.Fold.Types

--- a/src/Streamly/Internal/Data/List.hs
+++ b/src/Streamly/Internal/Data/List.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide                #-}
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/src/Streamly/Internal/Data/Pipe.hs
+++ b/src/Streamly/Internal/Data/Pipe.hs
@@ -1,10 +1,11 @@
+{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
 
 -- |
 -- Module      : Streamly.Internal.Data.Pipe

--- a/src/Streamly/Internal/Data/Pipe/Types.hs
+++ b/src/Streamly/Internal/Data/Pipe/Types.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
 

--- a/src/Streamly/Internal/Data/SVar.hs
+++ b/src/Streamly/Internal/Data/SVar.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide                #-}
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE ConstraintKinds            #-}

--- a/src/Streamly/Internal/Data/Sink.hs
+++ b/src/Streamly/Internal/Data/Sink.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_HADDOCK hide #-}
+
 -- |
 -- Module      : Streamly.Internal.Data.Sink
 -- Copyright   : (c) 2019 Composewell Technologies

--- a/src/Streamly/Internal/Data/Sink/Types.hs
+++ b/src/Streamly/Internal/Data/Sink/Types.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_HADDOCK hide #-}
+
 -- |
 -- Module      : Streamly.Internal.Data.Sink.Types
 -- Copyright   : (c) 2019 Composewell Technologies

--- a/src/Streamly/Internal/Data/Strict.hs
+++ b/src/Streamly/Internal/Data/Strict.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_HADDOCK hide #-}
+
 -- |
 -- Module      : Streamly.Internal.Data.Strict
 -- Copyright   : (c) 2019 Composewell Technologies

--- a/src/Streamly/Internal/Data/Time.hs
+++ b/src/Streamly/Internal/Data/Time.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_HADDOCK hide #-}
+
 -- |
 -- Module      : Streamly.Internal.Data.Time
 -- Copyright   : (c) 2017 Harendra Kumar

--- a/src/Streamly/Internal/Data/Time/Clock.hsc
+++ b/src/Streamly/Internal/Data/Time/Clock.hsc
@@ -1,11 +1,12 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_HADDOCK hide                 #-}
+{-# LANGUAGE CPP                         #-}
+{-# LANGUAGE DeriveGeneric               #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving  #-}
+{-# LANGUAGE ScopedTypeVariables         #-}
 
 #if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-identities #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-identities          #-}
+{-# OPTIONS_GHC -Wno-orphans             #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 #endif
 

--- a/src/Streamly/Internal/Data/Time/Units.hs
+++ b/src/Streamly/Internal/Data/Time/Units.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP #-}
+{-# OPTIONS_HADDOCK hide                #-}
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 

--- a/src/Streamly/Internal/Data/Unfold.hs
+++ b/src/Streamly/Internal/Data/Unfold.hs
@@ -1,12 +1,13 @@
+{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE PatternSynonyms           #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TupleSections             #-}
 
 #include "inline.hs"
 

--- a/src/Streamly/Internal/Data/Unfold/Types.hs
+++ b/src/Streamly/Internal/Data/Unfold/Types.hs
@@ -1,6 +1,7 @@
+{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE CPP                       #-}
-{-# LANGUAGE ExistentialQuantification          #-}
-{-# LANGUAGE FlexibleContexts                   #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
 
 -- |
 -- Module      : Streamly.Internal.Data.Unfold.Types

--- a/src/Streamly/Internal/Data/Unicode/Char.hs
+++ b/src/Streamly/Internal/Data/Unicode/Char.hs
@@ -1,4 +1,6 @@
+{-# OPTIONS_HADDOCK hide      #-}
 {-# LANGUAGE FlexibleContexts #-}
+
 -- |
 -- Module      : Streamly.Data.Internal.Unicode.Char
 -- Copyright   : (c) 2018 Composewell Technologies

--- a/src/Streamly/Internal/Data/Unicode/Stream.hs
+++ b/src/Streamly/Internal/Data/Unicode/Stream.hs
@@ -1,4 +1,6 @@
+{-# OPTIONS_HADDOCK hide      #-}
 {-# LANGUAGE FlexibleContexts #-}
+
 -- |
 -- Module      : Streamly.Data.Internal.Unicode.Stream
 -- Copyright   : (c) 2018 Composewell Technologies

--- a/src/Streamly/Internal/FileSystem/File.hs
+++ b/src/Streamly/Internal/FileSystem/File.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_HADDOCK hide      #-}
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE MagicHash        #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE UnboxedTuples    #-}
 
 #include "inline.hs"
 

--- a/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/src/Streamly/Internal/FileSystem/Handle.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE MagicHash #-}
+{-# OPTIONS_HADDOCK hide     #-}
+{-# LANGUAGE CPP             #-}
+{-# LANGUAGE BangPatterns    #-}
+{-# LANGUAGE MagicHash       #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UnboxedTuples   #-}
 
 #include "inline.hs"
 

--- a/src/Streamly/Internal/Memory/Array.hs
+++ b/src/Streamly/Internal/Memory/Array.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UnboxedTuples #-}
+{-# OPTIONS_HADDOCK hide         #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE UnboxedTuples       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 #include "inline.hs"

--- a/src/Streamly/Internal/Memory/Array/Types.hs
+++ b/src/Streamly/Internal/Memory/Array/Types.hs
@@ -1,12 +1,13 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_HADDOCK hide               #-}
+{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UnboxedTuples #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MagicHash                 #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE UnboxedTuples             #-}
+{-# LANGUAGE FlexibleContexts          #-}
 #include "inline.hs"
 
 -- |

--- a/src/Streamly/Internal/Memory/ArrayStream.hs
+++ b/src/Streamly/Internal/Memory/ArrayStream.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UnboxedTuples #-}
+{-# OPTIONS_HADDOCK hide         #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE UnboxedTuples       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 #include "inline.hs"

--- a/src/Streamly/Internal/Memory/Unicode/Array.hs
+++ b/src/Streamly/Internal/Memory/Unicode/Array.hs
@@ -1,4 +1,6 @@
+{-# OPTIONS_HADDOCK hide      #-}
 {-# LANGUAGE FlexibleContexts #-}
+
 -- |
 -- Module      : Streamly.Memory.Internal.Unicode.Array
 -- Copyright   : (c) 2018 Composewell Technologies

--- a/src/Streamly/Internal/Network/Inet/TCP.hs
+++ b/src/Streamly/Internal/Network/Inet/TCP.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_HADDOCK hide      #-}
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE MagicHash        #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE UnboxedTuples    #-}
 
 #include "inline.hs"
 

--- a/src/Streamly/Internal/Network/Socket.hs
+++ b/src/Streamly/Internal/Network/Socket.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_HADDOCK hide      #-}
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE MagicHash        #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE UnboxedTuples    #-}
 
 #include "inline.hs"
 

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE CPP                       #-}
-{-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE FlexibleContexts          #-}
+{-# OPTIONS_HADDOCK hide      #-}
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE RankNTypes       #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 #if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans  #-}
 #endif
 
 #include "../Streams/inline.hs"


### PR DESCRIPTION
Also includes minor formatting changes to `{-# #-}` 