### PR TITLE
Keep signature/pragma and definitions for each benchmark together

### DIFF
--- a/streamly.cabal
+++ b/streamly.cabal
@@ -648,14 +648,13 @@ executable SearchQuery
   hs-source-dirs:  examples
   if (flag(examples) || flag(examples-sdl)) && !impl(ghcjs)
     buildable: True
-    build-Depends:
+    build-depends:
         streamly
       , base          >= 4.8   && < 5
       , http-conduit  >= 2.2.2 && < 2.4
     if impl(ghc < 8.0)
-       build-depends:
-           resourcet     < 1.2
-         , unliftio-core < 0.2
+      build-depends:
+        unliftio-core < 0.2
   else
     buildable: False
 

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -650,8 +650,12 @@ executable SearchQuery
     buildable: True
     build-Depends:
         streamly
-      , base         >= 4.8   && < 5
-      , http-conduit >= 2.2.2 && < 2.4
+      , base          >= 4.8   && < 5
+      , http-conduit  >= 2.2.2 && < 2.4
+    if impl(ghc < 8.0)
+       build-depends:
+           resourcet     < 1.2
+         , unliftio-core < 0.2
   else
     buildable: False
 


### PR DESCRIPTION
Solves a few points mentioned in #255 

* [x] Currently signatures and INLINE pragmas are separated from the definitions. This does not work well for maintenance. We should keep signature/pragma and definitions for each benchmark together.