### PR TITLE
Fix typos

### DIFF
--- a/src/Streamly/Memory/Array.hs
+++ b/src/Streamly/Memory/Array.hs
@@ -24,7 +24,7 @@
 -- 'Storable' values of a given type, they cannot store non-serializable data
 -- like functions.  Once created an array cannot be modified.  Pinned memory
 -- allows efficient buffering of long lived data without adding any impact to
--- GC. One array is just one pointer visible to GC and it does not have to
+-- GC. One array is just one pointer visible to GC and it does not have to be
 -- copied across generations.  Moreover, pinned memory allows communication
 -- with foreign consumers and producers (e.g. file or network IO) without
 -- copying the data.

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -9,7 +9,7 @@
 --
 -- A socket is a handle to a protocol endpoint.
 --
--- This module provides APIs to read and write streams and arrays to and from
+-- This module provides APIs to read and write streams and arrays from and to
 -- network sockets. Sockets may be connected or unconnected. Connected sockets
 -- can only send or recv data to/from the connected endpoint, therefore, APIs
 -- for connected sockets do not need to explicitly specify the remote endpoint.


### PR DESCRIPTION
This PR fixes two typos I found in `Memory.Array` and `Network.Socket`