### PR TITLE
Move Benchmark* from src/ to benchmark/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ matrix:
   #- env: BUILD=stack RESOLVER=nightly
   #  addons: {apt: {packages: [cabal-install-1.24], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack RESOLVER=lts-13 GHCVER=8.6 STACK_BUILD_OPTIONS="--flag streamly:examples-sdl --flag streamly:benchmark"
+  - env: BUILD=stack RESOLVER=lts-13 GHCVER=8.6 STACK_BUILD_OPTIONS="--flag streamly:examples-sdl"
     addons: {apt: {packages: [cabal-install-2.4,libsdl1.2-dev], sources: [hvr-ghc]}}
 
   #- env: BUILD=stack RESOLVER=lts-12 GHCVER=8.4

--- a/benchmark/FileIO.hs
+++ b/benchmark/FileIO.hs
@@ -14,8 +14,8 @@ import System.Process.Typed (shell, runProcess_)
 import Data.IORef
 import Gauge
 
-import qualified Streamly.Internal.Benchmark.FileIO.Stream as BFS
-import qualified Streamly.Internal.Benchmark.FileIO.Array as BFA
+import qualified Streamly.Benchmark.FileIO.Stream as BFS
+import qualified Streamly.Benchmark.FileIO.Array as BFA
 
 -- Input and output file handles
 data Handles = Handles Handle Handle

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -16,7 +16,7 @@ import System.Random (randomRIO)
 import Data.Monoid (Last(..))
 
 import qualified GHC.Exts as GHC
-import qualified Streamly.Internal.Benchmark.Prelude as Ops
+import qualified Streamly.Benchmark.Prelude as Ops
 
 import Streamly
 import qualified Streamly.Data.Fold as FL

--- a/benchmark/LinearAsync.hs
+++ b/benchmark/LinearAsync.hs
@@ -8,7 +8,7 @@
 import Control.DeepSeq (NFData)
 -- import Data.Functor.Identity (Identity, runIdentity)
 import System.Random (randomRIO)
-import qualified Streamly.Internal.Benchmark.Prelude as Ops
+import qualified Streamly.Benchmark.Prelude as Ops
 
 import Streamly
 import Gauge

--- a/benchmark/LinearRate.hs
+++ b/benchmark/LinearRate.hs
@@ -10,7 +10,7 @@
 
 -- import Data.Functor.Identity (Identity, runIdentity)
 import System.Random (randomRIO)
-import qualified Streamly.Internal.Benchmark.Prelude as Ops
+import qualified Streamly.Benchmark.Prelude as Ops
 
 import Streamly
 import Gauge

--- a/benchmark/Streamly/Benchmark/FileIO/Array.hs
+++ b/benchmark/Streamly/Benchmark/FileIO/Array.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      : Streamly.Internal.Benchmark.FileIO.Array
+-- Module      : Streamly.Benchmark.FileIO.Array
 -- Copyright   : (c) 2019 Composewell Technologies
 --
 -- License     : BSD3
