### PR TITLE
Mask async exceptions in the "bracketIO" functions.

### DIFF
--- a/src/Streamly/Internal/Data/Stream/StreamD.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD.hs
@@ -2951,6 +2951,10 @@ gbracketIO bef exc aft fexc fnormal =
     -- weak pointer to us.
     {-# INLINE_LATE step #-}
     step _ GBracketIOInit = do
+        -- We mask asynchronous exceptions to make the execution
+        -- of 'bef' and the registration of 'aft' atomic.
+        -- A similar thing is done in the resourcet package: https://git.io/JvKV3
+        -- Tutorial: https://markkarpov.com/tutorial/exceptions.html
         (r, ref) <- liftBaseOp_ mask_ $ do
             r <- bef
             ref <- newFinalizedIORef (aft r)

--- a/src/Streamly/Internal/Data/Unfold.hs
+++ b/src/Streamly/Internal/Data/Unfold.hs
@@ -788,6 +788,8 @@ gbracketIO bef exc aft (Unfold estep einject) (Unfold step1 inject1) =
     where
 
     inject x = do
+        -- Mask asynchronous exceptions to make the execution of 'bef' and
+        -- the registration of 'aft' atomic. See comment in 'D.gbracketIO'.
         (r, ref) <- liftBaseOp_ mask_ $ do
             r <- bef x
             ref <- D.newFinalizedIORef (aft r)
@@ -1040,6 +1042,8 @@ bracketIO bef aft (Unfold step1 inject1) = Unfold step inject
     where
 
     inject x = do
+        -- Mask asynchronous exceptions to make the execution of 'bef' and
+        -- the registration of 'aft' atomic. See comment in 'D.gbracketIO'.
         (r, ref) <- liftBaseOp_ mask_ $ do
             r <- bef x
             ref <- D.newFinalizedIORef (aft r)


### PR DESCRIPTION
Without this change, there are points (between "bef" and registration of "aft") at which async exceptions can cause resource leaks.

A similar thing is done here: https://github.com/snoyberg/conduit/blob/resourcet-1.2.3/resourcet/Control/Monad/Trans/Resource.hs#L119