### PR TITLE
Group benchmarks based on memory and cpu costs

### DIFF
--- a/benchmark/LinearAsync.hs
+++ b/benchmark/LinearAsync.hs
@@ -51,7 +51,8 @@ main :: IO ()
 main = do
   -- XXX Fix indentation
   (value, cfg, benches) <- parseCLIOpts defaultStreamSize
-  value `seq` runMode (mode cfg) cfg benches
+  let value2 = round $ sqrt $ (fromIntegral value :: Double)
+  value2 `seq` value `seq` runMode (mode cfg) cfg benches
     [ bgroup "asyncly"
         [ benchSrcIO asyncly "unfoldr" (Ops.sourceUnfoldr value)
         , benchSrcIO asyncly "unfoldrM" (Ops.sourceUnfoldrM value)
@@ -69,6 +70,8 @@ main = do
             (maxBuffer 1 . Ops.sourceUnfoldrMN (value `div` 10))
         , benchMonadicSrcIO "concatMapWith (2,x/2)"
             (Ops.concatStreamsWith async 2 (value `div` 2))
+        , benchMonadicSrcIO "concatMapWith (sqrt x,sqrt x)"
+            (Ops.concatStreamsWith async value2 value2)
         , benchMonadicSrcIO "concatMapWith (x/2,2)"
             (Ops.concatStreamsWith async (value `div` 2) 2)
         ]
@@ -83,8 +86,22 @@ main = do
         , benchIO value "map"    $ Ops.map' wAsyncly 1
         , benchIO value "fmap"   $ Ops.fmap' wAsyncly 1
         , benchIO value "mapM"   $ Ops.mapM wAsyncly 1
+        , benchSrcIO wAsyncly "unfoldrM maxThreads 1"
+            (maxThreads 1 . Ops.sourceUnfoldrM value)
+        , benchSrcIO wAsyncly "unfoldrM maxBuffer 1 (x/10 ops)"
+            (maxBuffer 1 . Ops.sourceUnfoldrMN (value `div` 10))
+        -- When we merge streams using wAsync the size of the queue increases
+        -- slowly because of the binary composition adding just one more item
+        -- to the work queue only after every scheduling pass through the
+        -- work queue.
+        --
+        -- We should see the memory consumption increasing slowly if these
+        -- benchmarks are left to run on infinite number of streams of infinite
+        -- sizes.
         , benchMonadicSrcIO "concatMapWith (2,x/2)"
             (Ops.concatStreamsWith wAsync 2 (value `div` 2))
+        , benchMonadicSrcIO "concatMapWith (sqrt x,sqrt x)"
+            (Ops.concatStreamsWith wAsync value2 value2)
         , benchMonadicSrcIO "concatMapWith (x/2,2)"
             (Ops.concatStreamsWith wAsync (value `div` 2) 2)
         ]
@@ -94,7 +111,7 @@ main = do
         [ benchSrcIO aheadly "unfoldr" (Ops.sourceUnfoldr value)
         , benchSrcIO aheadly "unfoldrM" (Ops.sourceUnfoldrM value)
         , benchSrcIO aheadly "fromFoldableM" (Ops.sourceFromFoldableM value)
-        -- , benchSrcIO aheadly "foldMapWith" Ops.sourceFoldMapWith
+        , benchSrcIO aheadly "foldMapWith" (Ops.sourceFoldMapWith value)
         , benchSrcIO aheadly "foldMapWithM" (Ops.sourceFoldMapWithM value)
         , benchSrcIO aheadly "foldMapM" (Ops.sourceFoldMapM value)
         , benchIO value "map"  $ Ops.map' aheadly 1
@@ -104,35 +121,43 @@ main = do
             (maxThreads 1 . Ops.sourceUnfoldrM value)
         , benchSrcIO aheadly "unfoldrM maxBuffer 1 (x/10 ops)"
             (maxBuffer 1 . Ops.sourceUnfoldrMN (value `div` 10))
-        -- , benchSrcIO aheadly "fromFoldable" Ops.sourceFromFoldable
+        , benchSrcIO aheadly "fromFoldable" (Ops.sourceFromFoldable value)
         , benchMonadicSrcIO "concatMapWith (2,x/2)"
             (Ops.concatStreamsWith ahead 2 (value `div` 2))
+        , benchMonadicSrcIO "concatMapWith (sqrt x,sqrt x)"
+            (Ops.concatStreamsWith ahead value2 value2)
         , benchMonadicSrcIO "concatMapWith (x/2,2)"
             (Ops.concatStreamsWith ahead (value `div` 2) 2)
         ]
      -- XXX need to use smaller streams to finish in reasonable time
       , bgroup "parallely"
