### PR TITLE
Simple combinators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ cabal.project.local
 *.swp
 *.swo
 *~
+
+# Other
+.log

--- a/benchmark/BaseStreams.hs
+++ b/benchmark/BaseStreams.hs
@@ -194,6 +194,8 @@ main =
         , benchD "dropOne"              D.iterateDropOne
         , benchD "dropWhileFalse(1/10)" D.iterateDropWhileFalse
         , benchD "dropWhileTrue"        D.iterateDropWhileTrue
+        , benchD "iterateM"             D.iterateM
+
         ]
       ]
     , bgroup "list"

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -229,6 +229,9 @@ main =
         ]
       , bgroup "folds"
         [ benchIOSink "drain" (S.fold FL.drain)
+        , benchIOSink "drainN" (S.fold (IFL.drainN Ops.value))
+        , benchIOSink "drainWhileTrue" (S.fold (IFL.drainWhile $ (<=) Ops.maxValue))
+        , benchIOSink "drainWhileFalse" (S.fold (IFL.drainWhile $ (>=) Ops.maxValue))
         , benchIOSink "sink" (S.fold $ Sink.toFold Sink.drain)
         , benchIOSink "last" (S.fold FL.last)
         , benchIOSink "length" (S.fold FL.length)

--- a/benchmark/StreamDOps.hs
+++ b/benchmark/StreamDOps.hs
@@ -251,6 +251,10 @@ iterateTakeAll         = iterateSource (S.take maxValue) maxIters
 iterateDropOne         = iterateSource (S.drop 1) maxIters
 iterateDropWhileTrue   = iterateSource (S.dropWhile (<= maxValue)) maxIters
 
+{-# INLINE iterateM #-}
+iterateM :: Monad m => Int -> Stream m Int
+iterateM i = S.take maxIters (S.iterateM (\x -> return (x + 1)) (return i))
+
 -------------------------------------------------------------------------------
 -- Zipping and concat
 -------------------------------------------------------------------------------

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -56,7 +56,7 @@ module Streamly.Internal.Data.Fold
     , stdDev
     , rollingHash
     , rollingHashWithSalt
-    -- , rollingHashFirstN
+    , rollingHashFirstN
     -- , rollingHashLastN
 
     -- ** Full Folds (Monoidal)
@@ -70,8 +70,8 @@ module Streamly.Internal.Data.Fold
     , toListRevF  -- experimental
 
     -- ** Partial Folds
-    -- , drainN
-    -- , drainWhile
+    , drainN
+    , drainWhile
     -- , lastN
     -- , (!!)
     -- , genericIndex
@@ -563,6 +563,14 @@ defaultSalt = 0x087fc72c
 rollingHash :: (Monad m, Enum a) => Fold m a Int
 rollingHash = rollingHashWithSalt defaultSalt
 
+-- | Compute an 'Int' sized polynomial rolling hash of the first n elements of
+-- a stream.
+--
+-- > rollingHashFirstN = ltake n rollingHash
+{-# INLINABLE rollingHashFirstN #-}
+rollingHashFirstN :: (Monad m, Enum a) => Int -> Fold m a Int
+rollingHashFirstN n = ltake n rollingHash
+
 ------------------------------------------------------------------------------
 -- Monoidal left folds
 ------------------------------------------------------------------------------
@@ -630,6 +638,18 @@ toList = Fold (\f x -> return $ f . (x :))
 ------------------------------------------------------------------------------
 -- Partial Folds
 ------------------------------------------------------------------------------
+
+-- | A fold that drains the first n elements of its input, running the effects
+-- and discarding the results.
+{-# INLINABLE drainN #-}
+drainN :: Monad m => Int -> Fold m a () 
+drainN n = ltake n drain
+
+-- | A fold that drains elements of its input as long as the predicate succeeds,
+-- running the effects and discarding the results.
+{-# INLINABLE drainWhile #-}
+drainWhile :: Monad m => (a -> Bool) -> Fold m a ()
+drainWhile p = ltakeWhile p drain
 
 ------------------------------------------------------------------------------
 -- To Elements

--- a/src/Streamly/Internal/Data/Stream/StreamD.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD.hs
@@ -78,6 +78,8 @@ module Streamly.Internal.Data.Stream.StreamD
     , fromIndicesM
     , generate
     , generateM
+    , iterate
+    , iterateM
 
     -- ** Enumerations
     , enumerateFromStepIntegral
@@ -324,7 +326,7 @@ import Prelude
                takeWhile, drop, dropWhile, all, any, maximum, minimum, elem,
                notElem, null, head, tail, zipWith, lookup, foldr1, sequence,
                (!!), scanl, scanl1, concatMap, replicate, enumFromTo, concat,
-               reverse)
+               reverse, iterate)
 
 import qualified Control.Monad.Catch as MC
 import qualified Control.Monad.Reader as Reader
@@ -448,11 +450,21 @@ unfold (Unfold ustep inject) seed = Stream step Nothing
 -- Specialized Generation
 ------------------------------------------------------------------------------
 
+{-# INLINE_NORMAL repeatM #-}
 repeatM :: Monad m => m a -> Stream m a
 repeatM x = Stream (\_ _ -> x >>= \r -> return $ Yield r ()) ()
 
+{-# INLINE_NORMAL repeat #-}
 repeat :: Monad m => a -> Stream m a
 repeat x = Stream (\_ _ -> return $ Yield x ()) ()
+
+{-# INLINE_NORMAL iterateM #-}
+iterateM :: Monad m => (a -> m a) -> m a -> Stream m a
+iterateM step = Stream (\_ st -> st >>= \x -> return $ Yield x (step x))
+
+{-# INLINE_NORMAL iterate #-}
+iterate :: Monad m => (a -> a) -> a -> Stream m a
+iterate step st = iterateM (return . step) (return st)
 
 {-# INLINE_NORMAL replicateM #-}
 replicateM :: forall m a. Monad m => Int -> m a -> Stream m a

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -464,6 +464,19 @@ test-suite array-test
         transformers  >= 0.4 && < 0.6
   default-language: Haskell2010
 
+test-suite internal-data-fold-test
+  import: test-options
+  type: exitcode-stdio-1.0
+  main-is: Streamly/Test/Internal/Data/Fold.hs
+  js-sources: jsbits/clock.js
+  hs-source-dirs: test
+  build-depends:
+      streamly
+    , base              >= 4.8   && < 5
+    , hspec             >= 2.0   && < 3
+    , QuickCheck        >= 2.10  && < 2.14
+  default-language: Haskell2010
+
 test-suite data-array-test
   import: test-options
   type: exitcode-stdio-1.0

--- a/test/Streamly/Test/Internal/Data/Fold.hs
+++ b/test/Streamly/Test/Internal/Data/Fold.hs
@@ -1,0 +1,27 @@
+module Main (main) where
+
+import qualified Streamly.Prelude as S
+import Streamly.Internal.Data.Fold
+
+import Test.Hspec.QuickCheck
+import Test.QuickCheck (Property, forAll, Gen, vectorOf, arbitrary, choose)
+import Test.QuickCheck.Monadic (monadicIO, assert, run)
+
+import Test.Hspec as H
+
+maxStreamLen :: Int
+maxStreamLen = 1000
+
+testRollingHashFirstN :: Property
+testRollingHashFirstN = 
+    forAll (choose (0, maxStreamLen)) $ \len ->
+        forAll (choose (0, len)) $ \n ->
+            forAll (vectorOf len (arbitrary :: Gen Int)) $ \vec -> monadicIO $ do
+                a <- run $ S.fold rollingHash $ S.take n $ S.fromList vec
+                b <- run $ S.fold (rollingHashFirstN n) $ S.fromList vec
+                assert $ a == b
+
+main :: IO ()
+main = hspec $
+    describe "Rolling Hash Folds" $
+        prop "testRollingHashFirstN" testRollingHashFirstN


### PR DESCRIPTION
Simple one-line combinators.
`iterate`
`iterateM`
`drainN`
`drainWhile`
`rollingHashFirstN`
The changes were small, hence used a single PR.