### PR TITLE
Use fusion-plugin package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ env: &env
       # If you have not committed packcheck.sh in your repo at PACKCHECK
       # then it is automatically pulled from this URL.
       PACKCHECK_GITHUB_URL: "https://raw.githubusercontent.com/harendra-kumar/packcheck"
-      PACKCHECK_GITHUB_COMMIT: "d11a8a68fef00f4932bbedd6134950495ccd7420"
+      PACKCHECK_GITHUB_COMMIT: "b8d39c9cf336e4627e12eb4b1f5827bb7b6afc91"
 
     docker:
       - image: debian:stretch

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc_version: [8.6.5, 8.8.1]
+        ghc_version: [8.8.1, 8.6.5, 8.6.5]
         cabal_version: ["3.0"]
         include:
           - ghc_version: 8.8.1
@@ -42,6 +42,9 @@ jobs:
           - ghc_version: 8.6.5
             build: cabal-v2
             cabal_build_options: "--flags streamk"
+          - ghc_version: 8.6.5
+            build: cabal-v2
+            cabal_build_options: "--flags fusion-plugin"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,7 +13,7 @@ jobs:
       CABAL_REINIT_CONFIG: y
       LC_ALL: C.UTF-8
 
-      ENABLE_INSTALL: y
+      ENABLE_INSTALL: "n"
 
       STACK_UPGRADE: "y"
 
@@ -23,7 +23,7 @@ jobs:
 
       PACKCHECK_LOCAL_PATH: "./packcheck.sh"
       PACKCHECK_GITHUB_URL: "https://raw.githubusercontent.com/harendra-kumar/packcheck"
