### PR TITLE
Minor documentation and strictness changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ matrix:
   # Use CABAL_BUILD_OPTIONS to pass any options to cabal e.g. project-file
   # DISABLE_SDIST_BUILD is set because of a cabal issue. 'cabal info'
   # unnecessarily requires "ghc".
-  - env: BUILD=cabal-v2 ENABLE_GHCJS=y ENABLE_INSTALL= DISABLE_DOCS=y DISABLE_SDIST_BUILD=y
+  - env: BUILD=cabal-v2 ENABLE_GHCJS=y DISABLE_TEST=y ENABLE_INSTALL= DISABLE_DOCS=y DISABLE_SDIST_BUILD=y
     addons:
       apt:
         sources:

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,8 @@
 
 * Fix a bug that caused `findIndices` to return wrong indices in some
   cases.
-* Fix a bug in `tap` that caused memory consumption to increase in some cases.
+* Fix a bug in `tap`, `chunksOf` that caused memory consumption to
+  increase in some cases.
 * Fix a space leak in `async` streams that caused memory consumption
   to increase with the number of elements in the stream, especially when
   built with `-threaded` and used with `-N` RTS option. The issue occurs

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
   Hackage.
 * [Latest development version](https://github.com/composewell/streamly) is
   available on github.
-* See [recommeded compilation options here](docs/Build.md).
+* See [recommended compilation options here](docs/Build.md).
 
 If you are using `stack` or `nix` please make sure to add the latest version
 from Hackage to your tool configuration.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ performance results and a comparison with the `async` package.
 
 ## Installing and using
 
-Please see [INSTALL.md](INSTALL.md) for instructions on how to use streamly
+Please see [INSTALL.md](./INSTALL.md) for instructions on how to use streamly
 with your Haskell build tool or package manager. You may want to go through it
 before jumping to run the examples below.
 
@@ -508,7 +508,7 @@ In presence of concurrency, synchronous exceptions work just the way they are
 supposed to work in non-concurrent code. When concurrent streams
 are combined together, exceptions from the constituent streams are propagated
 to the consumer stream. When an exception occurs in any of the constituent
-streams other concurrent streams are promptly terminated. 
+streams other concurrent streams are promptly terminated.
 
 There is no notion of explicit threads in streamly, therefore, no
 asynchronous exceptions to deal with. You can just ignore the zillions of

--- a/src/Streamly/Data/Unfold.hs
+++ b/src/Streamly/Data/Unfold.hs
@@ -22,8 +22,8 @@
 -- values from a single starting value often called a seed value. Values can be
 -- generated and /pulled/ from the 'Unfold' one at a time. It can also be
 -- called a producer or a source of stream.  It is a data representation of the
--- standard 'S.unfoldr' function.  An 'Unfold' can be converted into a stream
--- type using 'S.unfold' by supplying the seed.
+-- standard 'Streamly.Prelude.unfoldr' function.  An 'Unfold' can be converted
+-- into a stream type using 'Streamly.Prelude.unfold' by supplying the seed.
 --
 -- = Performance Notes
 --
@@ -34,13 +34,13 @@
 -- @Unfold m a b@ can be considered roughly equivalent to an action @a -> t m
 -- b@ (where @t@ is a stream type). Instead of using an 'Unfold' one could just
 -- use a function of the shape @a -> t m b@. However, working with stream types
--- like 'S.SerialT' does not allow the compiler to perform stream fusion
+-- like t'Streamly.SerialT' does not allow the compiler to perform stream fusion
 -- optimization when merging, appending or concatenating multiple streams.
 -- Even though stream based combinator have excellent performance, they are
 -- much less efficient when compared to combinators using 'Unfold'.  For
--- example, the 'S.concatMap' combinator which uses @a -> t m b@ (where @t@ is
--- a stream type) to generate streams is much less efficient compared to
--- 'S.concatUnfold'.
+-- example, the 'Streamly.Prelude.concatMap' combinator which uses @a -> t m b@
+-- (where @t@ is a stream type) to generate streams is much less efficient
+-- compared to 'Streamly.Prelude.concatUnfold'.
 --
 -- On the other hand, transformation operations on stream types are as
 -- efficient as transformations on 'Unfold'.
@@ -58,8 +58,8 @@
 -- More, not yet exposed, unfold combinators can be found in
 -- "Streamly.Internal.Data.Unfold".
 
--- The stream types (e.g. 'S.SerialT') can be considered as a special case of
--- 'Unfold' with no starting seed.
+-- The stream types (e.g. t'Streamly.SerialT') can be considered as a special
+-- case of 'Unfold' with no starting seed.
 --
 module Streamly.Data.Unfold
     (

--- a/src/Streamly/Data/Unicode/Stream.hs
+++ b/src/Streamly/Data/Unicode/Stream.hs
@@ -58,8 +58,9 @@
 --
 -- = Experimental APIs
 --
--- Some experimental APIs to conveniently process text using the @Array Char@
--- represenation directly can be found in "Streamly.Internal.Unicode.Array".
+-- Some experimental APIs to conveniently process text using the
+-- @Array Char@ represenation directly can be found in
+-- "Streamly.Internal.Memory.Unicode.Array".
 
 -- XXX an unpinned array representation can be useful to store short and short
 -- lived strings in memory.

--- a/src/Streamly/Internal/Data/Atomics.hs
+++ b/src/Streamly/Internal/Data/Atomics.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE CPP         #-}
 
 -- |

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -623,7 +623,7 @@ foldMapM act = Fold step begin done
 -- | Folds the input stream to a list.
 --
 -- /Warning!/ working on large lists accumulated as buffers in memory could be
--- very inefficient, consider using "Streamly.Array" instead.
+-- very inefficient, consider using "Streamly.Memory.Array" instead.
 --
 -- @since 0.7.0
 
@@ -641,7 +641,7 @@ toList = Fold (\f x -> return $ f . (x :))
 -- | A fold that drains the first n elements of its input, running the effects
 -- and discarding the results.
 {-# INLINABLE drainN #-}
-drainN :: Monad m => Int -> Fold m a () 
+drainN :: Monad m => Int -> Fold m a ()
 drainN n = ltake n drain
 
 -- | A fold that drains elements of its input as long as the predicate succeeds,

--- a/src/Streamly/Internal/Data/Fold/Types.hs
+++ b/src/Streamly/Internal/Data/Fold/Types.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}

--- a/src/Streamly/Internal/Data/List.hs
+++ b/src/Streamly/Internal/Data/List.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide                #-}
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/src/Streamly/Internal/Data/Pipe.hs
+++ b/src/Streamly/Internal/Data/Pipe.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}

--- a/src/Streamly/Internal/Data/Pipe/Types.hs
+++ b/src/Streamly/Internal/Data/Pipe/Types.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
 

--- a/src/Streamly/Internal/Data/SVar.hs
+++ b/src/Streamly/Internal/Data/SVar.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide                #-}
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE ConstraintKinds            #-}

--- a/src/Streamly/Internal/Data/Sink.hs
+++ b/src/Streamly/Internal/Data/Sink.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_HADDOCK hide #-}
-
 -- |
 -- Module      : Streamly.Internal.Data.Sink
 -- Copyright   : (c) 2019 Composewell Technologies

--- a/src/Streamly/Internal/Data/Sink/Types.hs
+++ b/src/Streamly/Internal/Data/Sink/Types.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_HADDOCK hide #-}
-
 -- |
 -- Module      : Streamly.Internal.Data.Sink.Types
 -- Copyright   : (c) 2019 Composewell Technologies

--- a/src/Streamly/Internal/Data/Sink/Types.hs
+++ b/src/Streamly/Internal/Data/Sink/Types.hs
@@ -16,9 +16,9 @@ where
 -- Sink
 ------------------------------------------------------------------------------
 
--- | A 'Sink' is a special type of 'Foldl' that does not accumulate any value,
+-- | A 'Sink' is a special type of 'Fold' that does not accumulate any value,
 -- but runs only effects. A 'Sink' has no state to maintain therefore can be a
--- bit more efficient than a 'Foldl' with '()' as the state, especially when
+-- bit more efficient than a 'Fold' with '()' as the state, especially when
 -- 'Sink's are composed with other operations. A Sink can be upgraded to a
--- 'Foldl', but a 'Foldl' cannot be converted into a Sink.
+-- 'Fold', but a 'Fold' cannot be converted into a Sink.
 data Sink m a = Sink (a -> m ())

--- a/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide     #-}
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ConstraintKinds           #-}

--- a/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
@@ -585,7 +585,7 @@ groupsOf n (Fold fstep initial extract) (Stream step state) =
         r <- step (adaptState gst) st
         case r of
             Yield x s -> do
-                fs' <- fstep fs x
+                !fs' <- fstep fs x
                 let i' = i + 1
                 return $
                     if i' >= n
@@ -629,7 +629,7 @@ groupsOf2 n input (Fold2 fstep inject extract) (Stream step state) =
         r <- step (adaptState gst) st
         case r of
             Yield x s -> do
-                fs' <- fstep fs x
+                !fs' <- fstep fs x
                 let i' = i + 1
                 return $
                     if i' >= n

--- a/src/Streamly/Internal/Data/Strict.hs
+++ b/src/Streamly/Internal/Data/Strict.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_HADDOCK hide #-}
-
 -- |
 -- Module      : Streamly.Internal.Data.Strict
 -- Copyright   : (c) 2019 Composewell Technologies

--- a/src/Streamly/Internal/Data/Time.hs
+++ b/src/Streamly/Internal/Data/Time.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_HADDOCK hide #-}
-
 -- |
 -- Module      : Streamly.Internal.Data.Time
 -- Copyright   : (c) 2017 Harendra Kumar

--- a/src/Streamly/Internal/Data/Time/Clock.hsc
+++ b/src/Streamly/Internal/Data/Time/Clock.hsc
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide                 #-}
 {-# LANGUAGE CPP                         #-}
 {-# LANGUAGE DeriveGeneric               #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving  #-}

--- a/src/Streamly/Internal/Data/Time/Units.hs
+++ b/src/Streamly/Internal/Data/Time/Units.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide                #-}
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}

--- a/src/Streamly/Internal/Data/Unfold.hs
+++ b/src/Streamly/Internal/Data/Unfold.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}

--- a/src/Streamly/Internal/Data/Unfold/Types.hs
+++ b/src/Streamly/Internal/Data/Unfold/Types.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}

