### PR TITLE
Fix space leak in async combinator

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,9 +3,13 @@
 ### Bug Fixes
 
 * Fix a bug that caused `findIndices` to return wrong indices in some
-pipelines
-
-* Fix a bug in `tap` that sometimes increased memory consumption.
+  cases.
+* Fix a bug in `tap` that caused memory consumption to increase in some cases.
+* Fix a space leak in `async` streams that caused memory consumption
+  to increase with the number of elements in the stream, especially when
+  built with `-threaded` and used with `-N` RTS option. The issue occurs
+  only in cases when a worker thread happens to be used continuously for a
+  long time.
 
 ## 0.7.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -52,6 +52,8 @@ pipelines
 * Fix a bug that caused `uniq` function to yield the same element twice.
 * Fix a bug that caused "thread blocked indefinitely in an MVar operation"
   exception in a parallel stream.
+* Fix unbounded memory usage (leak) in `parallel` combinator. The bug manifests
+  when large streams are combined using `parallel`.
 
 ### Major Enhancements
 

--- a/src/Streamly/Internal/Data/Stream/Async.hs
+++ b/src/Streamly/Internal/Data/Stream/Async.hs
@@ -95,7 +95,7 @@ workLoopLIFO q st sv winfo = run
     yieldk a r = do
         res <- liftIO $ sendYield sv winfo (ChildYield a)
         if res
-        then foldStreamSVar sv st yieldk single run r
+        then foldStreamShared st yieldk single run r
         else liftIO $ do
             enqueueLIFO sv q r
             sendStop sv winfo
@@ -155,7 +155,7 @@ workLoopLIFOLimited q st sv winfo = run
         yieldLimitOk <- liftIO $ decrementYieldLimit sv
         let stop = liftIO (incrementYieldLimit sv) >> run
         if res && yieldLimitOk
-        then foldStreamSVar sv st yieldk single stop r
+        then foldStreamShared st yieldk single stop r
         else liftIO $ do
             incrementYieldLimit sv
             enqueueLIFO sv q r
@@ -196,7 +196,7 @@ workLoopFIFO q st sv winfo = run
     yieldk a r = do
         res <- liftIO $ sendYield sv winfo (ChildYield a)
         if res
-        then foldStreamSVar sv st yieldk single run r
+        then foldStreamShared st yieldk single run r
         else liftIO $ do
             enqueueFIFO sv q r
             sendStop sv winfo
@@ -237,7 +237,7 @@ workLoopFIFOLimited q st sv winfo = run
         yieldLimitOk <- liftIO $ decrementYieldLimit sv
         let stop = liftIO (incrementYieldLimit sv) >> run
         if res && yieldLimitOk
-        then foldStreamSVar sv st yieldk single stop r
+        then foldStreamShared st yieldk single stop r
         else liftIO $ do
             incrementYieldLimit sv
             enqueueFIFO sv q r


### PR DESCRIPTION
We run the stream in a worker thread using captured monadic state from the parent thread. The call to mrun caused memory to stack up because it is called again and again and never returns. We need this call only once when a stream is picked for execution from the work queue. We do not need to call mrun on every yield. The call on yield is removed by this commit.

Fixes #346 