-        [ benchSrcIO parallely "unfoldr" (Ops.sourceUnfoldr value)
+        [ -- unfoldr is pure and works serially irrespective of the stream type
+          benchSrcIO parallely "unfoldr" (Ops.sourceUnfoldr value)
         , benchSrcIO parallely "unfoldrM" (Ops.sourceUnfoldrM value)
-        --, benchSrcIO parallely "fromFoldable" Ops.sourceFromFoldable
+        , benchSrcIO parallely "fromFoldable" (Ops.sourceFromFoldable value)
         , benchSrcIO parallely "fromFoldableM" (Ops.sourceFromFoldableM value)
-        -- , benchSrcIO parallely "foldMapWith" Ops.sourceFoldMapWith
+        , benchSrcIO parallely "foldMapWith" (Ops.sourceFoldMapWith value)
         , benchSrcIO parallely "foldMapWithM" (Ops.sourceFoldMapWithM value)
         , benchSrcIO parallely "foldMapM" (Ops.sourceFoldMapM value)
+        -- map/fmap are pure and therefore no concurrency would be added on top
+        -- of what the source stream (i.e. unfoldrM) provides.
         , benchIO value "map"  $ Ops.map' parallely 1
         , benchIO value "fmap" $ Ops.fmap' parallely 1
         , benchIO value "mapM" $ Ops.mapM parallely 1
-        -- Zip has only one parallel flavor
-        , benchIO value "zip" Ops.zipAsync
+        , benchMonadicSrcIO "concatMapWith (2,x/2)"
+            (Ops.concatStreamsWith parallel 2 (value `div` 2))
+        , benchMonadicSrcIO "concatMapWith (sqrt x,sqrt x)"
+            (Ops.concatStreamsWith parallel value2 value2)
+        , benchMonadicSrcIO "concatMapWith (x/2,2)"
+            (Ops.concatStreamsWith parallel (value `div` 2) 2)
+        ]
+      , bgroup "zip"
+        [ benchIO value "zip" Ops.zipAsync
         , benchIO value "zipM" Ops.zipAsyncM
         , benchIO value "zipAp" Ops.zipAsyncAp
         , benchIO value "fmap zipAsyncly"  $ Ops.fmap' zipAsyncly 1
         -- Parallel stages in a pipeline
         , benchIO value "parAppMap" Ops.parAppMap
         , benchIO value "parAppSum" Ops.parAppSum
-        , benchMonadicSrcIO "concatMapWith (2,x/2)"
-            (Ops.concatStreamsWith parallel 2 (value `div` 2))
-        , benchMonadicSrcIO "concatMapWith (x/10,10)"
-            (Ops.concatStreamsWith parallel (value `div` 10) 10)
         ]
       ]

--- a/benchmark/LinearAsync.hs
+++ b/benchmark/LinearAsync.hs
@@ -126,6 +126,7 @@ main = do
         , benchIO value "zip" Ops.zipAsync
         , benchIO value "zipM" Ops.zipAsyncM
         , benchIO value "zipAp" Ops.zipAsyncAp
+        , benchIO value "fmap zipAsyncly"  $ Ops.fmap' zipAsyncly 1
         -- Parallel stages in a pipeline
         , benchIO value "parAppMap" Ops.parAppMap
         , benchIO value "parAppSum" Ops.parAppSum

--- a/benchmark/LinearAsync.hs
+++ b/benchmark/LinearAsync.hs
@@ -129,28 +129,6 @@ main = do
         , benchMonadicSrcIO "concatMapWith (sqrt x * 2,sqrt x / 2)"
             (Ops.concatStreamsWith ahead (value2 * 2) (value2 `div` 2))
         ]
