### PR TITLE
Add a predicate to pollCounts

### DIFF
--- a/benchmark/Streamly/Benchmark/Prelude.hs
+++ b/benchmark/Streamly/Benchmark/Prelude.hs
@@ -418,7 +418,7 @@ tapRate n str = do
 {-# INLINE pollCounts #-}
 pollCounts :: Int -> Stream IO Int -> IO ()
 pollCounts n str = do
-    composeN n (Internal.pollCounts f FL.drain) str
+    composeN n (Internal.pollCounts (P.const P.True) f FL.drain) str
     where f = Internal.rollingMap (P.-) . Internal.delayPost 1
 
 {-# INLINE tapAsyncS #-}

--- a/src/Streamly/Internal/Data/Stream/StreamD.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD.hs
@@ -3457,11 +3457,12 @@ tapOffsetEvery offset n (Fold fstep initial extract) (Stream step state) =
 {-# INLINE_NORMAL pollCounts #-}
 pollCounts
     :: MonadAsync m
-    => (Stream m Int -> Stream m Int)
+    => (a -> Bool)
+    -> (Stream m Int -> Stream m Int)
     -> Fold m Int b
     -> Stream m a
     -> Stream m a
-pollCounts transf fld (Stream step state) = Stream step' Nothing
+pollCounts predicate transf fld (Stream step state) = Stream step' Nothing
   where
 
     {-# INLINE_LATE step' #-}
@@ -3479,7 +3480,7 @@ pollCounts transf fld (Stream step state) = Stream step' Nothing
         r <- step gst st
         case r of
             Yield x s -> do
-                liftIO $ modifyVar' countVar (+ 1)
+                when (predicate x) $ liftIO $ modifyVar' countVar (+ 1)
                 return $ Yield x (Just (countVar, tid, s))
             Skip s -> return $ Skip (Just (countVar, tid, s))
             Stop -> do


### PR DESCRIPTION
The predicate provides more power to the combinator by allowing you to count
only certain elements in the stream and filter out others. This is efficient
compared to an async tap followed by a filter and fold as here filtering is
done on the source.