### PR TITLE
large stream size benchmarks

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -30,6 +30,9 @@
 * _Benchmarks_:
 
     * Check regressions from previous release
+    * Run benchmarks with large stream size (`bench.sh -- long`) to
+      check for space leaks and to ensure constant memory usage for streaming
+      operations.
     * Check comparative benchmarks using streaming-benchmarks
 
 * _Update Package Metadata:_

--- a/bench.sh
+++ b/bench.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
+ALL_BENCHMARKS="linear linear-async linear-rate nested nested-concurrent nested-unfold concurrent fileio array base"
+
 print_help () {
   echo "Usage: $0 "
-  echo "       [--benchmarks <all|linear|linear-async|linear-rate|nested|concurrent|fileio|array|base>]"
+  echo "       [--benchmarks <all|linear|linear-async|linear-rate|nested|nested-concurrent|nested-unfold|concurrent|fileio|array|base>]"
   echo "       [--group-diff]"
   echo "       [--graphs]"
   echo "       [--no-measure]"
-  echo "       [--append] "
+  echo "       [--append]"
+  echo "       [--long]"
   echo "       [--compare] [--base commit] [--candidate commit]"
   echo "       [--slow]"
   echo "       -- <gauge options>"
@@ -144,6 +147,19 @@ run_bench () {
 
   echo "Running benchmark $bench_name ..."
 
+  local SPEED_OPTIONS
+  if test "$LONG" -eq 0
+  then
+    if test "$SLOW" -eq 0
+    then
+      SPEED_OPTIONS="--quick --min-samples 10 --time-limit 1 --min-duration 0"
+    else
+      SPEED_OPTIONS="--min-duration 0"
+    fi
+  else
+      SPEED_OPTIONS="--stream-size 10000000 -v2 --quick --include-first-iter --time-limit 1 --min-duration 0"
+  fi
+
   $bench_prog $SPEED_OPTIONS \
     --csvraw=$output_file \
     -v 2 \
@@ -231,7 +247,6 @@ run_reports() {
 #-----------------------------------------------------------------------------
 
 DEFAULT_BENCHMARKS="linear"
-ALL_BENCHMARKS="linear linear-async linear-rate nested nested-concurrent concurrent fileio array base"
 GROUP_DIFF=0
 
 COMPARE=0
@@ -239,10 +254,11 @@ BASE=
 CANDIDATE=
 
 APPEND=0
+SLOW=0
+LONG=0
 RAW=0
 GRAPH=0
 MEASURE=1
-SPEED_OPTIONS="--quick --min-samples 10 --time-limit 1 --min-duration 0"
 
 GAUGE_ARGS=
 BUILD_ONCE=0
@@ -263,7 +279,7 @@ do
   case $1 in
     -h|--help|help) print_help ;;
     # options with arguments
-    --slow) SPEED_OPTIONS="--min-duration 0"; shift ;;
+    --slow) SLOW=1; shift ;;
     --benchmarks) shift; BENCHMARKS=$1; shift ;;
     --base) shift; BASE=$1; shift ;;
     --candidate) shift; CANDIDATE=$1; shift ;;
@@ -271,6 +287,7 @@ do
     --compare) COMPARE=1; shift ;;
     --raw) RAW=1; shift ;;
     --append) APPEND=1; shift ;;
+    --long) LONG=1; shift ;;
     --group-diff) GROUP_DIFF=1; shift ;;
     --graphs) GRAPH=1; shift ;;
     --no-measure) MEASURE=0; shift ;;

--- a/benchmark/Chart.hs
+++ b/benchmark/Chart.hs
@@ -353,6 +353,11 @@ main = do
                             makeNestedGraphs
                             "charts/nested/results.csv"
                             "charts/nested"
+                NestedConcurrent -> benchShow opts cfg
+                            { title = Just "Nested concurrent loops 316 x 316 elems" }
+                            makeNestedGraphs
+                            "charts/nested-concurrent/results.csv"
+                            "charts/nested-concurrent"
                 NestedUnfold -> benchShow opts cfg
                             { title = Just "Nested unfold loops 316 x 316 elems" }
                             makeNestedGraphs

