### PR TITLE
Remove cpp-options that control length in linear*

### DIFF
--- a/benchmark/Common.hs
+++ b/benchmark/Common.hs
@@ -1,0 +1,82 @@
+-- |
+-- Module      : Main
+-- Copyright   : (c) 2019 Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : streamly@composewell.com
+
+module Common (parseCLIOpts) where
+
+import Control.Exception (evaluate)
+import Control.Monad (when)
+import Data.List (scanl')
+import Data.Maybe (catMaybes)
+import System.Console.GetOpt
+       (OptDescr(..), ArgDescr(..), ArgOrder(..), getOpt')
+import System.Environment (getArgs)
+import Text.Read (readMaybe)
+
+import Gauge
+
+-------------------------------------------------------------------------------
+-- Parse custom CLI options
+-------------------------------------------------------------------------------
+
+data BenchOpts = StreamSize Int deriving Show
+
+options :: [OptDescr BenchOpts]
+options =
+    [
+      Option [] ["stream-size"] (ReqArg getSize "COUNT") "Stream element count"
+    ]
+
+    where
+
+    getSize :: String -> BenchOpts
+    getSize size =
+        case (readMaybe size :: Maybe Int) of
+            Just x -> StreamSize x
+            Nothing -> error "Stream size must be  numeric"
+
+deleteOptArgs
+    :: (Maybe String, Maybe String) -- (prev, yielded)
+    -> String
+    -> (Maybe String, Maybe String)
+deleteOptArgs (Nothing, _) opt =
+    if opt == "--stream-size"
+    then (Just opt, Nothing)
+    else (Just opt, Just opt)
+
+deleteOptArgs (Just prev, _) opt =
+    if opt == "--stream-size" || prev == "--stream-size"
+    then (Just opt, Nothing)
+    else (Just opt, Just opt)
+
+parseCLIOpts :: Int -> IO (Int, Config, [String])
+parseCLIOpts defaultStreamSize = do
+    args <- getArgs
+
+    -- Parse custom options
+    let (opts, _, _, errs) = getOpt' Permute options args
+    when (not $ null errs) $ error $ concat errs
+    (streamSize, args') <- evaluate $
+        case opts of
+            StreamSize x : _ ->
+                -- Hack! remove the option and its argument from args
+                -- getOpt should have a way to return the unconsumed args in
+                -- correct order.
+                let newArgs =
+                          catMaybes
+                        $ map snd
+                        $ scanl' deleteOptArgs (Nothing, Nothing) args
+                in (x, newArgs)
+            _ -> (defaultStreamSize, args)
+
+    -- Parse gauge options
+    let config = defaultConfig
+                { timeLimit = Just 1
+                , minDuration = 0
+                , includeFirstIter = streamSize > defaultStreamSize
+                }
+    let (cfg, benches) = parseWith config args'
+    return (streamSize, cfg, benches)

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -12,10 +12,10 @@
 
 import Control.DeepSeq (NFData(..), deepseq)
 import Data.Functor.Identity (Identity, runIdentity)
-import System.Random (randomRIO)
 import Data.Monoid (Last(..))
-import System.Environment (getArgs)
-import Text.Read (readMaybe)
+import System.Random (randomRIO)
+
+import Common (parseCLIOpts)
 
 import qualified GHC.Exts as GHC
 import qualified Streamly.Benchmark.Prelude as Ops
@@ -121,13 +121,14 @@ mkListString value = "[1" ++ concat (replicate value ",1") ++ "]"
 mkList :: Int -> [Int]
 mkList value = [1..value]
 
+defaultStreamSize :: Int
+defaultStreamSize = 100000
+
 main :: IO ()
 main = do
-  -- Basement.Terminal.initialize required?
-  args <- getArgs
-  let (value, args') = parseValue args
-      (cfg, extra) = parseWith defaultConfig args'
-  runMode (mode cfg) cfg extra
+  -- XXX Fix indentation
+  (value, cfg, benches) <- parseCLIOpts defaultStreamSize
+  runMode (mode cfg) cfg benches
     [ bgroup "serially"
       [ bgroup "pure"
         [ benchPureSink value "id" id
@@ -474,10 +475,3 @@ main = do
             ]
         ]
     ]
-  where
-      defaultValue = 100000
-      parseValue [] = (defaultValue, [])
-      parseValue a@(x:xs) =
-          case (readMaybe x :: Maybe Int) of
-            Just value -> (value, xs)
-            Nothing -> (defaultValue, a)

--- a/benchmark/Linear.hs
+++ b/benchmark/Linear.hs
@@ -128,7 +128,7 @@ main :: IO ()
 main = do
   -- XXX Fix indentation
   (value, cfg, benches) <- parseCLIOpts defaultStreamSize
-  runMode (mode cfg) cfg benches
+  value `seq` runMode (mode cfg) cfg benches
     [ bgroup "serially"
       [ bgroup "pure"
         [ benchPureSink value "id" id

--- a/benchmark/LinearAsync.hs
+++ b/benchmark/LinearAsync.hs
@@ -51,7 +51,7 @@ main :: IO ()
 main = do
   -- XXX Fix indentation
   (value, cfg, benches) <- parseCLIOpts defaultStreamSize
-  runMode (mode cfg) cfg benches
+  value `seq` runMode (mode cfg) cfg benches
     [ bgroup "asyncly"
         [ benchSrcIO asyncly "unfoldr" (Ops.sourceUnfoldr value)
         , benchSrcIO asyncly "unfoldrM" (Ops.sourceUnfoldrM value)

--- a/benchmark/LinearRate.hs
+++ b/benchmark/LinearRate.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Main
 -- Copyright   : (c) 2018 Harendra Kumar
@@ -11,12 +10,13 @@
 
 -- import Data.Functor.Identity (Identity, runIdentity)
 import System.Random (randomRIO)
-import qualified Streamly.Benchmark.Prelude as Ops
-import System.Environment (getArgs)
-import Text.Read (readMaybe)
+
+import Common (parseCLIOpts)
 
 import Streamly
 import Gauge
+
+import qualified Streamly.Benchmark.Prelude as Ops
 
 -- | Takes a source, and uses it with a default drain/fold method.
 {-# INLINE benchSrcIO #-}
@@ -33,13 +33,14 @@ _benchId :: NFData b => String -> (Ops.Stream m Int -> Identity b) -> Benchmark
 _benchId name f = bench name $ nf (runIdentity . f) (Ops.source 10)
 -}
 
+defaultStreamSize :: Int
+defaultStreamSize = 100000
+
 main :: IO ()
 main = do
-  -- Basement.Terminal.initialize required?
-  args <- getArgs
-  let (value, args') = parseValue args
-      (cfg, extra) = parseWith defaultConfig args'
-  runMode (mode cfg) cfg extra
+  -- XXX Fix indentation
+  (value, cfg, benches) <- parseCLIOpts defaultStreamSize
+  runMode (mode cfg) cfg benches
     -- XXX arbitrarily large rate should be the same as rate Nothing
     [ bgroup "avgrate"
       [ bgroup "asyncly"
@@ -65,10 +66,3 @@ main = do
         ]
       ]
     ]
-  where
-      defaultValue = 100000
-      parseValue [] = (defaultValue, [])
-      parseValue a@(x:xs) =
-          case (readMaybe x :: Maybe Int) of
-            Just value -> (value, xs)
-            Nothing -> (defaultValue, a)

--- a/benchmark/LinearRate.hs
+++ b/benchmark/LinearRate.hs
@@ -40,7 +40,7 @@ main :: IO ()
 main = do
   -- XXX Fix indentation
   (value, cfg, benches) <- parseCLIOpts defaultStreamSize
-  runMode (mode cfg) cfg benches
+  value `seq` runMode (mode cfg) cfg benches
     -- XXX arbitrarily large rate should be the same as rate Nothing
     [ bgroup "avgrate"
       [ bgroup "asyncly"

--- a/benchmark/Nested.hs
+++ b/benchmark/Nested.hs
@@ -11,6 +11,8 @@ import System.Random (randomRIO)
 import qualified NestedOps as Ops
 import Streamly
 import Gauge
+import System.Environment (getArgs)
+import Text.Read (readMaybe)
 
 benchIO :: (NFData b) => String -> (Int -> IO b) -> Benchmark
 benchIO name f = bench name $ nfIO $ randomRIO (1,1) >>= f
@@ -19,34 +21,45 @@ _benchId :: (NFData b) => String -> (Int -> Identity b) -> Benchmark
 _benchId name f = bench name $ nf (\g -> runIdentity (g 1))  f
 
 main :: IO ()
-main =
+main = do
   -- TBD Study scaling with 10, 100, 1000 loop iterations
-  defaultMain
+  -- Basement.Terminal.initialize required?
+  args <- getArgs
+  let (linearCount, args') = parseValue args
+      (cfg, extra) = parseWith defaultConfig args'
+  runMode (mode cfg) cfg extra
     [ bgroup "serially"
-      [ benchIO "toNullAp"       $ Ops.toNullAp       serially
-      , benchIO "toNull"         $ Ops.toNull         serially
-      , benchIO "toNull3"        $ Ops.toNull3        serially
-      , benchIO "toList"         $ Ops.toList         serially
+      [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       serially
+      , benchIO "toNull"         $ Ops.toNull linearCount         serially
+      , benchIO "toNull3"        $ Ops.toNull3 linearCount        serially
+      , benchIO "toList"         $ Ops.toList linearCount         serially
    --   , benchIO "toListSome"     $ Ops.toListSome     serially
-      , benchIO "filterAllOut"   $ Ops.filterAllOut   serially
-      , benchIO "filterAllIn"    $ Ops.filterAllIn    serially
-      , benchIO "filterSome"     $ Ops.filterSome     serially
-      , benchIO "breakAfterSome" $ Ops.breakAfterSome serially
+      , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   serially
+      , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    serially
+      , benchIO "filterSome"     $ Ops.filterSome linearCount     serially
+      , benchIO "breakAfterSome" $ Ops.breakAfterSome linearCount serially
       ]
 
     , bgroup "wSerially"
-      [ benchIO "toNullAp"       $ Ops.toNullAp       wSerially
-      , benchIO "toNull"         $ Ops.toNull         wSerially
-      , benchIO "toNull3"        $ Ops.toNull3        wSerially
-      , benchIO "toList"         $ Ops.toList         wSerially
+      [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       wSerially
+      , benchIO "toNull"         $ Ops.toNull linearCount         wSerially
+      , benchIO "toNull3"        $ Ops.toNull3 linearCount        wSerially
+      , benchIO "toList"         $ Ops.toList linearCount         wSerially
     --  , benchIO "toListSome"     $ Ops.toListSome     wSerially
-      , benchIO "filterAllOut"   $ Ops.filterAllOut   wSerially
-      , benchIO "filterAllIn"    $ Ops.filterAllIn    wSerially
-      , benchIO "filterSome"     $ Ops.filterSome     wSerially
-      , benchIO "breakAfterSome" $ Ops.breakAfterSome wSerially
+      , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   wSerially
+      , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    wSerially
+      , benchIO "filterSome"     $ Ops.filterSome linearCount     wSerially
+      , benchIO "breakAfterSome" $ Ops.breakAfterSome linearCount wSerially
       ]
 
     , bgroup "zipSerially"
-      [ benchIO "toNullAp"       $ Ops.toNullAp       zipSerially
+      [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       zipSerially
       ]
     ]
+  where
+      defaultValue = 100000
+      parseValue [] = (defaultValue, [])
+      parseValue a@(x:xs) =
+          case (readMaybe x :: Maybe Int) of
+            Just value -> (value, xs)
+            Nothing -> (defaultValue, a)

--- a/benchmark/Nested.hs
+++ b/benchmark/Nested.hs
@@ -8,11 +8,13 @@
 import Control.DeepSeq (NFData)
 import Data.Functor.Identity (Identity, runIdentity)
 import System.Random (randomRIO)
-import qualified NestedOps as Ops
+
+import Common (parseCLIOpts)
+
 import Streamly
 import Gauge
-import System.Environment (getArgs)
-import Text.Read (readMaybe)
+
+import qualified NestedOps as Ops
 
 benchIO :: (NFData b) => String -> (Int -> IO b) -> Benchmark
 benchIO name f = bench name $ nfIO $ randomRIO (1,1) >>= f
@@ -20,14 +22,14 @@ benchIO name f = bench name $ nfIO $ randomRIO (1,1) >>= f
 _benchId :: (NFData b) => String -> (Int -> Identity b) -> Benchmark
 _benchId name f = bench name $ nf (\g -> runIdentity (g 1))  f
 
+defaultStreamSize :: Int
+defaultStreamSize = 100000
+
 main :: IO ()
 main = do
-  -- TBD Study scaling with 10, 100, 1000 loop iterations
-  -- Basement.Terminal.initialize required?
-  args <- getArgs
-  let (linearCount, args') = parseValue args
-      (cfg, extra) = parseWith defaultConfig args'
-  runMode (mode cfg) cfg extra
+  -- XXX Fix indentation
+  (linearCount, cfg, benches) <- parseCLIOpts defaultStreamSize
+  runMode (mode cfg) cfg benches
     [ bgroup "serially"
       [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       serially
       , benchIO "toNull"         $ Ops.toNull linearCount         serially
@@ -56,10 +58,3 @@ main = do
       [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       zipSerially
       ]
     ]
-  where
-      defaultValue = 100000
-      parseValue [] = (defaultValue, [])
-      parseValue a@(x:xs) =
-          case (readMaybe x :: Maybe Int) of
-            Just value -> (value, xs)
-            Nothing -> (defaultValue, a)

--- a/benchmark/Nested.hs
+++ b/benchmark/Nested.hs
@@ -29,7 +29,7 @@ main :: IO ()
 main = do
   -- XXX Fix indentation
   (linearCount, cfg, benches) <- parseCLIOpts defaultStreamSize
-  runMode (mode cfg) cfg benches
+  linearCount `seq` runMode (mode cfg) cfg benches
     [ bgroup "serially"
       [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       serially
       , benchIO "toNull"         $ Ops.toNull linearCount         serially

--- a/benchmark/NestedConcurrent.hs
+++ b/benchmark/NestedConcurrent.hs
@@ -11,6 +11,8 @@ import System.Random (randomRIO)
 import qualified NestedOps as Ops
 import Streamly
 import Gauge
+import System.Environment (getArgs)
+import Text.Read (readMaybe)
 
 benchIO :: (NFData b) => String -> (Int -> IO b) -> Benchmark
 benchIO name f = bench name $ nfIO $ randomRIO (1,1) >>= f
@@ -19,59 +21,70 @@ _benchId :: (NFData b) => String -> (Int -> Identity b) -> Benchmark
 _benchId name f = bench name $ nf (\g -> runIdentity (g 1))  f
 
 main :: IO ()
-main =
+main = do
   -- TBD Study scaling with 10, 100, 1000 loop iterations
-  defaultMain
+  -- Basement.Terminal.initialize required?
+  args <- getArgs
+  let (linearCount, args') = parseValue args
+      (cfg, extra) = parseWith defaultConfig args'
+  runMode (mode cfg) cfg extra
     [
       bgroup "aheadly"
-      [ benchIO "toNullAp"       $ Ops.toNullAp       aheadly
-      , benchIO "toNull"         $ Ops.toNull         aheadly
-      , benchIO "toNull3"        $ Ops.toNull3        aheadly
-      , benchIO "toList"         $ Ops.toList         aheadly
+      [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       aheadly
+      , benchIO "toNull"         $ Ops.toNull linearCount         aheadly
+      , benchIO "toNull3"        $ Ops.toNull3 linearCount        aheadly
+      , benchIO "toList"         $ Ops.toList linearCount         aheadly
      -- , benchIO "toListSome"     $ Ops.toListSome     aheadly
-      , benchIO "filterAllOut"   $ Ops.filterAllOut   aheadly
-      , benchIO "filterAllIn"    $ Ops.filterAllIn    aheadly
-      , benchIO "filterSome"     $ Ops.filterSome     aheadly
-      , benchIO "breakAfterSome" $ Ops.breakAfterSome aheadly
+      , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   aheadly
+      , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    aheadly
+      , benchIO "filterSome"     $ Ops.filterSome linearCount     aheadly
+      , benchIO "breakAfterSome" $ Ops.breakAfterSome linearCount aheadly
       ]
 
     , bgroup "asyncly"
-      [ benchIO "toNullAp"       $ Ops.toNullAp       asyncly
-      , benchIO "toNull"         $ Ops.toNull         asyncly
-      , benchIO "toNull3"        $ Ops.toNull3        asyncly
-      , benchIO "toList"         $ Ops.toList         asyncly
+      [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       asyncly
+      , benchIO "toNull"         $ Ops.toNull linearCount         asyncly
+      , benchIO "toNull3"        $ Ops.toNull3 linearCount        asyncly
+      , benchIO "toList"         $ Ops.toList linearCount         asyncly
     --  , benchIO "toListSome"     $ Ops.toListSome     asyncly
-      , benchIO "filterAllOut"   $ Ops.filterAllOut   asyncly
-      , benchIO "filterAllIn"    $ Ops.filterAllIn    asyncly
-      , benchIO "filterSome"     $ Ops.filterSome     asyncly
-      , benchIO "breakAfterSome" $ Ops.breakAfterSome asyncly
+      , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   asyncly
+      , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    asyncly
+      , benchIO "filterSome"     $ Ops.filterSome linearCount     asyncly
+      , benchIO "breakAfterSome" $ Ops.breakAfterSome linearCount asyncly
       ]
 
     , bgroup "wAsyncly"
-      [ benchIO "toNullAp"       $ Ops.toNullAp       wAsyncly
-      , benchIO "toNull"         $ Ops.toNull         wAsyncly
-      , benchIO "toNull3"        $ Ops.toNull3        wAsyncly
-      , benchIO "toList"         $ Ops.toList         wAsyncly
+      [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       wAsyncly
+      , benchIO "toNull"         $ Ops.toNull linearCount         wAsyncly
+      , benchIO "toNull3"        $ Ops.toNull3 linearCount        wAsyncly
+      , benchIO "toList"         $ Ops.toList linearCount         wAsyncly
      -- , benchIO "toListSome"     $ Ops.toListSome     wAsyncly
-      , benchIO "filterAllOut"   $ Ops.filterAllOut   wAsyncly
-      , benchIO "filterAllIn"    $ Ops.filterAllIn    wAsyncly
-      , benchIO "filterSome"     $ Ops.filterSome     wAsyncly
-      , benchIO "breakAfterSome" $ Ops.breakAfterSome wAsyncly
+      , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   wAsyncly
+      , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    wAsyncly
+      , benchIO "filterSome"     $ Ops.filterSome linearCount     wAsyncly
+      , benchIO "breakAfterSome" $ Ops.breakAfterSome linearCount wAsyncly
       ]
 
     , bgroup "parallely"
-      [ benchIO "toNullAp"       $ Ops.toNullAp       parallely
-      , benchIO "toNull"         $ Ops.toNull         parallely
-      , benchIO "toNull3"        $ Ops.toNull3        parallely
-      , benchIO "toList"         $ Ops.toList         parallely
+      [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       parallely
+      , benchIO "toNull"         $ Ops.toNull linearCount         parallely
+      , benchIO "toNull3"        $ Ops.toNull3 linearCount        parallely
+      , benchIO "toList"         $ Ops.toList linearCount         parallely
       --, benchIO "toListSome"     $ Ops.toListSome     parallely
-      , benchIO "filterAllOut"   $ Ops.filterAllOut   parallely
-      , benchIO "filterAllIn"    $ Ops.filterAllIn    parallely
-      , benchIO "filterSome"     $ Ops.filterSome     parallely
-      , benchIO "breakAfterSome" $ Ops.breakAfterSome parallely
+      , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   parallely
+      , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    parallely
+      , benchIO "filterSome"     $ Ops.filterSome linearCount     parallely
+      , benchIO "breakAfterSome" $ Ops.breakAfterSome linearCount parallely
       ]
 
     , bgroup "zipAsyncly"
-      [ benchIO "toNullAp"       $ Ops.toNullAp       zipAsyncly
+      [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       zipAsyncly
       ]
     ]
+  where
+      defaultValue = 100000
+      parseValue [] = (defaultValue, [])
+      parseValue a@(x:xs) =
+          case (readMaybe x :: Maybe Int) of
+            Just value -> (value, xs)
+            Nothing -> (defaultValue, a)

--- a/benchmark/NestedConcurrent.hs
+++ b/benchmark/NestedConcurrent.hs
@@ -29,7 +29,7 @@ main :: IO ()
 main = do
   -- XXX Fix indentation
   (linearCount, cfg, benches) <- parseCLIOpts defaultStreamSize
-  runMode (mode cfg) cfg benches
+  linearCount `seq` runMode (mode cfg) cfg benches
     [
       bgroup "aheadly"
       [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       aheadly

--- a/benchmark/NestedOps.hs
+++ b/benchmark/NestedOps.hs
@@ -17,21 +17,6 @@ import GHC.Exception (ErrorCall)
 import qualified Streamly          as S hiding (runStream)
 import qualified Streamly.Prelude  as S
 
-linearCount :: Int
-#ifdef LONG_BENCHMARKS
-linearCount = 10000000
-#else
-linearCount = 100000
-#endif
-
--- double nested loop
-nestedCount2 :: Int
-nestedCount2 = round (fromIntegral linearCount**(1/2::Double))
-
--- triple nested loop
-nestedCount3 :: Int
-nestedCount3 = round (fromIntegral linearCount**(1/3::Double))
-
 -------------------------------------------------------------------------------
 -- Stream generation and elimination
 -------------------------------------------------------------------------------
@@ -42,6 +27,7 @@ type Stream m a = S.SerialT m a
 source :: (S.MonadAsync m, S.IsStream t) => Int -> Int -> t m Int
 source = sourceUnfoldrM
 
+-- Change this to "sourceUnfoldrM value n" for consistency
 {-# INLINE sourceUnfoldrM #-}
 sourceUnfoldrM :: (S.IsStream t, S.MonadAsync m) => Int -> Int -> t m Int
 sourceUnfoldrM n value = S.serially $ S.unfoldrM step n
@@ -75,89 +61,105 @@ runToList = S.toList
 {-# INLINE toNullAp #-}
 toNullAp
     :: (S.IsStream t, S.MonadAsync m, Applicative (t m))
-    => (t m Int -> S.SerialT m Int) -> Int -> m ()
-toNullAp t start = runStream . t $
+    => Int -> (t m Int -> S.SerialT m Int) -> Int -> m ()
+toNullAp linearCount t start = runStream . t $
     (+) <$> source start nestedCount2 <*> source start nestedCount2
+  where
+    nestedCount2 = round (fromIntegral linearCount**(1/2::Double))
 
 {-# INLINE toNull #-}
 toNull
     :: (S.IsStream t, S.MonadAsync m, Monad (t m))
-    => (t m Int -> S.SerialT m Int) -> Int -> m ()
-toNull t start = runStream . t $ do
+    => Int -> (t m Int -> S.SerialT m Int) -> Int -> m ()
+toNull linearCount t start = runStream . t $ do
     x <- source start nestedCount2
     y <- source start nestedCount2
     return $ x + y
+  where
+    nestedCount2 = round (fromIntegral linearCount**(1/2::Double))
 
 {-# INLINE toNull3 #-}
 toNull3
     :: (S.IsStream t, S.MonadAsync m, Monad (t m))
-    => (t m Int -> S.SerialT m Int) -> Int -> m ()
-toNull3 t start = runStream . t $ do
+    => Int -> (t m Int -> S.SerialT m Int) -> Int -> m ()
+toNull3 linearCount t start = runStream . t $ do
     x <- source start nestedCount3
     y <- source start nestedCount3
     z <- source start nestedCount3
     return $ x + y + z
+  where
+    nestedCount3 = round (fromIntegral linearCount**(1/3::Double))
 
 {-# INLINE toList #-}
 toList
     :: (S.IsStream t, S.MonadAsync m, Monad (t m))
-    => (t m Int -> S.SerialT m Int) -> Int -> m [Int]
-toList t start = runToList . t $ do
+    => Int -> (t m Int -> S.SerialT m Int) -> Int -> m [Int]
+toList linearCount t start = runToList . t $ do
     x <- source start nestedCount2
     y <- source start nestedCount2
     return $ x + y
+  where
+    nestedCount2 = round (fromIntegral linearCount**(1/2::Double))
 
 {-# INLINE toListSome #-}
 toListSome
     :: (S.IsStream t, S.MonadAsync m, Monad (t m))
-    => (t m Int -> S.SerialT m Int) -> Int -> m [Int]
-toListSome t start =
+    => Int -> (t m Int -> S.SerialT m Int) -> Int -> m [Int]
+toListSome linearCount t start =
     runToList . t $ S.take 1000 $ do
         x <- source start nestedCount2
         y <- source start nestedCount2
         return $ x + y
+  where
+    nestedCount2 = round (fromIntegral linearCount**(1/2::Double))
 
 {-# INLINE filterAllOut #-}
 filterAllOut
     :: (S.IsStream t, S.MonadAsync m, Monad (t m))
-    => (t m Int -> S.SerialT m Int) -> Int -> m ()
-filterAllOut t start = runStream . t $ do
+    => Int -> (t m Int -> S.SerialT m Int) -> Int -> m ()
+filterAllOut linearCount t start = runStream . t $ do
     x <- source start nestedCount2
     y <- source start nestedCount2
     let s = x + y
     if s < 0
     then return s
     else S.nil
+  where
+    nestedCount2 = round (fromIntegral linearCount**(1/2::Double))
 
 {-# INLINE filterAllIn #-}
 filterAllIn
     :: (S.IsStream t, S.MonadAsync m, Monad (t m))
-    => (t m Int -> S.SerialT m Int) -> Int -> m ()
-filterAllIn t start = runStream . t $ do
+    => Int -> (t m Int -> S.SerialT m Int) -> Int -> m ()
+filterAllIn linearCount t start = runStream . t $ do
     x <- source start nestedCount2
     y <- source start nestedCount2
     let s = x + y
     if s > 0
     then return s
     else S.nil
+  where
+    nestedCount2 = round (fromIntegral linearCount**(1/2::Double))
 
 {-# INLINE filterSome #-}
 filterSome
     :: (S.IsStream t, S.MonadAsync m, Monad (t m))
-    => (t m Int -> S.SerialT m Int) -> Int -> m ()
-filterSome t start = runStream . t $ do
+    => Int -> (t m Int -> S.SerialT m Int) -> Int -> m ()
+filterSome linearCount t start = runStream . t $ do
     x <- source start nestedCount2
     y <- source start nestedCount2
     let s = x + y
     if s > 1100000
     then return s
     else S.nil
+  where
+    nestedCount2 = round (fromIntegral linearCount**(1/2::Double))
 
 {-# INLINE breakAfterSome #-}
 breakAfterSome
     :: (S.IsStream t, Monad (t IO))
-    => (t IO Int -> S.SerialT IO Int) -> Int -> IO ()
-breakAfterSome t start = do
+    => Int -> (t IO Int -> S.SerialT IO Int) -> Int -> IO ()
+breakAfterSome linearCount t start = do
     (_ :: Either ErrorCall ()) <- try $ runStream . t $ do
         x <- source start nestedCount2
         y <- source start nestedCount2
@@ -166,3 +168,5 @@ breakAfterSome t start = do
         then error "break"
         else return s
     return ()
+  where
+    nestedCount2 = round (fromIntegral linearCount**(1/2::Double))

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -584,29 +584,18 @@ test-suite parallel-loops
 -- Benchmarks
 -------------------------------------------------------------------------------
 
+-- NOTE :
+-- For linear, linear-async and linear-rate if you want to pass the number
+-- of stream elements for benchmarking then you can pass it as the first 
+-- argument after `--`, as a gauge argument. If you don't give the argument,
+-- the number of stream elements default to 100000.
+-- Examples:
+-- $ cabal run linear -- 1000000 [additional gauge options here...]
+-- $ cabal run linear -- [additional gauge options here...]
+
 benchmark linear
   import: bench-options
   type: exitcode-stdio-1.0
-  hs-source-dirs: benchmark
-  main-is: Linear.hs
-  other-modules: Streamly.Benchmark.Prelude
-  build-depends:
-      streamly
-    , base                >= 4.8   && < 5
-    , deepseq             >= 1.4.1 && < 1.5
-    , random              >= 1.0   && < 2.0
-    , gauge               >= 0.2.4 && < 0.3
-  if impl(ghc < 8.0)
-    build-depends:
-        transformers  >= 0.4 && < 0.6
-  if flag(inspection)
-    build-depends:     template-haskell   >= 2.14  && < 2.16
-                     , inspection-testing >= 0.4   && < 0.5
-
-benchmark linear-long
-  import: bench-options-threaded
-  type: exitcode-stdio-1.0
-  cpp-options: -DLONG_BENCHMARKS
   hs-source-dirs: benchmark
   main-is: Linear.hs
   other-modules: Streamly.Benchmark.Prelude
@@ -729,7 +718,6 @@ benchmark fileio
 
 benchmark linear-async
   import: bench-options-threaded
-  cpp-options: -DLINEAR_ASYNC
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: LinearAsync.hs
@@ -746,30 +734,6 @@ benchmark linear-async
   if flag(inspection)
     build-depends:     template-haskell   >= 2.14  && < 2.16
                      , inspection-testing >= 0.4   && < 0.5
-
-benchmark linear-async-long
-  import: bench-options-threaded
-  cpp-options: -DLONG_BENCHMARKS
-  type: exitcode-stdio-1.0
-  hs-source-dirs: benchmark
-  main-is: LinearAsync.hs
-  other-modules: Streamly.Benchmark.Prelude
-  if flag(dev)
-    buildable: True
-    build-depends:
-        streamly
-      , base                >= 4.8   && < 5
-      , deepseq             >= 1.4.1 && < 1.5
-      , random              >= 1.0   && < 2.0
-      , gauge               >= 0.2.4 && < 0.3
-    if impl(ghc < 8.0)
-      build-depends:
-          transformers  >= 0.4 && < 0.6
-    if flag(inspection)
-      build-depends:     template-haskell   >= 2.14  && < 2.16
-                       , inspection-testing >= 0.4   && < 0.5
-  else
-    buildable: False
 
 benchmark nested-concurrent
   import: bench-options-threaded

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -584,21 +584,17 @@ test-suite parallel-loops
 -- Benchmarks
 -------------------------------------------------------------------------------
 
--- NOTE :
--- For linear, linear-async, linear-rate, nested and nested-concurrent if you
--- want to pass the number of stream elements for benchmarking, you can pass it
--- as the first argument after `--`, as a gauge argument. If you don't give the
--- argument, the number of stream elements default to 100000.
--- Examples:
--- $ cabal run linear -- 1000000 [additional gauge options here...]
--- $ cabal run linear -- [additional gauge options here...]
+-- For linear, linear-async, linear-rate, nested and nested-concurrent
+-- you can pass the number of elements in the stream using the
+-- --stream-size option:
+-- $ cabal run linear -- --stream-size 1000000
 
 benchmark linear
   import: bench-options
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: Linear.hs
-  other-modules: Streamly.Benchmark.Prelude
+  other-modules: Streamly.Benchmark.Prelude, Common
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -617,7 +613,7 @@ benchmark nested
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: Nested.hs
-  other-modules: NestedOps
+  other-modules: NestedOps, Common
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -721,7 +717,7 @@ benchmark linear-async
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: LinearAsync.hs
-  other-modules: Streamly.Benchmark.Prelude
+  other-modules: Streamly.Benchmark.Prelude, Common
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -740,7 +736,7 @@ benchmark nested-concurrent
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: NestedConcurrent.hs
-  other-modules: NestedOps
+  other-modules: NestedOps, Common
   build-depends:
       streamly
     , base                >= 4.8   && < 5
@@ -756,7 +752,7 @@ benchmark linear-rate
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: LinearRate.hs
-  other-modules: Streamly.Benchmark.Prelude
+  other-modules: Streamly.Benchmark.Prelude, Common
   build-depends:
       streamly
     , base                >= 4.8   && < 5

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -585,10 +585,10 @@ test-suite parallel-loops
 -------------------------------------------------------------------------------
 
 -- NOTE :
--- For linear, linear-async and linear-rate if you want to pass the number
--- of stream elements for benchmarking then you can pass it as the first 
--- argument after `--`, as a gauge argument. If you don't give the argument,
--- the number of stream elements default to 100000.
+-- For linear, linear-async, linear-rate, nested and nested-concurrent if you
+-- want to pass the number of stream elements for benchmarking, you can pass it
+-- as the first argument after `--`, as a gauge argument. If you don't give the
+-- argument, the number of stream elements default to 100000.
 -- Examples:
 -- $ cabal run linear -- 1000000 [additional gauge options here...]
 -- $ cabal run linear -- [additional gauge options here...]
@@ -737,23 +737,6 @@ benchmark linear-async
 
 benchmark nested-concurrent
   import: bench-options-threaded
-  type: exitcode-stdio-1.0
-  hs-source-dirs: benchmark
-  main-is: NestedConcurrent.hs
-  other-modules: NestedOps
-  build-depends:
-      streamly
-    , base                >= 4.8   && < 5
-    , deepseq             >= 1.4.1 && < 1.5
-    , random              >= 1.0   && < 2.0
-    , gauge               >= 0.2.4 && < 0.3
-  if impl(ghc < 8.0)
-    build-depends:
-        transformers  >= 0.4 && < 0.6
-
-benchmark nested-concurrent-long
-  import: bench-options-threaded
-  cpp-options: -DLONG_BENCHMARKS
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: NestedConcurrent.hs


### PR DESCRIPTION
* This includes linear, linear-async, linear-rate
* Modules removed: linear-long, linear-async-long
* CPP options removed: -DLINEAR_ASYNC

TODO:
- [X] Remove  `-DLONG_BENCHMARKS` completely
  - [X] Remove nested-concurrent-long

NOTE: Other benchmarks should be made/modified in the same fashion, but that can be done in the later stage when variable length is needed. This PR only aims to get rid of the current cpp-options that define the stream length.