### PR TITLE
Expose some unsafe array primitives and add intersperseSuffixBySpan

### DIFF
--- a/src/Streamly/Internal/Memory/Array.hs
+++ b/src/Streamly/Internal/Memory/Array.hs
@@ -57,6 +57,7 @@ module Streamly.Internal.Memory.Array
     -- Monadic APIs
     -- , newArray
     , A.writeN      -- drop new
+    , A.writeNAligned
     , A.write       -- full buffer
     -- , writeLastN -- drop old (ring buffer)
 
@@ -74,6 +75,7 @@ module Streamly.Internal.Memory.Array
     , last
     -- , (!!)
     , readIndex
+    , A.unsafeIndex
     -- , readIndices
     -- , readRanges
 

--- a/src/Streamly/Internal/Memory/Array/Types.hs
+++ b/src/Streamly/Internal/Memory/Array/Types.hs
@@ -539,7 +539,7 @@ writeNAllocWith alloc n = Fold step initial extract
 writeN :: forall m a. (MonadIO m, Storable a) => Int -> Fold m a (Array a)
 writeN = writeNAllocWith newArray
 
--- | @writeNAligned n@ folds a maximum of @n@ elements from the input
+-- | @writeNAligned alignment n@ folds a maximum of @n@ elements from the input
 -- stream to an 'Array' aligned to the given size.
 --
 -- /Internal/

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -208,6 +208,7 @@ module Streamly.Internal.Prelude
     , intersperseM
     , intersperse
     , intersperseSuffix
+    , intersperseSuffixBySpan
     -- , intersperseBySpan
     , interjectSuffix
 
@@ -1894,6 +1895,22 @@ intersperse a = fromStreamS . S.intersperse a . toStreamS
 {-# INLINE intersperseSuffix #-}
 intersperseSuffix :: (IsStream t, MonadAsync m) => m a -> t m a -> t m a
 intersperseSuffix m = fromStreamD . D.intersperseSuffix m . toStreamD
+
+-- | Like 'intersperseSuffix' but intersperses a monadic action into the input
+-- stream after every @n@ elements and after the last element.
+--
+-- @
+-- > S.toList $ S.intersperseSuffixBySpan 2 (return ',') $ S.fromList "hello"
+-- "he,ll,o,"
+-- @
+--
+-- /Internal/
+--
+{-# INLINE intersperseSuffixBySpan #-}
+intersperseSuffixBySpan :: (IsStream t, MonadAsync m)
+    => Int -> m a -> t m a -> t m a
+intersperseSuffixBySpan n eff =
+    fromStreamD . D.intersperseSuffixBySpan n eff . toStreamD
 
 {-
 -- | Intersperse a monadic action into the input stream after every @n@


### PR DESCRIPTION
Mainly motivated by the fasta benchmark.