-     -- XXX need to use smaller streams to finish in reasonable time
-      , bgroup "parallely"
-        [ -- unfoldr is pure and works serially irrespective of the stream type
-          benchSrcIO parallely "unfoldr" (Ops.sourceUnfoldr value)
-        , benchSrcIO parallely "unfoldrM" (Ops.sourceUnfoldrM value)
-        , benchSrcIO parallely "fromFoldable" (Ops.sourceFromFoldable value)
-        , benchSrcIO parallely "fromFoldableM" (Ops.sourceFromFoldableM value)
-        , benchSrcIO parallely "foldMapWith" (Ops.sourceFoldMapWith value)
-        , benchSrcIO parallely "foldMapWithM" (Ops.sourceFoldMapWithM value)
-        , benchSrcIO parallely "foldMapM" (Ops.sourceFoldMapM value)
-        -- map/fmap are pure and therefore no concurrency would be added on top
-        -- of what the source stream (i.e. unfoldrM) provides.
-        , benchIO value "map"  $ Ops.map' parallely 1
-        , benchIO value "fmap" $ Ops.fmap' parallely 1
-        , benchIO value "mapM" $ Ops.mapM parallely 1
-        , benchMonadicSrcIO "concatMapWith (2,x/2)"
-            (Ops.concatStreamsWith parallel 2 (value `div` 2))
-        , benchMonadicSrcIO "concatMapWith (sqrt x,sqrt x)"
-            (Ops.concatStreamsWith parallel value2 value2)
-        , benchMonadicSrcIO "concatMapWith (sqrt x * 2,sqrt x / 2)"
-            (Ops.concatStreamsWith parallel (value2 * 2) (value2 `div` 2))
-        ]
       , bgroup "zip"
         [ benchIO value "zip" Ops.zipAsync
         , benchIO value "zipM" Ops.zipAsyncM

--- a/benchmark/LinearAsync.hs
+++ b/benchmark/LinearAsync.hs
@@ -45,7 +45,7 @@ _benchId name f = bench name $ nf (runIdentity . f) (Ops.source 10)
 -}
 
 defaultStreamSize :: Int
-defaultStreamSize = 10000
+defaultStreamSize = 100000
 
 main :: IO ()
 main = do
@@ -72,8 +72,8 @@ main = do
             (Ops.concatStreamsWith async 2 (value `div` 2))
         , benchMonadicSrcIO "concatMapWith (sqrt x,sqrt x)"
             (Ops.concatStreamsWith async value2 value2)
-        , benchMonadicSrcIO "concatMapWith (x/2,2)"
-            (Ops.concatStreamsWith async (value `div` 2) 2)
+        , benchMonadicSrcIO "concatMapWith (sqrt x * 2,sqrt x / 2)"
+            (Ops.concatStreamsWith async (value2 * 2) (value2 `div` 2))
         ]
       , bgroup "wAsyncly"
         [ benchSrcIO wAsyncly "unfoldr" (Ops.sourceUnfoldr value)
@@ -102,10 +102,10 @@ main = do
             (Ops.concatStreamsWith wAsync 2 (value `div` 2))
         , benchMonadicSrcIO "concatMapWith (sqrt x,sqrt x)"
             (Ops.concatStreamsWith wAsync value2 value2)
-        , benchMonadicSrcIO "concatMapWith (x/2,2)"
-            (Ops.concatStreamsWith wAsync (value `div` 2) 2)
+        , benchMonadicSrcIO "concatMapWith (sqrt x * 2,sqrt x / 2)"
+            (Ops.concatStreamsWith wAsync (value2 * 2) (value2 `div` 2))
         ]
-      -- unfoldr and fromFoldable are always serial and thereofore the same for
+      -- unfoldr and fromFoldable are always serial and therefore the same for
       -- all stream types.
       , bgroup "aheadly"
         [ benchSrcIO aheadly "unfoldr" (Ops.sourceUnfoldr value)
@@ -126,8 +126,8 @@ main = do
             (Ops.concatStreamsWith ahead 2 (value `div` 2))
         , benchMonadicSrcIO "concatMapWith (sqrt x,sqrt x)"
             (Ops.concatStreamsWith ahead value2 value2)
-        , benchMonadicSrcIO "concatMapWith (x/2,2)"
-            (Ops.concatStreamsWith ahead (value `div` 2) 2)
+        , benchMonadicSrcIO "concatMapWith (sqrt x * 2,sqrt x / 2)"
+            (Ops.concatStreamsWith ahead (value2 * 2) (value2 `div` 2))
         ]
      -- XXX need to use smaller streams to finish in reasonable time
       , bgroup "parallely"
@@ -148,8 +148,8 @@ main = do
             (Ops.concatStreamsWith parallel 2 (value `div` 2))
         , benchMonadicSrcIO "concatMapWith (sqrt x,sqrt x)"
             (Ops.concatStreamsWith parallel value2 value2)
