### PR TITLE
Additional combinators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,3 @@ cabal.project.local
 
 # Other
 .log
-*.swp
-*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ cabal.project.local
 *.swp
 *.swo
 *~
+
+# Other
+.log
+*.swp
+*.swo

--- a/benchmark/BaseStreams.hs
+++ b/benchmark/BaseStreams.hs
@@ -194,6 +194,7 @@ main =
         , benchD "dropOne"              D.iterateDropOne
         , benchD "dropWhileFalse(1/10)" D.iterateDropWhileFalse
         , benchD "dropWhileTrue"        D.iterateDropWhileTrue
+        , benchD "iterateM"             D.iterateM
         ]
       ]
     , bgroup "list"

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -232,6 +232,10 @@ main =
         , benchIOSink "drainN" (S.fold (IFL.drainN Ops.value))
         , benchIOSink "drainWhileTrue" (S.fold (IFL.drainWhile $ (<=) Ops.maxValue))
         , benchIOSink "drainWhileFalse" (S.fold (IFL.drainWhile $ (>=) Ops.maxValue))
+        -- XXX Change?
+        , benchIOSink "lastN.1" (S.fold (IFL.lastN 1 FL.length))
+        , benchIOSink "lastN.10" (S.fold (IFL.lastN 10 FL.length))
+        , benchIOSink "lastN.Max" (S.fold (IFL.lastN Ops.maxValue FL.length))
         , benchIOSink "sink" (S.fold $ Sink.toFold Sink.drain)
         , benchIOSink "last" (S.fold FL.last)
         , benchIOSink "length" (S.fold FL.length)

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -229,6 +229,9 @@ main =
         ]
       , bgroup "folds"
         [ benchIOSink "drain" (S.fold FL.drain)
+        , benchIOSink "drainN" (S.fold (IFL.drainN Ops.value))
+        , benchIOSink "drainWhileTrue" (S.fold (IFL.drainWhile $ (<=) Ops.maxValue))
+        , benchIOSink "drainWhileFalse" (S.fold (IFL.drainWhile $ (>=) Ops.maxValue))
         , benchIOSink "sink" (S.fold $ Sink.toFold Sink.drain)
         , benchIOSink "last" (S.fold FL.last)
         , benchIOSink "length" (S.fold FL.length)

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -24,6 +24,7 @@ import qualified Streamly.Memory.Array as A
 import qualified Streamly.Prelude as S
 import qualified Streamly.Internal.Data.Sink as Sink
 
+import qualified Streamly.Internal.Memory.Array as IA
 import qualified Streamly.Internal.Data.Fold as IFL
 import qualified Streamly.Internal.Prelude as IP
 import qualified Streamly.Internal.Data.Pipe as Pipe
@@ -232,10 +233,9 @@ main =
         , benchIOSink "drainN" (S.fold (IFL.drainN Ops.value))
         , benchIOSink "drainWhileTrue" (S.fold (IFL.drainWhile $ (<=) Ops.maxValue))
         , benchIOSink "drainWhileFalse" (S.fold (IFL.drainWhile $ (>=) Ops.maxValue))
-        -- XXX Change?
-        , benchIOSink "lastN.1" (S.fold (IFL.lastN 1 FL.length))
-        , benchIOSink "lastN.10" (S.fold (IFL.lastN 10 FL.length))
-        , benchIOSink "lastN.Max" (S.fold (IFL.lastN Ops.maxValue FL.length))
+        , benchIOSink "lastN.1"   (S.fold (IA.lastN 1))
+        , benchIOSink "lastN.10"  (S.fold (IA.lastN 10))
+        , benchIOSink "lastN.Max" (S.fold (IA.lastN Ops.maxValue))
         , benchIOSink "sink" (S.fold $ Sink.toFold Sink.drain)
         , benchIOSink "last" (S.fold FL.last)
         , benchIOSink "length" (S.fold FL.length)

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -280,6 +280,8 @@ main =
         , benchIOSink "isInfixOf" Ops.isInfixOf
         , benchIOSink "isSubsequenceOf" Ops.isSubsequenceOf
         , benchIOSink "stripPrefix" Ops.stripPrefix
+        , benchIOSink "stripSuffix" Ops.stripSuffix
+        , benchIOSink "stripInfix" Ops.stripInfix
         ]
       , bgroup "folds-transforms"
         [ benchIOSink "drain" (S.fold FL.drain)

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -281,7 +281,7 @@ main =
         , benchIOSink "isSubsequenceOf" Ops.isSubsequenceOf
         , benchIOSink "stripPrefix" Ops.stripPrefix
         , benchIOSink "stripSuffix" Ops.stripSuffix
-        , benchIOSink "stripInfix" Ops.stripInfix
+--        , benchIOSink "stripInfix" Ops.stripInfix
         ]
       , bgroup "folds-transforms"
         [ benchIOSink "drain" (S.fold FL.drain)

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -276,6 +276,8 @@ main =
         [ benchIOSink1 "eqBy" Ops.eqBy
         , benchIOSink1 "cmpBy" Ops.cmpBy
         , benchIOSink "isPrefixOf" Ops.isPrefixOf
+        , benchIOSink "isSuffixOf" Ops.isSuffixOf
+        , benchIOSink "isInfixOf" Ops.isInfixOf
         , benchIOSink "isSubsequenceOf" Ops.isSubsequenceOf
         , benchIOSink "stripPrefix" Ops.stripPrefix
         ]

--- a/benchmark/StreamDOps.hs
+++ b/benchmark/StreamDOps.hs
@@ -251,6 +251,7 @@ iterateTakeAll         = iterateSource (S.take maxValue) maxIters
 iterateDropOne         = iterateSource (S.drop 1) maxIters
 iterateDropWhileTrue   = iterateSource (S.dropWhile (<= maxValue)) maxIters
 
+{-# INLINE iterateM #-}
 iterateM :: Monad m => Int -> Stream m Int
 iterateM i = S.take maxIters (S.iterateM (\x -> return (x + 1)) (return i)) 
 

--- a/benchmark/StreamDOps.hs
+++ b/benchmark/StreamDOps.hs
@@ -251,6 +251,9 @@ iterateTakeAll         = iterateSource (S.take maxValue) maxIters
 iterateDropOne         = iterateSource (S.drop 1) maxIters
 iterateDropWhileTrue   = iterateSource (S.dropWhile (<= maxValue)) maxIters
 
+iterateM :: Monad m => Int -> Stream m Int
+iterateM i = S.take maxIters (S.iterateM (\x -> return (x + 1)) (return i)) 
+
 -------------------------------------------------------------------------------
 -- Zipping and concat
 -------------------------------------------------------------------------------

--- a/src/Streamly/Internal/Benchmark/Prelude.hs
+++ b/src/Streamly/Internal/Benchmark/Prelude.hs
@@ -656,11 +656,11 @@ stripSuffix src = do
     _ <- S.stripSuffix src src
     return ()
 
-{-# INLINE stripInfix #-}
-stripInfix :: MonadIO m => Stream m Int -> m ()
-stripInfix src = do
-    _ <- S.stripInfix src src
-    return ()
+-- {-# INLINE stripInfix #-}
+-- stripInfix :: MonadIO m => Stream m Int -> m ()
+-- stripInfix src = do
+--     _ <- S.stripInfix src src
+--     return ()
 
 {-# INLINE zipAsync #-}
 {-# INLINE zipAsyncM #-}

--- a/src/Streamly/Internal/Benchmark/Prelude.hs
+++ b/src/Streamly/Internal/Benchmark/Prelude.hs
@@ -641,7 +641,7 @@ isSubsequenceOf src = S.isSubsequenceOf src src
 {-# INLINE isInfixOf #-}
 isSuffixOf, isInfixOf :: MonadIO m => Stream m Int -> m Bool
 
-isSuffixOf src = S.isPrefixOf src src
+isSuffixOf src = S.isSuffixOf src src
 isInfixOf src = S.isPrefixOf src src
 
 {-# INLINE stripPrefix #-}

--- a/src/Streamly/Internal/Benchmark/Prelude.hs
+++ b/src/Streamly/Internal/Benchmark/Prelude.hs
@@ -637,6 +637,13 @@ isPrefixOf, isSubsequenceOf :: Monad m => Stream m Int -> m Bool
 isPrefixOf src = S.isPrefixOf src src
 isSubsequenceOf src = S.isSubsequenceOf src src
 
+{-# INLINE isSuffixOf #-}
+{-# INLINE isInfixOf #-}
+isSuffixOf, isInfixOf :: MonadIO m => Stream m Int -> m Bool
+
+isSuffixOf src = S.isPrefixOf src src
+isInfixOf src = S.isPrefixOf src src
+
 {-# INLINE stripPrefix #-}
 stripPrefix :: Monad m => Stream m Int -> m ()
 stripPrefix src = do

--- a/src/Streamly/Internal/Benchmark/Prelude.hs
+++ b/src/Streamly/Internal/Benchmark/Prelude.hs
@@ -650,6 +650,18 @@ stripPrefix src = do
     _ <- S.stripPrefix src src
     return ()
 
+{-# INLINE stripSuffix #-}
+stripSuffix :: MonadIO m => Stream m Int -> m ()
+stripSuffix src = do
+    _ <- S.stripSuffix src src
+    return ()
+
+{-# INLINE stripInfix #-}
+stripInfix :: MonadIO m => Stream m Int -> m ()
+stripInfix src = do
+    _ <- S.stripInfix src src
+    return ()
+
 {-# INLINE zipAsync #-}
 {-# INLINE zipAsyncM #-}
 {-# INLINE zipAsyncAp #-}

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -204,14 +204,12 @@ import qualified Prelude
 
 import Streamly.Internal.Data.Pipe.Types (Pipe (..), PipeState(..))
 import Streamly.Internal.Data.Fold.Types
-import Streamly.Internal.Data.Stream.StreamD.Type (foldlMx', fromList)
 import Streamly.Internal.Data.Strict
 import Streamly.Internal.Data.SVar
 
 import qualified Streamly.Internal.Data.Pipe.Types as Pipe
 import qualified Streamly.Memory.Ring as RB
 
-import Control.Monad.IO.Class (MonadIO(..))
 import Foreign.Storable (Storable(..))
 
 ------------------------------------------------------------------------------
@@ -570,7 +568,7 @@ rollingHashFirstN :: (Monad m, Enum a) => Int -> Fold m a Int
 rollingHashFirstN n = ltake n rollingHash
 
 {-# INLINABLE rollingHashLastN #-}
-rollingHashLastN :: (MonadIO m, Enum a, Storable a) => Int -> Fold m a Int
+rollingHashLastN :: (MonadIO m, Enum a) => Int -> Fold m a Int
 rollingHashLastN n = Fold step initial extract
   where
     k = 2891336453

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -205,7 +205,7 @@ import qualified Prelude
 
 import Streamly.Internal.Data.Pipe.Types (Pipe (..), PipeState(..))
 import Streamly.Internal.Data.Fold.Types
-import Streamly.Streams.StreamD.Type (foldlMx', fromList)
+import Streamly.Internal.Data.Stream.StreamD.Type (foldlMx', fromList)
 import Streamly.Internal.Data.Strict
 import Streamly.Internal.Data.SVar
 

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -570,26 +570,9 @@ rollingHash = rollingHashWithSalt defaultSalt
 rollingHashFirstN :: (Monad m, Enum a) => Int -> Fold m a Int
 rollingHashFirstN n = ltake n rollingHash
 
--- XXX Reduce duplication?
--- XXX Add tests and benchmarks
--- XXX Change to strict data structures accordingly
--- XXX Could potantially made faster
 {-# INLINABLE rollingHashLastN #-}
 rollingHashLastN :: (MonadIO m, Enum a, Storable a) => Int -> Fold m a Int
-rollingHashLastN n = Fold step' initial' done'
-  where
-    step' (rb, rh, i) a = do
-      rh1 <- liftIO $ RB.unsafeInsert rb rh a
-      return (rb, rh1, i + 1)
-    initial' = fmap (\(a, b) -> (a, b, 0)) $ liftIO $ RB.new n 
-    done' (rb, rh, i) = do
-      lst <- reverse <$> foldFunc i rh cons' [] rb
-      runFold rollingHash (fromList lst)
-    foldFunc i
-      | i < n = RB.unsafeFoldRingM 
-      | otherwise = RB.unsafeFoldRingFullM 
-    runFold (Fold step begin done) = foldlMx' step begin done
-    cons' b a = return $ a:b 
+rollingHashLastN n = lastN n rollingHash
 
 ------------------------------------------------------------------------------
 -- Monoidal left folds

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -587,8 +587,8 @@ rollingHashLastN n = Fold step initial extract
         let ea = fromEnum a
         a' <- liftIO $ peek rh
         rh1 <- liftIO $ RB.unsafeInsert rb rh ea
-        -- You don't need to change i to i + 1 here
-        -- Can remove this additional operation
+        -- XXX You don't need to change i to i + 1 here
+        -- XXX Can remove this additional operation
         return (dSA, rb, rh1, i + 1, cksum * k - a' * k' + ea)
     extract (dSA, _, _, _, cksum) = return $ dSA + cksum
 

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -70,8 +70,8 @@ module Streamly.Internal.Data.Fold
     , toListRevF  -- experimental
 
     -- ** Partial Folds
-    -- , drainN
-    -- , drainWhile
+    , drainN
+    , drainWhile
     -- , lastN
     -- , (!!)
     -- , genericIndex
@@ -628,6 +628,14 @@ toList = Fold (\f x -> return $ f . (x :))
 ------------------------------------------------------------------------------
 -- Partial Folds
 ------------------------------------------------------------------------------
+
+-- XXX Add proper Inline
+drainN :: Monad m => Int -> Fold m a () 
+drainN n = ltake n drain
+
+-- XXX Add proper Inline
+drainWhile :: Monad m => (a -> Bool) -> Fold m a ()
+drainWhile p = ltakeWhile p drain
 
 ------------------------------------------------------------------------------
 -- To Elements

--- a/src/Streamly/Internal/Memory/Array.hs
+++ b/src/Streamly/Internal/Memory/Array.hs
@@ -512,6 +512,7 @@ fold f arr = P.runFold f $ (toStream arr :: Serial.SerialT m a)
 streamFold :: (MonadIO m, Storable a) => (SerialT m a -> m b) -> Array a -> m b
 streamFold f arr = f (toStream arr)
 
+-- XXX Is there room for improvement?
 -- | Take last 'n' elements from the stream and discard the rest.
 {-# INLINABLE lastN #-}
 lastN :: (Storable a, MonadIO m) => Int -> Fold m a (Array a)

--- a/src/Streamly/Internal/Memory/Array.hs
+++ b/src/Streamly/Internal/Memory/Array.hs
@@ -149,7 +149,6 @@ import Streamly.Streams.Serial (SerialT)
 import Streamly.Streams.StreamK.Type (IsStream)
 
 import qualified Streamly.Internal.Memory.Array.Types as A
-import qualified Streamly.Memory.Ring as RB
 import qualified Streamly.Streams.Prelude as P
 import qualified Streamly.Streams.Serial as Serial
 import qualified Streamly.Streams.StreamD as D

--- a/src/Streamly/Internal/Memory/Array.hs
+++ b/src/Streamly/Internal/Memory/Array.hs
@@ -126,7 +126,7 @@ module Streamly.Internal.Memory.Array
     , fold
 
     -- * Folds with Array as the container
-    , lastN
+    , D.lastN
     )
 where
 
@@ -143,7 +143,6 @@ import GHC.Prim (touch#)
 import GHC.IO (IO(..))
 
 import Streamly.Internal.Data.Fold.Types (Fold(..))
-import Streamly.Internal.Data.Strict
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
 import Streamly.Internal.Memory.Array.Types (Array(..), length)
 import Streamly.Streams.Serial (SerialT)
@@ -511,21 +510,3 @@ fold f arr = P.runFold f $ (toStream arr :: Serial.SerialT m a)
 {-# INLINE streamFold #-}
 streamFold :: (MonadIO m, Storable a) => (SerialT m a -> m b) -> Array a -> m b
 streamFold f arr = f (toStream arr)
-
--- XXX Is there room for improvement?
--- | Take last 'n' elements from the stream and discard the rest.
-{-# INLINABLE lastN #-}
-lastN :: (Storable a, MonadIO m) => Int -> Fold m a (Array a)
-lastN n = Fold step initial done
-  where
-    step (Tuple3' rb rh i) a = do
-      rh1 <- liftIO $ RB.unsafeInsert rb rh a
-      return $ Tuple3' rb rh1 (i + 1)
-    initial = fmap (\(a, b) -> Tuple3' a b 0) $ liftIO $ RB.new n 
-    done (Tuple3' rb rh i) = do
-      arr <- liftIO $ A.newArray n
-      foldFunc i rh snoc' arr rb
-    snoc' b a = liftIO $ A.unsafeSnoc b a
-    foldFunc i
-      | i < n = RB.unsafeFoldRingM 
-      | otherwise = RB.unsafeFoldRingFullM 

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -754,10 +754,8 @@ repeatMSerial = fromStreamS . S.repeatM
 -- @
 --
 -- @since 0.1.2
-iterate :: IsStream t => (a -> a) -> a -> t m a
-iterate step = K.fromStream . go
-    where
-    go s = K.cons s (go (step s))
+iterate :: (Monad m, IsStream t) => (a -> a) -> a -> t m a
+iterate step = fromStreamD . D.iterate step
 
 -- |
 -- @
@@ -786,12 +784,8 @@ iterate step = K.fromStream . go
 -- /Since: 0.7.0 (signature change)/
 --
 -- /Since: 0.1.2/
-iterateM :: (IsStream t, MonadAsync m) => (a -> m a) -> m a -> t m a
-iterateM step = go
-    where
-    go s = K.mkStream $ \st stp sng yld -> do
-        next <- s
-        K.foldStreamShared st stp sng yld (return next |: go (step next))
+iterateM :: (IsStream t, Monad m) => (a -> m a) -> m a -> t m a
+iterateM step = fromStreamD . D.iterateM step
 
 ------------------------------------------------------------------------------
 -- Conversions

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -372,8 +372,8 @@ module Streamly.Internal.Prelude
     , isInfixOf
     , isSubsequenceOf
     , stripPrefix
-    -- , stripSuffix
-    -- , stripInfix
+    , stripSuffix
+    , stripInfix
 
     -- * Exceptions
     , before
@@ -1394,6 +1394,30 @@ stripPrefix
     => t m a -> t m a -> m (Maybe (t m a))
 stripPrefix m1 m2 = fmap fromStreamD <$>
     D.stripPrefix (toStreamD m1) (toStreamD m2)
+
+-- | Drops the given suffix from a stream. Returns 'Nothing' if the stream does
+-- not start with the given suffix. Returns @Just nil@ when the suffix is the
+-- same as the stream.
+--
+-- @since 0.6.0
+{-# INLINE stripSuffix #-}
+stripSuffix
+    :: (Storable a, IsStream t, MonadIO m)
+    => t m a -> t m a -> m (Maybe (t m a))
+stripSuffix m1 m2 = fmap fromStreamD <$>
+    D.stripSuffix (toStreamD m1) (toStreamD m2)
+
+-- | Drops the given infix from a stream. Returns 'Nothing' if the stream does
+-- not start with the given infix. Returns @Just nil@ when the infix is the
+-- same as the stream.
+--
+-- @since 0.6.0
+{-# INLINE stripInfix #-}
+stripInfix
+    :: (Storable a, IsStream t, MonadIO m)
+    => t m a -> t m a -> m (Maybe (t m a))
+stripInfix m1 m2 = fmap fromStreamD <$>
+    D.stripInfix (toStreamD m1) (toStreamD m2)
 
 ------------------------------------------------------------------------------
 -- Map and Fold

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -368,8 +368,8 @@ module Streamly.Internal.Prelude
     , eqBy
     , cmpBy
     , isPrefixOf
-    -- , isSuffixOf
-    -- , isInfixOf
+    , isSuffixOf
+    , isInfixOf
     , isSubsequenceOf
     , stripPrefix
     -- , stripSuffix
@@ -1342,6 +1342,32 @@ elemIndex a = findIndex (== a)
 {-# INLINE isPrefixOf #-}
 isPrefixOf :: (Eq a, IsStream t, Monad m) => t m a -> t m a -> m Bool
 isPrefixOf m1 m2 = D.isPrefixOf (toStreamD m1) (toStreamD m2)
+
+-- | Returns 'True' if the first stream is the same as or a suffix of the
+-- second. A stream is a suffix of itself.
+--
+-- @
+-- > S.isSuffixOf (S.fromList "hello") (S.fromList "hello" :: SerialT IO Char)
+-- True
+-- @
+--
+-- @since 0.6.0
+{-# INLINE isSuffixOf #-}
+isSuffixOf :: (Storable a, IsStream t, MonadIO m) => t m a -> t m a -> m Bool
+isSuffixOf m1 m2 = D.isSuffixOf (toStreamD m1) (toStreamD m2)
+
+-- | Returns 'True' if the first stream is the same as or a infix of the
+-- second. A stream is a infix of itself.
+--
+-- @
+-- > S.isInfixOf (S.fromList "hello") (S.fromList "hello" :: SerialT IO Char)
+-- True
+-- @
+--
+-- @since 0.6.0
+{-# INLINE isInfixOf #-}
+isInfixOf :: (Storable a, IsStream t, MonadIO m) => t m a -> t m a -> m Bool
+isInfixOf m1 m2 = D.isInfixOf (toStreamD m1) (toStreamD m2)
 
 -- | Returns 'True' if all the elements of the first stream occur, in order, in
 -- the second stream. The elements do not have to occur consecutively. A stream

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -1402,7 +1402,7 @@ stripPrefix m1 m2 = fmap fromStreamD <$>
 -- @since 0.6.0
 {-# INLINE stripSuffix #-}
 stripSuffix
-    :: (Storable a, IsStream t, MonadIO m)
+    :: (Storable a, IsStream t, MonadIO m, Eq a)
     => t m a -> t m a -> m (Maybe (t m a))
 stripSuffix m1 m2 = fmap fromStreamD <$>
     D.stripSuffix (toStreamD m1) (toStreamD m2)

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -1353,7 +1353,7 @@ isPrefixOf m1 m2 = D.isPrefixOf (toStreamD m1) (toStreamD m2)
 --
 -- @since 0.6.0
 {-# INLINE isSuffixOf #-}
-isSuffixOf :: (Storable a, IsStream t, MonadIO m) => t m a -> t m a -> m Bool
+isSuffixOf :: (Eq a, Storable a, IsStream t, MonadIO m) => t m a -> t m a -> m Bool
 isSuffixOf m1 m2 = D.isSuffixOf (toStreamD m1) (toStreamD m2)
 
 -- | Returns 'True' if the first stream is the same as or a infix of the

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -1366,7 +1366,7 @@ isSuffixOf m1 m2 = D.isSuffixOf (toStreamD m1) (toStreamD m2)
 --
 -- @since 0.6.0
 {-# INLINE isInfixOf #-}
-isInfixOf :: (Storable a, IsStream t, MonadIO m) => t m a -> t m a -> m Bool
+isInfixOf :: (Storable a, IsStream t, MonadIO m, Enum a) => t m a -> t m a -> m Bool
 isInfixOf m1 m2 = D.isInfixOf (toStreamD m1) (toStreamD m2)
 
 -- | Returns 'True' if all the elements of the first stream occur, in order, in

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -1338,7 +1338,9 @@ isPrefixOf :: (Eq a, IsStream t, Monad m) => t m a -> t m a -> m Bool
 isPrefixOf m1 m2 = D.isPrefixOf (toStreamD m1) (toStreamD m2)
 
 -- | Returns 'True' if the first stream is the same as or a suffix of the
--- second. A stream is a suffix of itself.
+-- second. A stream is a suffix of itself.  Both the streams should be finite
+-- for the suffix check to ever terminate.  The memory used by this function
+-- would be proportional to the size of the suffix.
 --
 -- @
 -- > S.isSuffixOf (S.fromList "hello") (S.fromList "hello" :: SerialT IO Char)
@@ -1391,7 +1393,9 @@ stripPrefix m1 m2 = fmap fromStreamD <$>
 
 -- | Drops the given suffix from a stream. Returns 'Nothing' if the stream does
 -- not start with the given suffix. Returns @Just nil@ when the suffix is the
--- same as the stream.
+-- same as the stream.  Both the streams should be finite for this function to
+-- ever terminate. The memory used by this function would be proportional to the
+-- size of the suffix.
 --
 -- @since 0.6.0
 {-# INLINE stripSuffix #-}

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -397,6 +397,10 @@ module Streamly.Internal.Prelude
     -- * Concurrency
     , mkParallel
 
+    -- XXX Shift this somewhere else?
+    -- * Reordering
+    , reassembleBy
+
     -- * Diagnostics
     , inspectMode
 
@@ -3443,19 +3447,17 @@ splitInnerBySuffix splitter joiner xs =
 -- Reorder in sequence
 ------------------------------------------------------------------------------
 
-{-
 -- Buffer until the next element in sequence arrives. The function argument
 -- determines the difference in sequence numbers. This could be useful in
 -- implementing sequenced streams, for example, TCP reassembly.
 {-# INLINE reassembleBy #-}
 reassembleBy
-    :: (IsStream t, Monad m)
-    => Fold m a b
+    :: (Bounded a, IsStream t, Monad m)
+    => Int
     -> (a -> a -> Int)
     -> t m a
-    -> t m b
-reassembleBy = undefined
--}
+    -> t m a
+reassembleBy sz diff = D.fromStreamD . D.reassembleBy sz diff . D.toStreamD
 
 ------------------------------------------------------------------------------
 -- Distributing

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -1362,7 +1362,7 @@ isSuffixOf m1 m2 = D.isSuffixOf (toStreamD m1) (toStreamD m2)
 --
 -- @since 0.6.0
 {-# INLINE isInfixOf #-}
-isInfixOf :: (Storable a, IsStream t, MonadIO m, Enum a) => t m a -> t m a -> m Bool
+isInfixOf :: (IsStream t, MonadIO m, Enum a) => t m a -> t m a -> m Bool
 isInfixOf m1 m2 = D.isInfixOf (toStreamD m1) (toStreamD m2)
 
 -- | Returns 'True' if all the elements of the first stream occur, in order, in

--- a/src/Streamly/Prelude.hs
+++ b/src/Streamly/Prelude.hs
@@ -259,7 +259,6 @@ module Streamly.Prelude
     -- trimming sequences
     , stripPrefix
     , stripSuffix
-    , stripInfix
 
     -- * Transformation
 

--- a/src/Streamly/Prelude.hs
+++ b/src/Streamly/Prelude.hs
@@ -252,8 +252,8 @@ module Streamly.Prelude
     , eqBy
     , cmpBy
     , isPrefixOf
-    -- , isSuffixOf
-    -- , isInfixOf
+    , isSuffixOf
+    , isInfixOf
     , isSubsequenceOf
 
     -- trimming sequences

--- a/src/Streamly/Prelude.hs
+++ b/src/Streamly/Prelude.hs
@@ -258,8 +258,8 @@ module Streamly.Prelude
 
     -- trimming sequences
     , stripPrefix
-    -- , stripSuffix
-    -- , stripInfix
+    , stripSuffix
+    , stripInfix
 
     -- * Transformation
 

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -4417,13 +4417,16 @@ reassembleBy sz diff (Stream step state) = Stream step' state'
         Yield a s' -> case diff a c of 
           0 -> return $ Skip (h, Just c, s')
           1 -> return $ Yield a (h, Just a, s')
-          x | x < sz ->
+          x | x < 0 -> return $ Skip (h, Just c, s')
+            | x < sz ->
             let y = diff a minBound in
             case view of
               Just (Entry _ payH, delH) ->
                 case diff payH c of
                   0 -> return $ Skip (H.insert (Entry y a) delH, Just c, s')
                   1 -> return $ Yield payH (H.insert (Entry y a) delH, Just payH, s')
+                  -- XXX Condition required?
+                  x_ | x_ < 0 -> return $ Skip (H.insert (Entry y a) delH, Just c, s')
                   _ -> return $ Skip (H.insert (Entry y a) h, Just c, s')
               _ -> return $ Skip (h, Just c, s')
             | otherwise -> return $ Skip (h, Just c, s')
@@ -4433,6 +4436,8 @@ reassembleBy sz diff (Stream step state) = Stream step' state'
               case diff payH c of
                 0 -> return $ Skip (delH, Just c, s')
                 1 -> return $ Yield payH (delH, Just payH, s')
+                -- XXX Condition required?
+                x | x < 0 -> return $ Skip (delH, Just c, s')
                 _ -> return $ Skip (h, Just c, s')
             _ -> return $ Skip (h, Just c, s')
         Stop -> 
@@ -4441,6 +4446,8 @@ reassembleBy sz diff (Stream step state) = Stream step' state'
               case diff payH c of
                 0 -> return $ Skip (delH, Just c, s)
                 1 -> return $ Yield payH (delH, Just payH, s)
+                -- XXX Condition required?
+                x | x < 0 -> return $ Skip (delH, Just c, s)
                 -- XXX Do we want to yeild the rest?
                 _ -> return Stop
             _ -> return Stop

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -360,6 +360,7 @@ import Streamly.Internal.Data.Fold.Types (Fold(..))
 import Streamly.Internal.Data.Pipe.Types (Pipe(..), PipeState(..))
 import Streamly.Internal.Data.Time.Clock (Clock(Monotonic), getTime)
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
+import Streamly.Internal.Data.Strict (Tuple'(..), Tuple3'(..))
 
 import Streamly.Internal.Data.Stream.StreamD.Type
 import Streamly.Internal.Data.SVar

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -376,8 +376,6 @@ import Foreign.Ptr (plusPtr)
 import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import Foreign.ForeignPtr (touchForeignPtr)
 
-import Streamly.Internal.Data.Strict
-
 ------------------------------------------------------------------------------
 -- Construction
 ------------------------------------------------------------------------------

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -72,6 +72,8 @@ module Streamly.Streams.StreamD
     , fromIndicesM
     , generate
     , generateM
+    , iterate
+    , iterateM
 
     -- ** Enumerations
     , enumerateFromStepIntegral
@@ -332,7 +334,7 @@ import Prelude
                takeWhile, drop, dropWhile, all, any, maximum, minimum, elem,
                notElem, null, head, tail, zipWith, lookup, foldr1, sequence,
                (!!), scanl, scanl1, concatMap, replicate, enumFromTo, concat,
-               reverse)
+               reverse, iterate)
 
 import qualified Control.Monad.Catch as MC
 import qualified Control.Monad.Reader as Reader
@@ -465,6 +467,12 @@ repeatM x = Stream (\_ _ -> x >>= \r -> return $ Yield r ()) ()
 
 repeat :: Monad m => a -> Stream m a
 repeat x = Stream (\_ _ -> return $ Yield x ()) ()
+
+iterateM :: Monad m => (a -> m a) -> m a -> Stream m a
+iterateM step = Stream (\_ st -> st >>= \x -> return $ Yield x (step x))
+
+iterate :: Monad m => (a -> a) -> a -> Stream m a
+iterate step st = iterateM (return . step) (return st)
 
 {-# INLINE_NORMAL replicateM #-}
 replicateM :: forall m a. Monad m => Int -> m a -> Stream m a

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -2094,9 +2094,8 @@ stripSuffix sa sb = do
   return $ if le == aa then Just $ take (len - al) sb
                        else Nothing
 
--- XXX Add tests and benchmarks
--- XXX Change to strict data structures accordingly
 -- XXX Could potantially be made faster
+-- XXX Use rollingHash here as well
 {-# INLINE_NORMAL stripInfix #-}
 stripInfix
   :: (MonadIO m, Storable a)

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -360,7 +360,6 @@ import Streamly.Internal.Data.Fold.Types (Fold(..))
 import Streamly.Internal.Data.Pipe.Types (Pipe(..), PipeState(..))
 import Streamly.Internal.Data.Time.Clock (Clock(Monotonic), getTime)
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
-import Streamly.Internal.Data.Strict (Tuple'(..))
 
 import Streamly.Internal.Data.Stream.StreamD.Type
 import Streamly.Internal.Data.SVar

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -2014,22 +2014,22 @@ isPrefixOf (Stream stepa ta) (Stream stepb tb) = go (ta, tb, Nothing)
 -- XXX Could potantially be made faster
 {-# INLINE_NORMAL isSuffixOf #-}
 isSuffixOf :: (MonadIO m, Storable a) => Stream m a -> Stream m a -> m Bool
-isSuffixOf (Stream stpa sa) (Stream stpb sb) = go1 (stpa, sa, 0, [])
+isSuffixOf (Stream stpa sa) (Stream stpb sb) = go1 (sa, 0, [])
   where
-    go1 (stp, st, i1, b) = do
-      r <- stp defState st
+    go1 (st, i1, b) = do
+      r <- stpa defState st
       case r of
-        Yield x st' -> go1 (stp, st', i1 + 1, x:b)
-        Skip st' -> go1 (stp, st', i1, b)
-        Stop -> liftIO (RB.new i1) >>= \(rb, rh) -> go2 (i1, A.fromList b, stpb, sb, 0, rb, rh)
+        Yield x st' -> go1 (st', i1 + 1, x:b)
+        Skip st' -> go1 (st', i1, b)
+        Stop -> liftIO (RB.new i1) >>= \(rb, rh) -> go2 (i1, A.fromList b, sb, 0, rb, rh)
 
-    go2 (i1, b, stp, st, i2, rb, rh) = do
-      r <- stp defState st
+    go2 (i1, b, st, i2, rb, rh) = do
+      r <- stpb defState st
       case r of
         Yield x st' -> do
           rh1 <- liftIO $ RB.unsafeInsert rb rh x
-          go2 (i1, b, stp, st', i2 + 1, rb, rh1)
-        Skip st' -> go2 (i1, b, stp, st', i2, rb, rh)
+          go2 (i1, b, st', i2 + 1, rb, rh1)
+        Skip st' -> go2 (i1, b, st', i2, rb, rh)
         Stop -> go3 (i1, b, i2, rb, rh) 
 
     go3 (i1, b, i2, rb, rh)
@@ -2041,29 +2041,29 @@ isSuffixOf (Stream stpa sa) (Stream stpb sb) = go1 (stpa, sa, 0, [])
 -- XXX Could potantially be made faster
 {-# INLINE_NORMAL isInfixOf #-}
 isInfixOf :: (MonadIO m, Storable a) => Stream m a -> Stream m a -> m Bool
-isInfixOf (Stream stpa sa) (Stream stpb sb) = go1 (stpa, sa, 0, [])
+isInfixOf (Stream stpa sa) (Stream stpb sb) = go1 (sa, 0, [])
   where
-    go1 (stp, st, i1, b) = do
-      r <- stp defState st
+    go1 (st, i1, b) = do
+      r <- stpa defState st
       case r of
-        Yield x st' -> go1 (stp, st', i1 + 1, x:b)
-        Skip st' -> go1 (stp, st', i1, b)
+        Yield x st' -> go1 (st', i1 + 1, x:b)
+        Skip st' -> go1 (st', i1, b)
         Stop -> do
           (rb, rh) <- liftIO (RB.new i1)
-          go2 (i1, A.fromList b, stpb, sb, 0, rb, rh)
+          go2 (i1, A.fromList b, sb, 0, rb, rh)
 
-    go2 (i1, b, stp, st, i2, rb, rh) = do
-      r <- stp defState st
+    go2 (i1, b, st, i2, rb, rh) = do
+      r <- stpb defState st
       case r of
         Yield x st' -> do
           rh1 <- liftIO $ RB.unsafeInsert rb rh x
-          if i2 + 1 >= i1 then go3 (i1, b, stp, st', i2 + 1, rb, rh1)
-                          else go2 (i1, b, stp, st', i2 + 1, rb, rh1)
-        Skip st' -> go2 (i1, b, stp, st', i2, rb, rh)
+          if i2 + 1 >= i1 then go3 (i1, b, st', i2 + 1, rb, rh1)
+                          else go2 (i1, b, st', i2 + 1, rb, rh1)
+        Skip st' -> go2 (i1, b, st', i2, rb, rh)
         Stop -> if i2 >= i1 then go4 (b, rb, rh)
                             else return False
 
-    go3 arg@(_, b, _, _, _, rb, rh)
+    go3 arg@(_, b, _, _, rb, rh)
       | RB.unsafeEqArray rb rh b = return True
       | otherwise = go2 arg   
 
@@ -2120,22 +2120,22 @@ stripPrefix (Stream stepa ta) (Stream stepb tb) = go (ta, tb, Nothing)
 stripSuffix
     :: (MonadIO m, Storable a)
     => Stream m a -> Stream m a -> m (Maybe (Stream m a))
-stripSuffix (Stream stpa sa) strm@(Stream stpb sb) = go1 (stpa, sa, 0, [])
+stripSuffix (Stream stpa sa) strm@(Stream stpb sb) = go1 (sa, 0, [])
   where
-    go1 (stp, st, i1, b) = do
-      r <- stp defState st
+    go1 (st, i1, b) = do
+      r <- stpa defState st
       case r of
-        Yield x st' -> go1 (stp, st', i1 + 1, x:b)
-        Skip st' -> go1 (stp, st', i1, b)
-        Stop -> liftIO (RB.new i1) >>= \(rb, rh) -> go2 (i1, A.fromList b, stpb, sb, 0, rb, rh)
+        Yield x st' -> go1 (st', i1 + 1, x:b)
+        Skip st' -> go1 (st', i1, b)
+        Stop -> liftIO (RB.new i1) >>= \(rb, rh) -> go2 (i1, A.fromList b, sb, 0, rb, rh)
 
-    go2 (i1, b, stp, st, i2, rb, rh) = do
-      r <- stp defState st
+    go2 (i1, b, st, i2, rb, rh) = do
+      r <- stpb defState st
       case r of
         Yield x st' -> do
           rh1 <- liftIO $ RB.unsafeInsert rb rh x
-          go2 (i1, b, stp, st', i2 + 1, rb, rh1)
-        Skip st' -> go2 (i1, b, stp, st', i2, rb, rh)
+          go2 (i1, b, st', i2 + 1, rb, rh1)
+        Skip st' -> go2 (i1, b, st', i2, rb, rh)
         Stop -> go3 (i1, b, i2, rb, rh) 
 
     go3 (i1, b, i2, rb, rh)

--- a/src/Streamly/Streams/StreamD.hs
+++ b/src/Streamly/Streams/StreamD.hs
@@ -378,8 +378,6 @@ import Foreign.ForeignPtr (touchForeignPtr)
 
 import Streamly.Internal.Data.Strict
 
-import qualified Streamly.Internal.Data.Fold as FL
-
 ------------------------------------------------------------------------------
 -- Construction
 ------------------------------------------------------------------------------
@@ -2032,7 +2030,7 @@ isSuffixOf sa sb = do
   return $ aa == ab
 
 {-# INLINE_NORMAL isInfixOf #-}
-isInfixOf :: (MonadIO m, Storable a, Enum a) => Stream m a -> Stream m a -> m Bool
+isInfixOf :: (MonadIO m, Enum a) => Stream m a -> Stream m a -> m Bool
 isInfixOf sa sb = do
   (patHash, len) <- runFold ((,) <$> FL.rollingHash <*> FL.length) sa
   patHash `elem` scan (FL.rollingHashLastN len) sb

--- a/test/Prop.hs
+++ b/test/Prop.hs
@@ -80,6 +80,19 @@ listEquals eq stream list = do
              )
     assert (stream `eq` list)
 
+stripSuffix :: Eq a => [a] -> [a] -> Maybe [a]
+stripSuffix a b = reverse <$> stripPrefix (reverse a) (reverse b)
+
+stripInfix :: Eq a => [a] -> [a] -> Maybe [a]
+stripInfix a b = if isInfixOf a b then Just $ stripInfix' a b
+                                  else Nothing
+  where
+    stripInfix' _ [] = []
+    stripInfix' a b =
+      case stripPrefix a b of
+        Nothing -> head b : stripInfix' a (tail b)
+        Just b' -> stripInfix' a b'
+
 -------------------------------------------------------------------------------
 -- Construction operations
 -------------------------------------------------------------------------------
@@ -749,6 +762,12 @@ eliminationOps constr desc t = do
     prop (desc <> " stripPrefix 10") $ eliminateOp constr (stripPrefix [1..10]) $
         (\s -> s >>= maybe (return Nothing) (fmap Just . S.toList)) .
         S.stripPrefix (S.fromList [(1::Int)..10]) . t
+    prop (desc <> " stripSuffix 10") $ eliminateOp constr (stripSuffix [1..10]) $
+        (\s -> s >>= maybe (return Nothing) (fmap Just . S.toList)) .
+        S.stripSuffix (S.fromList [(1::Int)..10]) . t
+    prop (desc <> " stripInfix 10") $ eliminateOp constr (stripInfix [1..10]) $
+        (\s -> s >>= maybe (return Nothing) (fmap Just . S.toList)) .
+        S.stripInfix (S.fromList [(1::Int)..10]) . t
 
 -- head/tail/last may depend on the order in case of parallel streams
 -- so we test these only for serial streams.

--- a/test/Prop.hs
+++ b/test/Prop.hs
@@ -84,7 +84,7 @@ stripSuffix :: Eq a => [a] -> [a] -> Maybe [a]
 stripSuffix a b = reverse <$> stripPrefix (reverse a) (reverse b)
 
 stripInfix :: Eq a => [a] -> [a] -> Maybe [a]
-stripInfix a b = if isInfixOf a b then Just $ stripInfix' a b
+stripInfix x y = if isInfixOf x y then Just $ stripInfix' x y
                                   else Nothing
   where
     stripInfix' _ [] = []

--- a/test/Prop.hs
+++ b/test/Prop.hs
@@ -83,15 +83,15 @@ listEquals eq stream list = do
 stripSuffix :: Eq a => [a] -> [a] -> Maybe [a]
 stripSuffix a b = reverse <$> stripPrefix (reverse a) (reverse b)
 
-stripInfix :: Eq a => [a] -> [a] -> Maybe [a]
-stripInfix x y = if isInfixOf x y then Just $ stripInfix' x y
-                                  else Nothing
-  where
-    stripInfix' _ [] = []
-    stripInfix' a b =
-      case stripPrefix a b of
-        Nothing -> head b : stripInfix' a (tail b)
-        Just b' -> stripInfix' a b'
+-- stripInfix :: Eq a => [a] -> [a] -> Maybe [a]
+-- stripInfix x y = if isInfixOf x y then Just $ stripInfix' x y
+--                                   else Nothing
+--   where
+--     stripInfix' _ [] = []
+--     stripInfix' a b =
+--       case stripPrefix a b of
+--         Nothing -> head b : stripInfix' a (tail b)
+--         Just b' -> stripInfix' a b'
 
 -------------------------------------------------------------------------------
 -- Construction operations

--- a/test/Prop.hs
+++ b/test/Prop.hs
@@ -17,7 +17,7 @@ import Data.List
        (sort, foldl', scanl', findIndices, findIndex, elemIndices,
         elemIndex, find, insertBy, intersperse, foldl1', (\\),
         maximumBy, minimumBy, deleteBy, isPrefixOf, isSubsequenceOf,
-        stripPrefix, intercalate)
+        stripPrefix, intercalate, isSuffixOf, isInfixOf)
 import Data.Maybe (mapMaybe)
 import GHC.Word (Word8)
 
@@ -739,6 +739,10 @@ eliminationOps constr desc t = do
     -- XXX Write better tests for substreams.
     prop (desc <> " isPrefixOf 10") $ eliminateOp constr (isPrefixOf [1..10]) $
         S.isPrefixOf (S.fromList [(1::Int)..10]) . t
+    prop (desc <> " isSuffixOf 10") $ eliminateOp constr (isSuffixOf [1..10]) $
+        S.isSuffixOf (S.fromList [(1::Int)..10]) . t
+    prop (desc <> " isInfixOf 10") $ eliminateOp constr (isInfixOf [1..10]) $
+        S.isInfixOf (S.fromList [(1::Int)..10]) . t
     prop (desc <> " isSubsequenceOf 10") $
         eliminateOp constr (isSubsequenceOf $ filter even [1..10]) $
         S.isSubsequenceOf (S.fromList $ filter even [(1::Int)..10]) . t

--- a/test/Prop.hs
+++ b/test/Prop.hs
@@ -765,9 +765,9 @@ eliminationOps constr desc t = do
     prop (desc <> " stripSuffix 10") $ eliminateOp constr (stripSuffix [1..10]) $
         (\s -> s >>= maybe (return Nothing) (fmap Just . S.toList)) .
         S.stripSuffix (S.fromList [(1::Int)..10]) . t
-    prop (desc <> " stripInfix 10") $ eliminateOp constr (stripInfix [1..10]) $
-        (\s -> s >>= maybe (return Nothing) (fmap Just . S.toList)) .
-        S.stripInfix (S.fromList [(1::Int)..10]) . t
+--    prop (desc <> " stripInfix 10") $ eliminateOp constr (stripInfix [1..10]) $
+--        (\s -> s >>= maybe (return Nothing) (fmap Just . S.toList)) .
+--        S.stripInfix (S.fromList [(1::Int)..10]) . t
 
 -- head/tail/last may depend on the order in case of parallel streams
 -- so we test these only for serial streams.


### PR DESCRIPTION
This PR adds a few additional combinators to the library, namely:

`StreamD.iterate`
`StreamD.iterateM`
`Internal.Data.Fold.drain`
`Internal.Data.Fold.drainWhile`
`Internal.Data.Fold.lastN`
`Internal.Data.Fold.rollingHashFirstN`
`Internal.Data.Fold.rollingHashLastN`
`StreamD.isInfixOf`
`StreamD.isSuffixOf`
`StreamD.stripInfix`
`StreamD.stripSuffix`
`StreamD.reassembleBy`

No tests have been added to `reassembleBy` and hence isn't exposed yet.