### PR TITLE
Multiple changes corresponding to the fold benchmark.

### DIFF
--- a/benchmark/Chart.hs
+++ b/benchmark/Chart.hs
@@ -38,6 +38,8 @@ data BenchType
     | Concurrent
     | Parallel
     | Adaptive
+    | FoldO1Space
+    | FoldOnHeap
     deriving Show
 
 data Options = Options
@@ -86,6 +88,8 @@ parseBench = do
         Just "concurrent" -> setBenchType Concurrent
         Just "parallel" -> setBenchType Parallel
         Just "adaptive" -> setBenchType Adaptive
+        Just "fold-o-1-space" -> setBenchType FoldO1Space
+        Just "fold-o-n-heap" -> setBenchType FoldOnHeap
         Just str -> do
                 liftIO $ putStrLn $ "unrecognized benchmark type " <> str
                 mzero
@@ -409,3 +413,13 @@ main = do
                         showStreamK opts cfg'
                                 "charts/base/results.csv"
                                 "charts/base"
+                FoldO1Space -> benchShow opts cfg
+                            { title = Just "Fold O(1) Space" }
+                            (makeGraphs "fold-o-1-space")
+                            "charts/fold-o-1-space/results.csv"
+                            "charts/fold-o-1-space"
+                FoldOnHeap -> benchShow opts cfg
+                            { title = Just "Fold O(n) Heap" }
+                            (makeGraphs "fold-o-n-heap")
+                            "charts/fold-o-n-heap/results.csv"
+                            "charts/fold-o-n-heap"

--- a/benchmark/streamly-benchmarks.cabal
+++ b/benchmark/streamly-benchmarks.cabal
@@ -225,11 +225,10 @@ benchmark serial-o-n-space
     build-depends: lib-prelude
     buildable: True
 
--- XXX Default memory restriction = o-1-space
 benchmark fold
   import: bench-options
   type: exitcode-stdio-1.0
-  ghc-options: -with-rtsopts "-T -K36K -M16M"
+  ghc-options: -rtsopts
   hs-source-dirs: ., Streamly/Benchmark/Data
   main-is: Fold.hs
   if impl(ghcjs)


### PR DESCRIPTION
1. Removed rts options at compile time for fold benchmark.
2. Added fold-o-1-space and fold-o-1-heap benchmark to bench.sh
3. Added fold-o-1-space and fold-o-1-heap to bench.sh