@@ -18,7 +18,7 @@
 {-# OPTIONS_GHC -fplugin Test.Inspection.Plugin #-}
 #endif
 
-module Streamly.Internal.Benchmark.FileIO.Array
+module Streamly.Benchmark.FileIO.Array
     (
       last
     , countBytes

--- a/benchmark/Streamly/Benchmark/FileIO/Stream.hs
+++ b/benchmark/Streamly/Benchmark/FileIO/Stream.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      : Streamly.Internal.Benchmark.FileIO.Stream
+-- Module      : Streamly.Benchmark.FileIO.Stream
 -- Copyright   : (c) 2019 Composewell Technologies
 --
 -- License     : BSD3
@@ -19,7 +19,7 @@
 {-# OPTIONS_GHC -fplugin Test.Inspection.Plugin #-}
 #endif
 
-module Streamly.Internal.Benchmark.FileIO.Stream
+module Streamly.Benchmark.FileIO.Stream
     (
     -- * FileIO
       last

--- a/benchmark/Streamly/Benchmark/Prelude.hs
+++ b/benchmark/Streamly/Benchmark/Prelude.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      : Streamly.Internal.Benchmark.Prelude
+-- Module      : Streamly.Benchmark.Prelude
 -- Copyright   : (c) 2018 Harendra Kumar
 --
 -- License     : MIT
@@ -20,7 +20,7 @@
 {-# OPTIONS_GHC -fplugin Test.Inspection.Plugin #-}
 #endif
 
-module Streamly.Internal.Benchmark.Prelude where
+module Streamly.Benchmark.Prelude where
 
 import Control.DeepSeq (NFData)
 import Control.Monad (when)

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -3,5 +3,4 @@ packages:
 
 package streamly
   ghc-options: -Werror
-  flags: benchmark
-         inspection
+  flags: inspection

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -557,11 +557,10 @@ test-suite parallel-loops
 
 benchmark linear
   import: bench-options
-  other-modules: Streamly.Benchmark.Prelude
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: Linear.hs
-  buildable: True
+  other-modules: Streamly.Benchmark.Prelude
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -577,12 +576,11 @@ benchmark linear
 
 benchmark linear-async
   import: bench-options
-  other-modules: Streamly.Benchmark.Prelude
   cpp-options: -DLINEAR_ASYNC
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: LinearAsync.hs
-  buildable: True
+  other-modules: Streamly.Benchmark.Prelude
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -598,11 +596,10 @@ benchmark linear-async
 
 benchmark linear-rate
   import: bench-options
-  other-modules: Streamly.Benchmark.Prelude
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: LinearRate.hs
-  buildable: True
+  other-modules: Streamly.Benchmark.Prelude
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -698,15 +695,14 @@ benchmark array
 
 benchmark fileio
   import: bench-options
-  other-modules: Streamly.Benchmark.FileIO.Array
-               , Streamly.Benchmark.FileIO.Stream
   type: exitcode-stdio-1.0
   -- A value of 400 works better for some benchmarks, however, it takes
   -- extraordinary amount of time to compile with that.
   -- ghc-options: -funfolding-use-threshold=150
   hs-source-dirs: benchmark
   main-is: FileIO.hs
-  buildable: True
+  other-modules: Streamly.Benchmark.FileIO.Array
+               , Streamly.Benchmark.FileIO.Stream
   build-depends:
       streamly
     , base                >= 4.8   && < 5

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -134,11 +134,6 @@ source-repository head
     type: git
     location: https://github.com/composewell/streamly
 
-flag benchmark
-  description: Benchmark build
-  manual: True
-  default: False
-
 flag inspection
   description: Enable inspection testing
   manual: True
@@ -257,6 +252,7 @@ common exe-options
 common bench-options
   import: compile-options, optimization-options
   ghc-options: -with-rtsopts "-T"
+  build-depends: mtl >= 2.2 && < 3
 
 -------------------------------------------------------------------------------
 -- Library
@@ -354,12 +350,6 @@ library
                      , Streamly.Internal.Network.Socket
                      , Streamly.Internal.Network.Inet.TCP
 
-    if flag(benchmark)
-       exposed-modules:
-                       Streamly.Internal.Benchmark.FileIO.Array
-                     , Streamly.Internal.Benchmark.FileIO.Stream
-                     , Streamly.Internal.Benchmark.Prelude
-
     build-depends:     base              >= 4.8   &&  < 5
                      , ghc-prim          >= 0.2   && < 0.6
                      , deepseq           >= 1.4.1 && < 1.5
@@ -378,10 +368,6 @@ library
                      , mtl               >= 2.2   && < 3
                      , transformers      >= 0.4   && < 0.6
                      , transformers-base >= 0.4   && < 0.5
-
-  if flag(inspection)
-    build-depends:     template-haskell   >= 2.14  && < 2.16
-                     , inspection-testing >= 0.4   && < 0.5
 
   if !impl(ghcjs)
     build-depends:
@@ -571,61 +557,64 @@ test-suite parallel-loops
 
 benchmark linear
   import: bench-options
+  other-modules: Streamly.Benchmark.Prelude
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: Linear.hs
-  if flag(benchmark)
-    buildable: True
+  buildable: True
+  build-depends:
+      streamly
+    , base                >= 4.8   && < 5
+    , deepseq             >= 1.4.1 && < 1.5
+    , random              >= 1.0   && < 2.0
+    , gauge               >= 0.2.4 && < 0.3
+  if impl(ghc < 8.0)
     build-depends:
-        streamly
-      , base                >= 4.8   && < 5
-      , deepseq             >= 1.4.1 && < 1.5
-      , random              >= 1.0   && < 2.0
-      , gauge               >= 0.2.4 && < 0.3
-    if impl(ghc < 8.0)
-      build-depends:
-          transformers  >= 0.4 && < 0.6
-  else
-    buildable: False
+        transformers  >= 0.4 && < 0.6
+  if flag(inspection)
+    build-depends:     template-haskell   >= 2.14  && < 2.16
+                     , inspection-testing >= 0.4   && < 0.5
 
 benchmark linear-async
   import: bench-options
+  other-modules: Streamly.Benchmark.Prelude
   cpp-options: -DLINEAR_ASYNC
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: LinearAsync.hs
-  if flag(benchmark)
-    buildable: True
+  buildable: True
+  build-depends:
+      streamly
+    , base                >= 4.8   && < 5
+    , deepseq             >= 1.4.1 && < 1.5
+    , random              >= 1.0   && < 2.0
+    , gauge               >= 0.2.4 && < 0.3
+  if impl(ghc < 8.0)
     build-depends:
-        streamly
-      , base                >= 4.8   && < 5
-      , deepseq             >= 1.4.1 && < 1.5
-      , random              >= 1.0   && < 2.0
-      , gauge               >= 0.2.4 && < 0.3
-    if impl(ghc < 8.0)
-      build-depends:
-          transformers  >= 0.4 && < 0.6
-  else
-    buildable: False
+        transformers  >= 0.4 && < 0.6
+  if flag(inspection)
+    build-depends:     template-haskell   >= 2.14  && < 2.16
+                     , inspection-testing >= 0.4   && < 0.5
 
 benchmark linear-rate
   import: bench-options
+  other-modules: Streamly.Benchmark.Prelude
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: LinearRate.hs
-  if flag(benchmark)
-    buildable: True
+  buildable: True
+  build-depends:
+      streamly
+    , base                >= 4.8   && < 5
+    , deepseq             >= 1.4.1 && < 1.5
+    , random              >= 1.0   && < 2.0
+    , gauge               >= 0.2.4 && < 0.3
+  if impl(ghc < 8.0)
     build-depends:
-        streamly
-      , base                >= 4.8   && < 5
-      , deepseq             >= 1.4.1 && < 1.5
-      , random              >= 1.0   && < 2.0
-      , gauge               >= 0.2.4 && < 0.3
-    if impl(ghc < 8.0)
-      build-depends:
-          transformers  >= 0.4 && < 0.6
-  else
-    buildable: False
+        transformers  >= 0.4 && < 0.6
+  if flag(inspection)
+    build-depends:     template-haskell   >= 2.14  && < 2.16
+                     , inspection-testing >= 0.4   && < 0.5
 
 benchmark nested
   import: bench-options
@@ -709,22 +698,24 @@ benchmark array
 
 benchmark fileio
   import: bench-options
+  other-modules: Streamly.Benchmark.FileIO.Array
+               , Streamly.Benchmark.FileIO.Stream
   type: exitcode-stdio-1.0
   -- A value of 400 works better for some benchmarks, however, it takes
   -- extraordinary amount of time to compile with that.
   -- ghc-options: -funfolding-use-threshold=150
   hs-source-dirs: benchmark
   main-is: FileIO.hs
-  if flag(benchmark)
-    buildable: True
-    build-depends:
-        streamly
-      , base                >= 4.8   && < 5
-      , gauge               >= 0.2.4 && < 0.3
-      , typed-process       >= 0.2.3 && < 0.3
-      , deepseq             >= 1.4.1 && < 1.5
-  else
-    buildable: False
+  buildable: True
+  build-depends:
+      streamly
+    , base                >= 4.8   && < 5
+    , gauge               >= 0.2.4 && < 0.3
+    , typed-process       >= 0.2.3 && < 0.3
+    , deepseq             >= 1.4.1 && < 1.5
+  if flag(inspection)
+    build-depends:     template-haskell   >= 2.14  && < 2.16
+                     , inspection-testing >= 0.4   && < 0.5
 
 benchmark concurrent
   import: bench-options
@@ -750,7 +741,8 @@ benchmark concurrent
 benchmark base
   import: bench-options
   type: exitcode-stdio-1.0
-  include-dirs:     src/Streamly/Internal/Data/Time
+  include-dirs:    src/Streamly/Internal/Data/Time
+                   src
   if os(windows)
     c-sources:     src/Streamly/Internal/Data/Time/Windows.c
   if os(darwin)
@@ -805,7 +797,8 @@ benchmark base
 executable nano-bench
   import: bench-options
   hs-source-dirs: benchmark, src
-  include-dirs:     src/Streamly/Internal/Data/Time
+  include-dirs:    src/Streamly/Internal/Data/Time
+                 , src
   if os(windows)
     c-sources:     src/Streamly/Internal/Data/Time/Windows.c
   if os(darwin)

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -376,6 +376,11 @@ library
     build-depends:
         semigroups    >= 0.18   && < 0.19
 
+  -- Array uses a Storable constraint in dev build making several inspection
+  -- tests fail
+  if flag(dev) && flag(inspection)
+    build-depends: inspection-and-dev-flags-cannot-be-used-together
+
 -------------------------------------------------------------------------------
 -- Test suites
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The modules have been specified to common benchmark properties in the cabal file. They could be moved to individual benchmarks though.