### PR TITLE
Hoist and generalizing routines

### DIFF
--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -48,6 +48,13 @@ benchIOSink
     => String -> (t IO Int -> IO b) -> Benchmark
 benchIOSink name f = bench name $ nfIO $ randomRIO (1,1) >>= f . Ops.source
 
+{-# INLINE benchHoistSink #-}
+benchHoistSink
+    :: (IsStream t, NFData b)
+    => String -> (t Identity Int -> IO b) -> Benchmark
+benchHoistSink name f =
+    bench name $ nfIO $ randomRIO (1,1) >>= f .  Ops.sourceUnfoldr
+
 -- XXX once we convert all the functions to use this we can rename this to
 -- benchIOSink
 {-# INLINE benchIOSink1 #-}
@@ -208,6 +215,7 @@ main =
         , benchIOSink "or" Ops.or
 
         , benchIOSink "length" Ops.length
+        , benchHoistSink "length . generally" (Ops.length . IP.generally)
         , benchIOSink "sum" Ops.sum
         , benchIOSink "product" Ops.product
 

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -296,6 +296,10 @@ main =
         , benchIOSink "tee" (Ops.transformTeeMapM serially 4)
         , benchIOSink "zip" (Ops.transformZipMapM serially 4)
         ]
+      , bgroup "transformer"
+        [ benchIOSrc serially "evalState" Ops.evalStateT
+        , benchIOSrc serially "withState" Ops.withState
+        ]
       , bgroup "transformation"
         [ benchIOSink "scanl" (Ops.scan 1)
         , benchIOSink "scanl1'" (Ops.scanl1' 1)

--- a/src/Streamly/Internal/Data/SVar.hs
+++ b/src/Streamly/Internal/Data/SVar.hs
@@ -536,7 +536,7 @@ defState = State
 -- appropriate unStream functions instead.
 --
 -- | Adapt the stream state from one type to another.
-adaptState :: State t m a -> State t m b
+adaptState :: State t m a -> State t n b
 adaptState st = st
     { streamVar = Nothing
     , _yieldLimit = Nothing

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -133,6 +133,8 @@ module Streamly.Internal.Prelude
 
     -- * Transformation
     , transform
+    , hoist
+    , generally
 
     -- ** Mapping
     , Serial.map
@@ -1468,6 +1470,15 @@ toPureRev = foldl' (flip K.cons) K.nil
 {-# INLINE transform #-}
 transform :: (IsStream t, Monad m) => Pipe m a b -> t m a -> t m b
 transform pipe xs = fromStreamD $ D.transform pipe (toStreamD xs)
+
+{-# INLINE hoist #-}
+hoist :: (Monad m, Monad n)
+    => (forall x. m x -> n x) -> SerialT m a -> SerialT n a
+hoist f xs = fromStreamS $ S.hoist f (toStreamS xs)
+
+{-# INLINE generally #-}
+generally :: (IsStream t, Monad m) => t Identity a -> t m a
+generally xs = fromStreamS $ S.hoist (return . runIdentity) (toStreamS xs)
 
 ------------------------------------------------------------------------------
 -- Transformation by Folding (Scans)


### PR DESCRIPTION
Added `hoist` and `generally`. The latter is a special case of `hoist` to generalize a pure stream to a general monad.

The StreamK code is based on #256 . The original code based on `uncons` required `MonaTrans t` and `Monad (t m)` constraints and was 2x slower (9ms vs 4ms for `length`) compared to the improved version by @pranaysashank .

However, the StreamK code is not being used in the exposed combinators. We are using the `StreamD` version which fuses well and is much faster (33 us for `length`), adding the `hoist` combinators makes no difference at all to `length`.