### PR TITLE
Streamly: Internal: FileSystem: Cleanup hlint warnings

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -14,6 +14,9 @@
 - ignore: {name: "Use tuple-section"} # requires GHC extension
 - ignore: {name: "Use fromMaybe"} # may want to use this suggestion, but it didn't match the common idiom of the library
 - ignore: {name: "Use unless"} # low power-to-weight
+- ignore: {name: "Reduce duplication"}
+- ignore: {name: "Use <>"}
+- ignore: {name: "Use fewer imports"}
 
 
 # Specify additional command line arguments

--- a/src/Streamly/Internal/FileSystem/Dir.hs
+++ b/src/Streamly/Internal/FileSystem/Dir.hs
@@ -1,8 +1,4 @@
 {-# LANGUAGE CPP             #-}
-{-# LANGUAGE BangPatterns    #-}
-{-# LANGUAGE MagicHash       #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UnboxedTuples   #-}
 
 #include "inline.hs"
 

--- a/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/src/Streamly/Internal/FileSystem/Handle.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE CPP             #-}
-{-# LANGUAGE BangPatterns    #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MagicHash       #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UnboxedTuples   #-}
 
 #include "inline.hs"
 
@@ -352,7 +349,7 @@ writeArray h Array{..} = withForeignPtr aStart $ \p -> hPutBuf h p aLen
 {-# INLINE fromChunks #-}
 fromChunks :: (MonadIO m, Storable a)
     => Handle -> SerialT m (Array a) -> m ()
-fromChunks h m = S.mapM_ (liftIO . writeArray h) m
+fromChunks h = S.mapM_ (liftIO . writeArray h)
 
 -- | Write a stream of chunks to standard output.
 --

--- a/src/Streamly/Internal/Memory/ArrayStream.hs
+++ b/src/Streamly/Internal/Memory/ArrayStream.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE CPP                 #-}
-{-# LANGUAGE MagicHash           #-}
 {-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE UnboxedTuples       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 #include "inline.hs"


### PR DESCRIPTION
For #406 

For added context, as mentioned on gitter channel, the benchmark currently fails
```
Running benchmark fileio ...
creating input file benchmark/scratch/in-100MB.txt
dd: warning: partial read (116 bytes); suggest iflag=fullblock
0+3200 records in
0+3200 records out
19507 bytes (20 kB, 19 KiB) copied, 10433.4 s, 0.0 kB/s
readArray/last
iters                194
time                 6.091 fileio: <stdout>: hPutChar: invalid argument (invalid character)
Error: Benchmarking failed
```
The test takes quite a bit of time even on master.

Signed-off-by: Sanchayan Maity <maitysanchayan@gmail.com>