### PR TITLE
Add the -fdicts-strict flag to avoid memory leaks

### DIFF
--- a/docs/Build.md
+++ b/docs/Build.md
@@ -2,7 +2,11 @@
 
 Recommended GHC options are: 
 
-  `-O2 -fspec-constr-recursive=16 -fmax-worker-args=16`
+  `-O2 -fdicts-strict -fspec-constr-recursive=16 -fmax-worker-args=16`
+
+`-fdicts-strict` is needed to avoid [a GHC
+issue](https://gitlab.haskell.org/ghc/ghc/issues/17745) leading to
+memory leak in some cases.
 
 `-fspec-constr-recursive` is needed for better stream fusion by enabling
 the `SpecConstr` optimization in more cases.

--- a/src/Streamly/Internal/Data/Stream/SVar.hs
+++ b/src/Streamly/Internal/Data/Stream/SVar.hs
@@ -115,6 +115,7 @@ inspect $ hasNoTypeClassesExcept 'fromStreamVar
     , ''MonadIO
     , ''MonadBaseControl
     , ''Typeable
+    , ''Functor
     ]
 #endif
 

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -215,6 +215,7 @@ common compile-options
 
 common optimization-options
   ghc-options: -O2
+               -fdicts-strict
                -fspec-constr-recursive=16
                -fmax-worker-args=16
 


### PR DESCRIPTION
See GHC ticket https://gitlab.haskell.org/ghc/ghc/issues/17745