--- a/benchmark/Chart.hs
+++ b/benchmark/Chart.hs
@@ -28,6 +28,7 @@ data BenchType
     | LinearRate
     | Nested
     | NestedConcurrent
+    | NestedUnfold
     | Base
     | FileIO
     | Array
@@ -71,6 +72,7 @@ parseBench = do
         Just "linear-rate" -> setBenchType LinearRate
         Just "nested" -> setBenchType Nested
         Just "nested-concurrent" -> setBenchType NestedConcurrent
+        Just "nested-unfold" -> setBenchType NestedUnfold
         Just "base" -> setBenchType Base
         Just "fileio" -> setBenchType FileIO
         Just "array" -> setBenchType Array
@@ -351,11 +353,11 @@ main = do
                             makeNestedGraphs
                             "charts/nested/results.csv"
                             "charts/nested"
-                NestedConcurrent -> benchShow opts cfg
-                            { title = Just "Nested concurrent loops 316 x 316 elems" }
+                NestedUnfold -> benchShow opts cfg
+                            { title = Just "Nested unfold loops 316 x 316 elems" }
                             makeNestedGraphs
-                            "charts/nested-concurrent/results.csv"
-                            "charts/nested-concurrent"
+                            "charts/nested-unfold/results.csv"
+                            "charts/nested-unfold"
                 FileIO -> benchShow opts cfg
                             { title = Just "File IO" }
                             makeFileIOGraphs

--- a/benchmark/NestedUnfold.hs
+++ b/benchmark/NestedUnfold.hs
@@ -8,6 +8,8 @@
 import Control.DeepSeq (NFData)
 import System.Random (randomRIO)
 
+import Common (parseCLIOpts)
+
 import qualified NestedUnfoldOps as Ops
 
 import Gauge
@@ -15,18 +17,22 @@ import Gauge
 benchIO :: (NFData b) => String -> (Int -> IO b) -> Benchmark
 benchIO name f = bench name $ nfIO $ randomRIO (1,1) >>= f
 
+defaultStreamSize :: Int
+defaultStreamSize = 100000
+
 main :: IO ()
-main =
-  defaultMain
+main = do
+  (linearCount, cfg, benches) <- parseCLIOpts defaultStreamSize
+  linearCount `seq` runMode (mode cfg) cfg benches
     [ bgroup "unfold"
-      [ benchIO "toNull"         $ Ops.toNull
-      , benchIO "toNull3"        $ Ops.toNull3
-      , benchIO "concat"         $ Ops.concat
-      , benchIO "toList"         $ Ops.toList
-      , benchIO "toListSome"     $ Ops.toListSome
-      , benchIO "filterAllOut"   $ Ops.filterAllOut
-      , benchIO "filterAllIn"    $ Ops.filterAllIn
-      , benchIO "filterSome"     $ Ops.filterSome
-      , benchIO "breakAfterSome" $ Ops.breakAfterSome
+      [ benchIO "toNull"         $ Ops.toNull linearCount
+      , benchIO "toNull3"        $ Ops.toNull3 linearCount
+      , benchIO "concat"         $ Ops.concat linearCount
+      -- , benchIO "toList"         $ Ops.toList
+      , benchIO "toListSome"     $ Ops.toListSome linearCount
+      , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount
+      , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount
+      , benchIO "filterSome"     $ Ops.filterSome linearCount
+      , benchIO "breakAfterSome" $ Ops.breakAfterSome linearCount
       ]
     ]

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -637,12 +637,12 @@ benchmark nested
     build-depends:
         transformers  >= 0.4 && < 0.6
 
-benchmark nestedUnfold
+benchmark nested-unfold
   import: bench-options
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
   main-is: NestedUnfold.hs
-  other-modules: NestedUnfoldOps
+  other-modules: NestedUnfoldOps, Common
   build-depends:
       streamly
     , base                >= 4.8   && < 5


### PR DESCRIPTION
* Fix `--stream-size` passing to child process for gauge `--measure-with` option to work correctly
* Support command line stream-size option for nested-unfold benchmark as well
* Support `--long` option in `bench.sh` to conveniently run large stream size (10 million elements) benchmarks before releasing.