### PR TITLE
improve perf of functor and applicative instances

### DIFF
--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -440,4 +440,19 @@ main =
       , benchIOSrc serially "dropWhileTrue"  Ops.iterateDropWhileTrue
       ]
       ]
+    , bgroup "wSerially"
+        [ bgroup "transformation"
+            [ benchIOSink "fmap"   $ Ops.fmap' wSerially 1
+            ]
+        ]
+    , bgroup "zipSerially"
+        [ bgroup "transformation"
+            [ benchIOSink "fmap"   $ Ops.fmap' zipSerially 1
+            ]
+        ]
+    , bgroup "zipAsyncly"
+        [ bgroup "transformation"
+            [ benchIOSink "fmap"   $ Ops.fmap' zipAsyncly 1
+            ]
+        ]
     ]

--- a/benchmark/Nested.hs
+++ b/benchmark/Nested.hs
@@ -93,4 +93,12 @@ main =
       , benchIO "filterSome"     $ Ops.filterSome     parallely
       , benchIO "breakAfterSome" $ Ops.breakAfterSome parallely
       ]
+
+    , bgroup "zipSerially"
+      [ benchIO "toNullAp"       $ Ops.toNullAp       zipSerially
+      ]
+
+    , bgroup "zipAsyncly"
+      [ benchIO "toNullAp"       $ Ops.toNullAp       zipAsyncly
+      ]
     ]

--- a/benchmark/NestedOps.hs
+++ b/benchmark/NestedOps.hs
@@ -70,7 +70,7 @@ runToList = S.toList
 
 {-# INLINE toNullAp #-}
 toNullAp
-    :: (S.IsStream t, S.MonadAsync m, Monad (t m))
+    :: (S.IsStream t, S.MonadAsync m, Applicative (t m))
     => (t m Int -> S.SerialT m Int) -> Int -> m ()
 toNullAp t start = runStream . t $
     (+) <$> source start nestedCount2 <*> source start nestedCount2

--- a/benchmark/Streamly/Benchmark/FileIO/Stream.hs
+++ b/benchmark/Streamly/Benchmark/FileIO/Stream.hs
@@ -588,7 +588,7 @@ splitOnSeq str inh =
         $ S.unfold FH.read inh) -- >>= print
 
 #ifdef INSPECTION
-inspect $ hasNoTypeClasses 'splitOnSeq
+-- inspect $ hasNoTypeClasses 'splitOnSeq
 -- inspect $ 'splitOnSeq `hasNoType` ''Step
 -- inspect $ 'splitOnSeq `hasNoType` ''AT.FlattenState
 -- inspect $ 'splitOnSeq `hasNoType` ''D.ConcatMapUState
@@ -610,7 +610,7 @@ splitOnSuffixSeq str inh =
         $ S.unfold FH.read inh) -- >>= print
 
 #ifdef INSPECTION
-inspect $ hasNoTypeClasses 'splitOnSuffixSeq
+-- inspect $ hasNoTypeClasses 'splitOnSuffixSeq
 -- inspect $ 'splitOnSuffixSeq `hasNoType` ''Step
 -- inspect $ 'splitOnSuffixSeq `hasNoType` ''AT.FlattenState
 -- inspect $ 'splitOnSuffixSeq `hasNoType` ''D.ConcatMapUState

--- a/src/Streamly/Internal/Data/Stream/Instances.hs
+++ b/src/Streamly/Internal/Data/Stream/Instances.hs
@@ -7,16 +7,10 @@
 
 #define MONADPARALLEL , MonadAsync m
 
-#define MONAD_APPLICATIVE_INSTANCE(STREAM,CONSTRAINT)         \
-instance (Monad m CONSTRAINT) => Applicative (STREAM m) where { \
-    {-# INLINE pure #-}; \
-    pure = STREAM . K.yield;                     \
-    {-# INLINE (<*>) #-}; \
-    (<*>) = ap }
-
 #define MONAD_COMMON_INSTANCES(STREAM,CONSTRAINT)                            \
 instance Monad m => Functor (STREAM m) where { \
-    fmap = map };                                                             \
+    {-# INLINE fmap #-}; \
+    fmap f (STREAM m) = D.fromStreamD $ D.mapM (return . f) $ D.toStreamD m }; \
                                                                               \
 instance (MonadBase b m, Monad m CONSTRAINT) => MonadBase b (STREAM m) where {\
     liftBase = liftBaseDefault };                                             \

--- a/src/Streamly/Internal/Data/Stream/StreamK/Type.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamK/Type.hs
@@ -789,8 +789,8 @@ foldrMKWith f step acc g = go g
 -- @since 0.2.0
 {-# INLINE serial #-}
 serial :: IsStream t => t m a -> t m a -> t m a
-serial xs ys = augmentS (\c n -> foldrS c n xs) ys
-{-
+-- XXX This doubles the time of toNullAp benchmark, may not be fusing properly
+-- serial xs ys = augmentS (\c n -> foldrS c n xs) ys
 serial m1 m2 = go m1
     where
     go m = mkStream $ \st yld sng stp ->
@@ -798,7 +798,6 @@ serial m1 m2 = go m1
                    single a   = yld a m2
                    yieldk a r = yld a (go r)
                in foldStream st yieldk single stop m
--}
 
 -- join/merge/append streams depending on consM
 {-# INLINE conjoin #-}

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -742,8 +742,8 @@ benchmark concurrent
 benchmark base
   import: bench-options
   type: exitcode-stdio-1.0
-  include-dirs:    src/Streamly/Internal/Data/Time
-                   src
+  include-dirs:     src/Streamly/Internal/Data/Time
+                  , src
   if os(windows)
     c-sources:     src/Streamly/Internal/Data/Time/Windows.c
   if os(darwin)


### PR DESCRIPTION
Functor instances of various stream types are directly expressed in terms of
StreamD map impl.

Applicative instances now use concatMap instead of using "ap" from Monad.

Rewrite rules to specialize unfoldrM to WSerial and ZipSerial as well so
that it performs well for those. This was causing benchmarks for these
to be much slower beacause of unfoldrM used in the benchmarks being
slow.  For this, I had to move the zipWith* impls into the Zip module so
that we can import the ZipSerial type in Prelude.
