### PR TITLE
Add exception handling combinators with guaranteed cleanup

### DIFF
--- a/benchmark/FileIO.hs
+++ b/benchmark/FileIO.hs
@@ -91,9 +91,15 @@ main = do
            , mkBench "catBracket" href $ do
                Handles inh _ <- readIORef href
                BFA.catBracket devNull inh
+           , mkBench "catBracketIO" href $ do
+               Handles inh _ <- readIORef href
+               BFA.catBracketIO devNull inh
            , mkBench "catBracketStream" href $ do
                Handles inh _ <- readIORef href
                BFA.catBracketStream devNull inh
+           , mkBench "catBracketStreamIO" href $ do
+               Handles inh _ <- readIORef href
+               BFA.catBracketStreamIO devNull inh
            , mkBench "catOnException" href $ do
                Handles inh _ <- readIORef href
                BFA.catOnException devNull inh
@@ -142,15 +148,27 @@ main = do
            , mkBench "catFinally" href $ do
                Handles inh _ <- readIORef href
                BFS.catFinally devNull inh
+           , mkBench "catFinallyIO" href $ do
+               Handles inh _ <- readIORef href
+               BFS.catFinallyIO devNull inh
            , mkBench "catFinallyStream" href $ do
                Handles inh _ <- readIORef href
                BFS.catFinallyStream devNull inh
+           , mkBench "catFinallyStreamIO" href $ do
+               Handles inh _ <- readIORef href
+               BFS.catFinallyStreamIO devNull inh
            , mkBench "catBracketStream" href $ do
                Handles inh _ <- readIORef href
                BFS.catBracketStream devNull inh
+           , mkBench "catBracketStreamIO" href $ do
+               Handles inh _ <- readIORef href
+               BFS.catBracketStreamIO devNull inh
            , mkBench "catBracket" href $ do
                Handles inh _ <- readIORef href
                BFS.catBracket devNull inh
+           , mkBench "catBracketIO" href $ do
+               Handles inh _ <- readIORef href
+               BFS.catBracketIO devNull inh
 #endif
            , mkBench "read-word8" href $ do
                Handles inh _ <- readIORef href


### PR DESCRIPTION
The "after", "finally" and "bracket" combinators did not run the "cleanup"
handler in case the stream is lazily partially evaluated e.g. using the lazy
right fold (foldrM), "Streamly.Prelude.head" is an example of such a fold.

Since we run the cleanup action when the stream Stops, the action won't be run
if the stream is not fully drained.

In the new implementation, we use a GC hook to run the cleanup action in case
the stream got garbage collected even before finishing. This will take care of
the lazy right fold cases mentioned above.