-      PACKCHECK_GITHUB_COMMIT: "d11a8a68fef00f4932bbedd6134950495ccd7420"
+      PACKCHECK_GITHUB_COMMIT: "b8d39c9cf336e4627e12eb4b1f5827bb7b6afc91"
 
       BUILD: ${{ matrix.build }}
       GHCVER: ${{ matrix.ghc_version }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ env:
   # If you have not committed packcheck.sh in your repo at PACKCHECK_LOCAL_PATH
   # then it is automatically pulled from this URL.
   - PACKCHECK_GITHUB_URL="https://raw.githubusercontent.com/harendra-kumar/packcheck"
-  - PACKCHECK_GITHUB_COMMIT="d11a8a68fef00f4932bbedd6134950495ccd7420"
+  - PACKCHECK_GITHUB_COMMIT="b8d39c9cf336e4627e12eb4b1f5827bb7b6afc91"
 
 notifications:
   email:

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
 
 ### Performance
 
+* Now uses `fusion-plugin` package for predictable stream fusion optimizations
 * Significant improvement in performance of concurrent stream operations.
 
 ## 0.7.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ environment:
     # If you have not committed packcheck.sh in your repo at PACKCHECK_LOCAL_PATH
     # then it is automatically pulled from this URL.
     PACKCHECK_GITHUB_URL: "https://raw.githubusercontent.com/harendra-kumar/packcheck"
-    PACKCHECK_GITHUB_COMMIT: "d11a8a68fef00f4932bbedd6134950495ccd7420"
+    PACKCHECK_GITHUB_COMMIT: "b8d39c9cf336e4627e12eb4b1f5827bb7b6afc91"
 
     # Override the temp directory to avoid sed escaping issues
     # See https://github.com/haskell/cabal/issues/5386

--- a/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
@@ -74,6 +74,7 @@ import Data.Functor.Identity (Identity(..))
 import GHC.Base (build)
 import GHC.Types (SPEC(..))
 import Prelude hiding (map, mapM, foldr, take, concatMap)
+import Fusion.Plugin.Types (Fuse(..))
 
 import Streamly.Internal.Data.SVar (State(..), adaptState, defState)
 import Streamly.Internal.Data.Fold.Types (Fold(..), Fold2(..))
@@ -87,6 +88,7 @@ import qualified Streamly.Internal.Data.Stream.StreamK as K
 -- | A stream is a succession of 'Step's. A 'Yield' produces a single value and
 -- the next state of the stream. 'Stop' indicates there are no more values in
 -- the stream.
+{-# ANN type Step Fuse #-}
 data Step s a = Yield a s | Skip s | Stop
 
 instance Functor (Step s) where

--- a/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
@@ -74,7 +74,7 @@ import Data.Functor.Identity (Identity(..))
 import GHC.Base (build)
 import GHC.Types (SPEC(..))
 import Prelude hiding (map, mapM, foldr, take, concatMap)
-import Fusion.Plugin.Types (Fuse(..))
+import Streamly.Internal.Fusion (Fuse(..))
 
 import Streamly.Internal.Data.SVar (State(..), adaptState, defState)
 import Streamly.Internal.Data.Fold.Types (Fold(..), Fold2(..))

--- a/src/Streamly/Internal/Fusion.hs
+++ b/src/Streamly/Internal/Fusion.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+
+-- |
+-- Module      : Streamly.Internal.Fusion
+-- Copyright   : (c) Composewell Technologies
+--
+-- License     : BSD3
+-- Maintainer  : streamly@composewell.com
+-- Stability   : experimental
+-- Portability : GHC
+
+module Streamly.Internal.Fusion
+    (
+      Fuse (..)
+    )
+where
+
+#if defined(__GHCJS__) || __GLASGOW_HASKELL__ < 806
+import Data.Data (Data)
+data Fuse = Fuse deriving (Data)
+#else
+import Fusion.Plugin.Types (Fuse(..))
+#endif

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,6 +7,7 @@ extra-deps:
     - Chart-diagrams-1.9.2
     - bench-show-0.2.2
     - inspection-testing-0.4.2.1
+    - fusion-plugin-0.1.1
 
 #allow-newer: true
 flags: {}

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -129,6 +129,11 @@ source-repository head
     type: git
     location: https://github.com/composewell/streamly
 
+flag fusion-plugin
+  description: Enable fusion plugin for better optimizations
+  manual: True
+  default: False
+
 flag inspection
   description: Enable inspection testing
   manual: True
@@ -237,18 +242,31 @@ common lib-options
 -- in general.
 common test-options
   import: compile-options, threading-options
+
   ghc-options:  -O0
                 -fno-ignore-asserts
+  if flag(fusion-plugin)
+    ghc-options: -fplugin Fusion.Plugin
+    build-depends:
+        fusion-plugin     >= 0.1   && < 0.2
 
 -- Used by maxrate test, benchmarks and executables
 common exe-options
   import: compile-options, optimization-options, threading-options
+  if flag(fusion-plugin)
+    ghc-options: -fplugin Fusion.Plugin
+    build-depends:
+        fusion-plugin     >= 0.1   && < 0.2
 
 -- Some benchmarks are threaded some are not
 -- XXX dependencies should be separated under bench-depends
 common bench-options
   import: compile-options, optimization-options
   ghc-options: -with-rtsopts "-T -M256M"
+  if flag(fusion-plugin)
+    ghc-options: -fplugin Fusion.Plugin
+    build-depends:
+        fusion-plugin     >= 0.1   && < 0.2
   build-depends: mtl >= 2.2 && < 3
 
 common bench-options-threaded
@@ -256,6 +274,10 @@ common bench-options-threaded
   -- -threaded and -N2 is important because some GC and space leak issues
   -- trigger only with these options.
   ghc-options: -threaded -with-rtsopts "-T -N2 -M256M"
+  if flag(fusion-plugin)
+    ghc-options: -fplugin Fusion.Plugin
+    build-depends:
+        fusion-plugin     >= 0.1   && < 0.2
   build-depends: mtl >= 2.2 && < 3
 
 -------------------------------------------------------------------------------

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -385,6 +385,8 @@ library
                      , monad-control     >= 1.0   && < 2
                      , transformers-base >= 0.4   && < 0.5
 
+                     , fusion-plugin     >= 0.1   && < 0.2
+
   if !impl(ghcjs)
     build-depends:
                        network           >= 2.6   && < 4

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -245,7 +245,7 @@ common test-options
 
   ghc-options:  -O0
                 -fno-ignore-asserts
-  if flag(fusion-plugin)
+  if flag(fusion-plugin) && !impl(ghcjs) && !impl(ghc < 8.6)
     ghc-options: -fplugin Fusion.Plugin
     build-depends:
         fusion-plugin     >= 0.1   && < 0.2
@@ -253,7 +253,7 @@ common test-options
 -- Used by maxrate test, benchmarks and executables
 common exe-options
   import: compile-options, optimization-options, threading-options
-  if flag(fusion-plugin)
+  if flag(fusion-plugin) && !impl(ghcjs) && !impl(ghc < 8.6)
     ghc-options: -fplugin Fusion.Plugin
     build-depends:
         fusion-plugin     >= 0.1   && < 0.2
@@ -263,7 +263,7 @@ common exe-options
 common bench-options
   import: compile-options, optimization-options
   ghc-options: -with-rtsopts "-T -M256M"
-  if flag(fusion-plugin)
+  if flag(fusion-plugin) && !impl(ghcjs) && !impl(ghc < 8.6)
     ghc-options: -fplugin Fusion.Plugin
     build-depends:
         fusion-plugin     >= 0.1   && < 0.2
@@ -274,7 +274,7 @@ common bench-options-threaded
   -- -threaded and -N2 is important because some GC and space leak issues
   -- trigger only with these options.
   ghc-options: -threaded -with-rtsopts "-T -N2 -M256M"
-  if flag(fusion-plugin)
+  if flag(fusion-plugin) && !impl(ghcjs) && !impl(ghc < 8.6)
     ghc-options: -fplugin Fusion.Plugin
     build-depends:
         fusion-plugin     >= 0.1   && < 0.2
@@ -371,6 +371,7 @@ library
                      , Streamly.Internal.Data.Unicode.Char
                      , Streamly.Internal.Memory.Unicode.Array
                      , Streamly.Internal.Prelude
+                     , Streamly.Internal.Fusion
 
                      -- Mutable data
                      , Streamly.Internal.Mutable.Prim.Var
@@ -407,7 +408,9 @@ library
                      , monad-control     >= 1.0   && < 2
                      , transformers-base >= 0.4   && < 0.5
 
-                     , fusion-plugin     >= 0.1   && < 0.2
+  if !impl(ghcjs) && !impl(ghc < 8.6)
+    build-depends:
+                       fusion-plugin     >= 0.1 && < 0.2
 
   if !impl(ghcjs)
     build-depends:


### PR DESCRIPTION
Use `fusion-plugin` package when `fusion-plugin` build flag is enabled. The plugin is used for benchmarks as well as tests.