### PR TITLE
Hide Streamly.Data.Array and Streamly.Data.SmallArray.

### DIFF
--- a/benchmark/Streamly/Benchmark/Data/Array.hs
+++ b/benchmark/Streamly/Benchmark/Data/Array.hs
@@ -15,7 +15,7 @@ import Control.DeepSeq (NFData(..), deepseq)
 import System.Random (randomRIO)
 
 import qualified Streamly.Benchmark.Data.ArrayOps as Ops
-import qualified Streamly.Data.Array as A
+import qualified Streamly.Internal.Data.Array as A
 import qualified Streamly.Prelude as S
 
 import Gauge

--- a/benchmark/Streamly/Benchmark/Data/ArrayOps.hs
+++ b/benchmark/Streamly/Benchmark/Data/ArrayOps.hs
@@ -23,7 +23,7 @@ import qualified Data.Foldable as F
 #endif
 
 import qualified Streamly           as S hiding (foldMapWith, runStream)
-import qualified Streamly.Data.Array as A
+import qualified Streamly.Internal.Data.Array as A
 import qualified Streamly.Prelude   as S
 
 value :: Int

--- a/benchmark/Streamly/Benchmark/Data/SmallArray.hs
+++ b/benchmark/Streamly/Benchmark/Data/SmallArray.hs
@@ -15,7 +15,7 @@ import Control.DeepSeq (NFData(..), deepseq)
 import System.Random (randomRIO)
 
 import qualified Streamly.Benchmark.Data.SmallArrayOps as Ops
-import qualified Streamly.Data.SmallArray as A
+import qualified Streamly.Internal.Data.SmallArray as A
 import qualified Streamly.Prelude as S
 
 import Gauge

--- a/benchmark/Streamly/Benchmark/Data/SmallArrayOps.hs
+++ b/benchmark/Streamly/Benchmark/Data/SmallArrayOps.hs
@@ -23,7 +23,7 @@ import qualified Data.Foldable as F
 #endif
 
 import qualified Streamly           as S hiding (foldMapWith, runStream)
-import qualified Streamly.Data.SmallArray as A
+import qualified Streamly.Internal.Data.SmallArray as A
 import qualified Streamly.Prelude   as S
 
 value :: Int

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -273,6 +273,9 @@ library
       c-sources:     src/Streamly/Internal/Data/Time/Darwin.c
     hs-source-dirs:    src
     other-modules:
+                       Streamly.Data.Array
+                     , Streamly.Data.SmallArray
+
                     -- Memory storage
                        Streamly.Memory.Malloc
                      , Streamly.Memory.Ring
@@ -284,8 +287,6 @@ library
     exposed-modules:
                        Streamly.Prelude
                      , Streamly
-                     , Streamly.Data.Array
-                     , Streamly.Data.SmallArray
                      , Streamly.Data.Fold
                      , Streamly.Data.Unfold
                      , Streamly.Data.Unicode.Stream

--- a/test/Streamly/Test/Array.hs
+++ b/test/Streamly/Test/Array.hs
@@ -24,7 +24,7 @@ import Streamly (SerialT)
 import qualified Streamly.Prelude as S
 
 #ifdef TEST_SMALL_ARRAY
-import qualified Streamly.Data.SmallArray as A
+import qualified Streamly.Internal.Data.SmallArray as A
 type Array = A.SmallArray
 #elif defined(TEST_ARRAY)
 import qualified Streamly.Memory.Array as A
@@ -32,7 +32,7 @@ import qualified Streamly.Internal.Memory.Array as A
 import qualified Streamly.Internal.Prelude as IP
 type Array = A.Array
 #else
-import qualified Streamly.Data.Array as A
+import qualified Streamly.Internal.Data.Array as A
 type Array = A.Array
 #endif
 


### PR DESCRIPTION
Only expose `Streamly.Internal.Data.Array` and `Streamly.Internal.Data.SmallArray`