-        , benchMonadicSrcIO "concatMapWith (x/2,2)"
-            (Ops.concatStreamsWith parallel (value `div` 2) 2)
+        , benchMonadicSrcIO "concatMapWith (sqrt x * 2,sqrt x / 2)"
+            (Ops.concatStreamsWith parallel (value2 * 2) (value2 `div` 2))
         ]
       , bgroup "zip"
         [ benchIO value "zip" Ops.zipAsync

--- a/benchmark/Nested.hs
+++ b/benchmark/Nested.hs
@@ -34,8 +34,8 @@ main = do
       [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       serially
       , benchIO "toNull"         $ Ops.toNull linearCount         serially
       , benchIO "toNull3"        $ Ops.toNull3 linearCount        serially
-      , benchIO "toList"         $ Ops.toList linearCount         serially
-   --   , benchIO "toListSome"     $ Ops.toListSome     serially
+      -- , benchIO "toList"         $ Ops.toList linearCount         serially
+      , benchIO "toListSome"     $ Ops.toListSome linearCount     serially
       , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   serially
       , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    serially
       , benchIO "filterSome"     $ Ops.filterSome linearCount     serially
@@ -46,8 +46,8 @@ main = do
       [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       wSerially
       , benchIO "toNull"         $ Ops.toNull linearCount         wSerially
       , benchIO "toNull3"        $ Ops.toNull3 linearCount        wSerially
-      , benchIO "toList"         $ Ops.toList linearCount         wSerially
-    --  , benchIO "toListSome"     $ Ops.toListSome     wSerially
+      -- , benchIO "toList"         $ Ops.toList linearCount         wSerially
+      , benchIO "toListSome"     $ Ops.toListSome  linearCount    wSerially
       , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   wSerially
       , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    wSerially
       , benchIO "filterSome"     $ Ops.filterSome linearCount     wSerially

--- a/benchmark/NestedConcurrent.hs
+++ b/benchmark/NestedConcurrent.hs
@@ -67,20 +67,6 @@ main = do
       , benchIO "breakAfterSome" $ Ops.breakAfterSome linearCount wAsyncly
       ]
 
-    -- XXX move this in a separate benchmark
-    , bgroup "parallely"
-      [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       parallely
-      , benchIO "toNull"         $ Ops.toNull linearCount         parallely
-      , benchIO "toNull3"        $ Ops.toNull3 linearCount        parallely
-      -- , benchIO "toList"         $ Ops.toList linearCount         parallely
-      -- XXX fix thread blocked indefinitely in MVar
-      -- , benchIO "toListSome"     $ Ops.toListSome linearCount     parallely
-      , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   parallely
-      , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    parallely
-      , benchIO "filterSome"     $ Ops.filterSome linearCount     parallely
-      , benchIO "breakAfterSome" $ Ops.breakAfterSome linearCount parallely
-      ]
-
     , bgroup "zipAsyncly"
       [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       zipAsyncly
       ]

--- a/benchmark/NestedConcurrent.hs
+++ b/benchmark/NestedConcurrent.hs
@@ -35,8 +35,8 @@ main = do
       [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       aheadly
       , benchIO "toNull"         $ Ops.toNull linearCount         aheadly
       , benchIO "toNull3"        $ Ops.toNull3 linearCount        aheadly
-      , benchIO "toList"         $ Ops.toList linearCount         aheadly
-     -- , benchIO "toListSome"     $ Ops.toListSome     aheadly
+      -- , benchIO "toList"         $ Ops.toList linearCount         aheadly
+      , benchIO "toListSome"     $ Ops.toListSome linearCount     aheadly
       , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   aheadly
       , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    aheadly
       , benchIO "filterSome"     $ Ops.filterSome linearCount     aheadly
@@ -47,8 +47,8 @@ main = do
       [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       asyncly
       , benchIO "toNull"         $ Ops.toNull linearCount         asyncly
       , benchIO "toNull3"        $ Ops.toNull3 linearCount        asyncly
-      , benchIO "toList"         $ Ops.toList linearCount         asyncly
-    --  , benchIO "toListSome"     $ Ops.toListSome     asyncly
+      -- , benchIO "toList"         $ Ops.toList linearCount         asyncly
+      , benchIO "toListSome"     $ Ops.toListSome  linearCount    asyncly
       , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   asyncly
       , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    asyncly
       , benchIO "filterSome"     $ Ops.filterSome linearCount     asyncly
@@ -59,20 +59,22 @@ main = do
       [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       wAsyncly
       , benchIO "toNull"         $ Ops.toNull linearCount         wAsyncly
       , benchIO "toNull3"        $ Ops.toNull3 linearCount        wAsyncly
-      , benchIO "toList"         $ Ops.toList linearCount         wAsyncly
-     -- , benchIO "toListSome"     $ Ops.toListSome     wAsyncly
+      -- , benchIO "toList"         $ Ops.toList linearCount         wAsyncly
+      , benchIO "toListSome"     $ Ops.toListSome linearCount     wAsyncly
       , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   wAsyncly
       , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    wAsyncly
       , benchIO "filterSome"     $ Ops.filterSome linearCount     wAsyncly
       , benchIO "breakAfterSome" $ Ops.breakAfterSome linearCount wAsyncly
       ]
 
+    -- XXX move this in a separate benchmark
     , bgroup "parallely"
       [ benchIO "toNullAp"       $ Ops.toNullAp linearCount       parallely
       , benchIO "toNull"         $ Ops.toNull linearCount         parallely
       , benchIO "toNull3"        $ Ops.toNull3 linearCount        parallely
-      , benchIO "toList"         $ Ops.toList linearCount         parallely
-      --, benchIO "toListSome"     $ Ops.toListSome     parallely
+      -- , benchIO "toList"         $ Ops.toList linearCount         parallely
+      -- XXX fix thread blocked indefinitely in MVar
+      -- , benchIO "toListSome"     $ Ops.toListSome linearCount     parallely
       , benchIO "filterAllOut"   $ Ops.filterAllOut linearCount   parallely
       , benchIO "filterAllIn"    $ Ops.filterAllIn linearCount    parallely
       , benchIO "filterSome"     $ Ops.filterSome linearCount     parallely

--- a/benchmark/NestedOps.hs
+++ b/benchmark/NestedOps.hs
@@ -101,12 +101,14 @@ toList linearCount t start = runToList . t $ do
   where
     nestedCount2 = round (fromIntegral linearCount**(1/2::Double))
 
+-- Taking a specified number of elements is very expensive in logict so we have
+-- a test to measure the same.
 {-# INLINE toListSome #-}
 toListSome
     :: (S.IsStream t, S.MonadAsync m, Monad (t m))
     => Int -> (t m Int -> S.SerialT m Int) -> Int -> m [Int]
 toListSome linearCount t start =
-    runToList . t $ S.take 1000 $ do
+    runToList . t $ S.take 10000 $ do
         x <- source start nestedCount2
         y <- source start nestedCount2
         return $ x + y

--- a/benchmark/Parallel.hs
+++ b/benchmark/Parallel.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE CPP #-}
+-- |
+-- Module      : Main
+-- Copyright   : (c) 2018 Harendra Kumar
+--
+-- License     : BSD3
+-- Maintainer  : streamly@composewell.com
+
+import Control.DeepSeq (NFData)
+-- import Data.Functor.Identity (Identity, runIdentity)
+import System.Random (randomRIO)
+
+import Common (parseCLIOpts)
+
+import Streamly
+import Gauge
+
+import qualified Streamly.Benchmark.Prelude as Ops
+import qualified NestedOps as Nested
+
+{-# INLINE benchIONested #-}
+benchIONested :: (NFData b) => String -> (Int -> IO b) -> Benchmark
+benchIONested name f = bench name $ nfIO $ randomRIO (1,1) >>= f
+
+-- We need a monadic bind here to make sure that the function f does not get
+-- completely optimized out by the compiler in some cases.
+--
+-- | Takes a fold method, and uses it with a default source.
+{-# INLINE benchIO #-}
+benchIO :: (IsStream t, NFData b) => Int -> String -> (t IO Int -> IO b) -> Benchmark
+benchIO value name f = bench name $ nfIO $ randomRIO (1,1) >>= f . Ops.source value
+
+-- | Takes a source, and uses it with a default drain/fold method.
+{-# INLINE benchSrcIO #-}
+benchSrcIO
+    :: (t IO Int -> SerialT IO Int)
+    -> String
+    -> (Int -> t IO Int)
+    -> Benchmark
+benchSrcIO t name f
+    = bench name $ nfIO $ randomRIO (1,1) >>= Ops.toNull t . f
+
+defaultStreamSize :: Int
+defaultStreamSize = 100000
+
+linear :: Int -> Int -> [Benchmark]
+linear value value2 =
+    [ -- unfoldr is pure and works serially irrespective of the stream type
+      benchSrcIO parallely "unfoldr" (Ops.sourceUnfoldr value)
+    , benchSrcIO parallely "unfoldrM" (Ops.sourceUnfoldrM value)
+    , benchSrcIO parallely "fromFoldable" (Ops.sourceFromFoldable value)
+    , benchSrcIO parallely "fromFoldableM" (Ops.sourceFromFoldableM value)
+    , benchSrcIO parallely "foldMapWith" (Ops.sourceFoldMapWith value)
+    , benchSrcIO parallely "foldMapWithM" (Ops.sourceFoldMapWithM value)
+    , benchSrcIO parallely "foldMapM" (Ops.sourceFoldMapM value)
+    -- map/fmap are pure and therefore no concurrency would be added on top
+    -- of what the source stream (i.e. unfoldrM) provides.
+    , benchIO value "map"  $ Ops.map' parallely 1
+    , benchIO value "fmap" $ Ops.fmap' parallely 1
+    , benchIO value "mapM" $ Ops.mapM parallely 1
+    , benchIONested "concatMapWith (2,x/2)"
+        (Ops.concatStreamsWith parallel 2 (value `div` 2))
+    , benchIONested "concatMapWith (sqrt x,sqrt x)"
+        (Ops.concatStreamsWith parallel value2 value2)
+    , benchIONested "concatMapWith (sqrt x * 2,sqrt x / 2)"
+        (Ops.concatStreamsWith parallel (value2 * 2) (value2 `div` 2))
+    ]
+
+nested :: Int -> [Benchmark]
+nested value =
+    [ benchIONested "toNullAp"       $ Nested.toNullAp value       parallely
+    , benchIONested "toNull"         $ Nested.toNull value         parallely
+    , benchIONested "toNull3"        $ Nested.toNull3 value        parallely
+    -- , benchIO "toList"         $ Ops.toList value         parallely
+    -- XXX fix thread blocked indefinitely in MVar
+    -- , benchIO "toListSome"     $ Ops.toListSome value     parallely
+    , benchIONested "filterAllOut"   $ Nested.filterAllOut value   parallely
+    , benchIONested "filterAllIn"    $ Nested.filterAllIn value    parallely
+    , benchIONested "filterSome"     $ Nested.filterSome value     parallely
+    , benchIONested "breakAfterSome" $ Nested.breakAfterSome value parallely
+    ]
+
+main :: IO ()
+main = do
+    (value, cfg, benches) <- parseCLIOpts defaultStreamSize
+    let value2 = round $ sqrt $ (fromIntegral value :: Double)
+    value2 `seq` value `seq`
+        runMode (mode cfg) cfg benches $
+            [ bgroup "parallelly"
+              [ bgroup "linear" $ linear value value2
+              , bgroup "nested" $ nested value
+              ]
+            ]

--- a/benchmark/Streamly/Benchmark/Prelude.hs
+++ b/benchmark/Streamly/Benchmark/Prelude.hs
@@ -875,8 +875,8 @@ concatStreamsWith
     -> IO ()
 concatStreamsWith op outer inner n =
     S.drain $ S.concatMapWith op
-        (\_ -> sourceUnfoldrMN inner n)
-        (sourceUnfoldrMN outer n)
+        (\i -> sourceUnfoldrMN (i + inner) i)
+        (sourceUnfoldrMN (n + outer) n)
 
 {-# INLINE concatMapWithSerial #-}
 concatMapWithSerial :: Int -> Int -> Int -> IO ()

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -760,6 +760,25 @@ benchmark nested-concurrent
     build-depends:
         transformers  >= 0.4 && < 0.6
 
+benchmark parallel
+  import: bench-options-threaded
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmark
+  main-is: Parallel.hs
+  other-modules: Streamly.Benchmark.Prelude, NestedOps, Common
+  build-depends:
+      streamly
+    , base                >= 4.8   && < 5
+    , deepseq             >= 1.4.1 && < 1.5
+    , random              >= 1.0   && < 2.0
+    , gauge               >= 0.2.4 && < 0.3
+  if impl(ghc < 8.0)
+    build-depends:
+        transformers  >= 0.4 && < 0.6
+  if flag(inspection)
+    build-depends:     template-haskell   >= 2.14  && < 2.16
+                     , inspection-testing >= 0.4   && < 0.5
+
 benchmark linear-rate
   import: bench-options-threaded
   type: exitcode-stdio-1.0


### PR DESCRIPTION
So that we can run different benchmark groups with different heap size restrictions. Especially we want to enforce that streaming benchmarks run in constant memory.

See the commit messages for more details.