--- a/src/Streamly/Internal/Data/Unicode/Char.hs
+++ b/src/Streamly/Internal/Data/Unicode/Char.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide      #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 -- |

--- a/src/Streamly/Internal/Data/Unicode/Stream.hs
+++ b/src/Streamly/Internal/Data/Unicode/Stream.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide      #-}
 {-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/src/Streamly/Internal/FileSystem/Dir.hs
+++ b/src/Streamly/Internal/FileSystem/Dir.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide     #-}
 {-# LANGUAGE CPP             #-}
 {-# LANGUAGE BangPatterns    #-}
 {-# LANGUAGE MagicHash       #-}

--- a/src/Streamly/Internal/FileSystem/File.hs
+++ b/src/Streamly/Internal/FileSystem/File.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide      #-}
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/src/Streamly/Internal/FileSystem/Handle.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide     #-}
 {-# LANGUAGE CPP             #-}
 {-# LANGUAGE BangPatterns    #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/src/Streamly/Internal/Memory/Array.hs
+++ b/src/Streamly/Internal/Memory/Array.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide         #-}
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE MagicHash           #-}

--- a/src/Streamly/Internal/Memory/Array/Types.hs
+++ b/src/Streamly/Internal/Memory/Array/Types.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide               #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE ExistentialQuantification #-}

--- a/src/Streamly/Internal/Memory/ArrayStream.hs
+++ b/src/Streamly/Internal/Memory/ArrayStream.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide         #-}
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE MagicHash           #-}

--- a/src/Streamly/Internal/Memory/Unicode/Array.hs
+++ b/src/Streamly/Internal/Memory/Unicode/Array.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide      #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 -- |

--- a/src/Streamly/Internal/Network/Inet/TCP.hs
+++ b/src/Streamly/Internal/Network/Inet/TCP.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide      #-}
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/src/Streamly/Internal/Network/Socket.hs
+++ b/src/Streamly/Internal/Network/Socket.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide      #-}
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_HADDOCK hide      #-}
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE RankNTypes       #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -598,7 +598,7 @@ unfoldrMZipSerial = Serial.unfoldrM
 
 -- | Convert an 'Unfold' into a stream by supplying it an input seed.
 --
--- >>> unfold UF.replicateM 10 (putStrLn "hello")
+-- >>> unfold (UF.replicateM 10) (putStrLn "hello")
 --
 -- /Since: 0.7.0/
 {-# INLINE unfold #-}

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -62,7 +62,7 @@ description:
   .
   Where to find more information:
   .
-  * /Quick Overview/: <src/README.md README file> in the package
+  * /Quick Overview/: <#readme README file> in the package
   * /Building/: <src/docs/Build.md Build guide> for optimal performance
   * /Detailed Tutorial/: "Streamly.Tutorial" module in the haddock documentation
   * /Interoperation/: "Streamly.Tutorial" module for interop with other
@@ -75,10 +75,6 @@ description:
   * <https://github.com/composewell/streaming-benchmarks Streaming Benchmarks>
   * <https://github.com/composewell/concurrency-benchmarks Concurrency Benchmarks>
   .
-  For additional unreleased/experimental APIs, build the haddock docs using:
-  .
-  > $ cabal haddock --haddock-option="--show-all"
-  > $ stack haddock --haddock-arguments "--show-all" --no-haddock-deps
 
 
 homepage:            https://github.com/composewell/streamly


### PR DESCRIPTION
This PR
- Allows the building of haddocks for all exposed modules and
fixes some minor typos and broken links.
- Makes the accumulator strict in groupsOf & groupsOf2
- Disable tests for ghcjs build as some of them are failing
  unpredictably.