### PR TITLE
Add CPS parser, use both CPS and direct style parsers

### DIFF
--- a/benchmark/Chart.hs
+++ b/benchmark/Chart.hs
@@ -30,6 +30,7 @@ data BenchType
     | NestedConcurrent
     | ParserD
     | ParserK
+    | Parser
     | Base
     | FileIO
     | Array
@@ -84,6 +85,7 @@ parseBench = do
         Just "nested-concurrent" -> setBenchType NestedConcurrent
         Just "parserD" -> setBenchType ParserD
         Just "parserK" -> setBenchType ParserK
+        Just "parser" -> setBenchType Parser
         Just "base" -> setBenchType Base
         Just "fileio" -> setBenchType FileIO
         Just "array-cmp" -> setBenchType ArrayCmp
@@ -374,6 +376,11 @@ main = do
                             (makeGraphs "parserK")
                             "charts/parserK/results.csv"
                             "charts/parserK"
+                Parser -> benchShow opts cfg
+                            { title = Just "Parser" }
+                            (makeGraphs "parser")
+                            "charts/parser/results.csv"
+                            "charts/parser"
                 FileIO -> benchShow opts cfg
                             { title = Just "File IO" }
                             (makeGraphs "fileIO")

--- a/benchmark/Chart.hs
+++ b/benchmark/Chart.hs
@@ -29,6 +29,7 @@ data BenchType
     | LinearRate
     | NestedConcurrent
     | Parser
+    | ParserK
     | Base
     | FileIO
     | Array
@@ -82,6 +83,7 @@ parseBench = do
         Just "linear-rate" -> setBenchType LinearRate
         Just "nested-concurrent" -> setBenchType NestedConcurrent
         Just "parser" -> setBenchType Parser
+        Just "parserK" -> setBenchType ParserK
         Just "base" -> setBenchType Base
         Just "fileio" -> setBenchType FileIO
         Just "array-cmp" -> setBenchType ArrayCmp
@@ -367,6 +369,11 @@ main = do
                             (makeGraphs "parser")
                             "charts/parser/results.csv"
                             "charts/parser"
+                ParserK -> benchShow opts cfg
+                            { title = Just "ParserK" }
+                            (makeGraphs "parserK")
+                            "charts/parserK/results.csv"
+                            "charts/parserK"
                 FileIO -> benchShow opts cfg
                             { title = Just "File IO" }
                             (makeGraphs "fileIO")

--- a/benchmark/Chart.hs
+++ b/benchmark/Chart.hs
@@ -28,7 +28,7 @@ data BenchType
     | LinearAsync
     | LinearRate
     | NestedConcurrent
-    | Parser
+    | ParserD
     | ParserK
     | Base
     | FileIO
@@ -82,7 +82,7 @@ parseBench = do
         Just "linear-async" -> setBenchType LinearAsync
         Just "linear-rate" -> setBenchType LinearRate
         Just "nested-concurrent" -> setBenchType NestedConcurrent
-        Just "parser" -> setBenchType Parser
+        Just "parserD" -> setBenchType ParserD
         Just "parserK" -> setBenchType ParserK
         Just "base" -> setBenchType Base
         Just "fileio" -> setBenchType FileIO
@@ -364,11 +364,11 @@ main = do
                             (makeStreamComparisonGraphs "nested-concurrent" nestedBenchPrefixes)
                             "charts/nested-concurrent/results.csv"
                             "charts/nested-concurrent"
-                Parser -> benchShow opts cfg
-                            { title = Just "Parsers" }
-                            (makeGraphs "parser")
-                            "charts/parser/results.csv"
-                            "charts/parser"
+                ParserD -> benchShow opts cfg
+                            { title = Just "ParserD" }
+                            (makeGraphs "parserD")
+                            "charts/parserD/results.csv"
+                            "charts/parserD"
                 ParserK -> benchShow opts cfg
                             { title = Just "ParserK" }
                             (makeGraphs "parserK")

--- a/benchmark/Streamly/Benchmark/Data/Parser.hs
+++ b/benchmark/Streamly/Benchmark/Data/Parser.hs
@@ -178,13 +178,9 @@ o_1_space_serial_parse value =
     , benchIOSink value "all" $ all value
     , benchIOSink value "take" $ take value
     , benchIOSink value "takeWhile" $ takeWhile value
-    , benchIOSink value "lookAhead" $ lookAhead value
     , benchIOSink value "split (all,any)" $ splitAllAny value
     , benchIOSink value "many" many
     , benchIOSink value "some" some
-    , benchIOSink value "manyAlt" manyAlt
-    , benchIOSink value "someAlt" someAlt
-    , benchIOSink value "manyTill" $ manyTill value
     , benchIOSink value "choice/100" $ choice (value `div` 100)
     , benchIOSink value "tee (all,any)" $ teeAllAny value
     , benchIOSink value "teeFst (all,any)" $ teeFstAllAny value
@@ -192,6 +188,14 @@ o_1_space_serial_parse value =
     , benchIOSink value "longest (all,any)" $ longestAllAny value
     , benchIOSink value "sequenceA/100" $ sequenceA (value `div` 100)
     , benchIOSink value "sequence/100" $ sequence (value `div` 100)
+    ]
+
+o_1_heap_serial_parse :: Int -> [Benchmark]
+o_1_heap_serial_parse value =
+    [ benchIOSink value "lookAhead" $ lookAhead value
+    , benchIOSink value "manyAlt" manyAlt
+    , benchIOSink value "someAlt" someAlt
+    , benchIOSink value "manyTill" $ manyTill value
     ]
 
 -------------------------------------------------------------------------------
@@ -206,10 +210,16 @@ main = do
     where
 
     allBenchmarks value =
-        [ bgroup "o1"
+        [ bgroup "o-1-space"
             [ bgroup "parser" $ concat
                 [
                   o_1_space_serial_parse value
+                ]
+            ]
+        , bgroup "o-n-heap"
+            [ bgroup "parser" $ concat
+                [
+                  o_1_heap_serial_parse value
                 ]
             ]
         ]

--- a/benchmark/Streamly/Benchmark/Data/Parser.hs
+++ b/benchmark/Streamly/Benchmark/Data/Parser.hs
@@ -2,7 +2,7 @@
 -- Module      : Streamly.Benchmark.Data.Parser
 -- Copyright   : (c) 2020 Composewell Technologies
 --
--- License     : MIT
+-- License     : BSD-3-Clause
 -- Maintainer  : streamly@composewell.com
 
 {-# LANGUAGE FlexibleContexts #-}

--- a/benchmark/Streamly/Benchmark/Data/ParserD.hs
+++ b/benchmark/Streamly/Benchmark/Data/ParserD.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      : Streamly.Benchmark.Data.Parser
+-- Module      : Streamly.Benchmark.Data.ParserD
 -- Copyright   : (c) 2020 Composewell Technologies
 --
 -- License     : MIT
@@ -24,7 +24,7 @@ import qualified Control.Applicative as AP
 import qualified Streamly as S hiding (runStream)
 import qualified Streamly.Prelude  as S
 import qualified Streamly.Internal.Data.Fold as FL
-import qualified Streamly.Internal.Data.Parser as PR
+import qualified Streamly.Internal.Data.Parser.ParserD as PR
 import qualified Streamly.Internal.Prelude as IP
 
 import Gauge

--- a/benchmark/Streamly/Benchmark/Data/ParserD.hs
+++ b/benchmark/Streamly/Benchmark/Data/ParserD.hs
@@ -186,22 +186,29 @@ o_1_space_serial_parse value =
     , benchIOSink value "split (all,any)" $ splitAllAny value
     , benchIOSink value "many" many
     , benchIOSink value "some" some
-    , benchIOSink value "choice/100" $ choice (value `div` 100)
     , benchIOSink value "tee (all,any)" $ teeAllAny value
     , benchIOSink value "teeFst (all,any)" $ teeFstAllAny value
     , benchIOSink value "shortest (all,any)" $ shortestAllAny value
     , benchIOSink value "longest (all,any)" $ longestAllAny value
-    , benchIOSink value "sequenceA/100" $ sequenceA (value `div` 100)
-    , benchIOSink value "sequenceA_/100" $ sequenceA_ (value `div` 100)
-    , benchIOSink value "sequence/100" $ sequence (value `div` 100)
     ]
 
-o_1_heap_serial_parse :: Int -> [Benchmark]
-o_1_heap_serial_parse value =
+-- These show non-linear time complexity
+-- Increase in rss is 20-40% on doubling the stream size
+o_n_heap_serial_parse :: Int -> [Benchmark]
+o_n_heap_serial_parse value =
     [ benchIOSink value "lookAhead" $ lookAhead value
     , benchIOSink value "manyAlt" manyAlt
     , benchIOSink value "someAlt" someAlt
     , benchIOSink value "manyTill" $ manyTill value
+    ]
+
+-- accumulate results in a list in IO
+o_n_space_serial_parse :: Int -> [Benchmark]
+o_n_space_serial_parse value =
+    [ benchIOSink value "sequenceA/100" $ sequenceA (value `div` 100)
+    , benchIOSink value "sequenceA_/100" $ sequenceA_ (value `div` 100)
+    , benchIOSink value "sequence/100" $ sequence (value `div` 100)
+    , benchIOSink value "choice/100" $ choice (value `div` 100)
     ]
 
 -------------------------------------------------------------------------------
@@ -225,7 +232,13 @@ main = do
         , bgroup "o-n-heap"
             [ bgroup "parser" $ concat
                 [
-                  o_1_heap_serial_parse value
+                  o_n_heap_serial_parse value
+                ]
+            ]
+        , bgroup "o-n-space"
+            [ bgroup "parser" $ concat
+                [
+                  o_n_space_serial_parse value
                 ]
             ]
         ]

--- a/benchmark/Streamly/Benchmark/Data/ParserD.hs
+++ b/benchmark/Streamly/Benchmark/Data/ParserD.hs
@@ -2,7 +2,7 @@
 -- Module      : Streamly.Benchmark.Data.ParserD
 -- Copyright   : (c) 2020 Composewell Technologies
 --
--- License     : MIT
+-- License     : BSD-3-Clause
 -- Maintainer  : streamly@composewell.com
 
 {-# LANGUAGE FlexibleContexts #-}

--- a/benchmark/Streamly/Benchmark/Data/ParserK.hs
+++ b/benchmark/Streamly/Benchmark/Data/ParserK.hs
@@ -1,0 +1,157 @@
+-- |
+-- Module      : Streamly.Benchmark.Data.ParserK
+-- Copyright   : (c) 2020 Composewell Technologies
+--
+-- License     : MIT
+-- Maintainer  : streamly@composewell.com
+
+{-# LANGUAGE FlexibleContexts #-}
+
+module Main
+  (
+    main
+  ) where
+
+import Control.DeepSeq (NFData(..))
+import Control.Monad.Catch (MonadCatch)
+import Data.Foldable (asum)
+import System.Random (randomRIO)
+import Prelude hiding (any, all, take, sequence, sequenceA, takeWhile)
+
+import qualified Data.Traversable as TR
+import qualified Control.Applicative as AP
+import qualified Streamly as S hiding (runStream)
+import qualified Streamly.Prelude  as S
+import qualified Streamly.Internal.Data.ParserK.Types as PR
+import qualified Streamly.Internal.Data.Parser as PRD
+import qualified Streamly.Internal.Prelude as IP
+
+import Gauge
+import Streamly hiding (runStream)
+import Streamly.Benchmark.Common
+
+-------------------------------------------------------------------------------
+-- Utilities
+-------------------------------------------------------------------------------
+
+-- XXX these can be moved to the common module
+
+-- We need a monadic bind here to make sure that the function f does not get
+-- completely optimized out by the compiler in some cases.
+
+{-# INLINE sourceUnfoldrM #-}
+sourceUnfoldrM :: (S.IsStream t, S.MonadAsync m) => Int -> Int -> t m Int
+sourceUnfoldrM value n = S.unfoldrM step n
+    where
+    step cnt =
+        if cnt > n + value
+        then return Nothing
+        else return (Just (cnt, cnt + 1))
+
+-- | Takes a fold method, and uses it with a default source.
+{-# INLINE benchIOSink #-}
+benchIOSink
+    :: (IsStream t, NFData b)
+    => Int -> String -> (t IO Int -> IO b) -> Benchmark
+benchIOSink value name f =
+    bench name $ nfIO $ randomRIO (1,1) >>= f . sourceUnfoldrM value
+
+-------------------------------------------------------------------------------
+-- Parsers
+-------------------------------------------------------------------------------
+
+{-# INLINE satisfy #-}
+satisfy :: MonadCatch m => (a -> Bool) -> PR.Parser m a a
+satisfy = PRD.toParserK . PRD.satisfy
+
+{-# INLINE any #-}
+any :: MonadCatch m => (a -> Bool) -> PR.Parser m a Bool
+any = PRD.toParserK . PRD.any
+
+{-# INLINE anyK #-}
+anyK :: (MonadCatch m, Ord a) => a -> SerialT m a -> m Bool
+anyK value = IP.parseK (any (> value))
+
+{-# INLINE splitApp #-}
+splitApp :: MonadCatch m
+    => Int -> SerialT m Int -> m (Bool, Bool)
+splitApp value =
+    IP.parseK ((,) <$> any (>= (value `div` 2)) <*> any (> value))
+
+{-# INLINE sequenceA #-}
+sequenceA :: MonadCatch m => Int -> SerialT m Int -> m Int
+sequenceA value xs = do
+    let parser = satisfy (> 0)
+        list = Prelude.replicate value parser
+    x <- IP.parseK (TR.sequenceA list) xs
+    return $ Prelude.length x
+
+{-# INLINE sequence #-}
+sequence :: MonadCatch m => Int -> SerialT m Int -> m Int
+sequence value xs = do
+    let parser = satisfy (> 0)
+        list = Prelude.replicate value parser
+    x <- IP.parseK (TR.sequence list) xs
+    return $ Prelude.length x
+
+{-# INLINE manyAlt #-}
+manyAlt :: MonadCatch m => SerialT m Int -> m Int
+manyAlt xs = do
+    x <- IP.parseK (AP.many (satisfy (> 0))) xs
+    return $ Prelude.length x
+
+{-# INLINE someAlt #-}
+someAlt :: MonadCatch m => SerialT m Int -> m Int
+someAlt xs = do
+    x <- IP.parseK (AP.some (satisfy (> 0))) xs
+    return $ Prelude.length x
+
+{-# INLINE choice #-}
+choice :: MonadCatch m => Int -> SerialT m Int -> m Int
+choice value = do
+    IP.parseK (asum (replicate value (satisfy (< 0)))
+        AP.<|> satisfy (> 0))
+
+-------------------------------------------------------------------------------
+-- Benchmarks
+-------------------------------------------------------------------------------
+
+o_1_space_serial_parse :: Int -> [Benchmark]
+o_1_space_serial_parse value =
+    [ benchIOSink value "any" $ anyK value
+    , benchIOSink value "splitApp" $ splitApp value
+    ]
+
+-- O(n) heap beacuse of accumulation of the list in strict IO monad?
+o_n_heap_serial_parse :: Int -> [Benchmark]
+o_n_heap_serial_parse value =
+    [ benchIOSink value "sequenceA" $ sequenceA value
+    , benchIOSink value "sequence" $ sequence value
+    , benchIOSink value "manyAlt" manyAlt
+    , benchIOSink value "someAlt" someAlt
+    , benchIOSink value "choice" $ choice value
+    ]
+
+-------------------------------------------------------------------------------
+-- Driver
+-------------------------------------------------------------------------------
+
+main :: IO ()
+main = do
+    (value, cfg, benches) <- parseCLIOpts defaultStreamSize
+    value `seq` runMode (mode cfg) cfg benches (allBenchmarks value)
+
+    where
+
+    allBenchmarks value =
+        [ bgroup "o-1-space"
+            [ bgroup "parserK" $ concat
+                [ o_1_space_serial_parse value
+                ]
+            ]
+        , bgroup "o-n-heap"
+            [ bgroup "parserK" $ concat
+                [ o_n_heap_serial_parse value
+                ]
+            ]
+        ]

--- a/benchmark/Streamly/Benchmark/Data/ParserK.hs
+++ b/benchmark/Streamly/Benchmark/Data/ParserK.hs
@@ -22,8 +22,8 @@ import qualified Data.Traversable as TR
 import qualified Control.Applicative as AP
 import qualified Streamly as S hiding (runStream)
 import qualified Streamly.Prelude  as S
-import qualified Streamly.Internal.Data.ParserK.Types as PR
-import qualified Streamly.Internal.Data.Parser as PRD
+import qualified Streamly.Internal.Data.Parser.ParserK.Types as PR
+import qualified Streamly.Internal.Data.Parser.ParserD as PRD
 import qualified Streamly.Internal.Prelude as IP
 
 import Gauge

--- a/benchmark/Streamly/Benchmark/Data/ParserK.hs
+++ b/benchmark/Streamly/Benchmark/Data/ParserK.hs
@@ -19,6 +19,7 @@ import System.Random (randomRIO)
 import Prelude hiding (any, all, take, sequence, sequenceA, takeWhile)
 
 import qualified Control.Applicative as AP
+import qualified Data.Foldable as F
 import qualified Data.Traversable as TR
 import qualified Streamly as S hiding (runStream)
 import qualified Streamly.Prelude  as S
@@ -83,6 +84,13 @@ sequenceA value xs = do
     x <- IP.parseK (TR.sequenceA list) xs
     return $ Prelude.length x
 
+{-# INLINE sequenceA_ #-}
+sequenceA_ :: MonadCatch m => Int -> SerialT m Int -> m ()
+sequenceA_ value xs = do
+    let parser = satisfy (> 0)
+        list = Prelude.replicate value parser
+    IP.parseK (F.sequenceA_ list) xs
+
 {-# INLINE sequence #-}
 sequence :: MonadCatch m => Int -> SerialT m Int -> m Int
 sequence value xs = do
@@ -123,6 +131,7 @@ o_1_space_serial_parse value =
 o_n_heap_serial_parse :: Int -> [Benchmark]
 o_n_heap_serial_parse value =
     [ benchIOSink value "sequenceA" $ sequenceA value
+    , benchIOSink value "sequenceA_" $ sequenceA_ value
     , benchIOSink value "sequence" $ sequence value
     , benchIOSink value "manyAlt" manyAlt
     , benchIOSink value "someAlt" someAlt

--- a/benchmark/Streamly/Benchmark/Data/ParserK.hs
+++ b/benchmark/Streamly/Benchmark/Data/ParserK.hs
@@ -18,8 +18,8 @@ import Data.Foldable (asum)
 import System.Random (randomRIO)
 import Prelude hiding (any, all, take, sequence, sequenceA, takeWhile)
 
-import qualified Data.Traversable as TR
 import qualified Control.Applicative as AP
+import qualified Data.Traversable as TR
 import qualified Streamly as S hiding (runStream)
 import qualified Streamly.Prelude  as S
 import qualified Streamly.Internal.Data.Parser.ParserK.Types as PR
@@ -35,9 +35,6 @@ import Streamly.Benchmark.Common
 -------------------------------------------------------------------------------
 
 -- XXX these can be moved to the common module
-
--- We need a monadic bind here to make sure that the function f does not get
--- completely optimized out by the compiler in some cases.
 
 {-# INLINE sourceUnfoldrM #-}
 sourceUnfoldrM :: (S.IsStream t, S.MonadAsync m) => Int -> Int -> t m Int
@@ -108,7 +105,7 @@ someAlt xs = do
 
 {-# INLINE choice #-}
 choice :: MonadCatch m => Int -> SerialT m Int -> m Int
-choice value = do
+choice value =
     IP.parseK (asum (replicate value (satisfy (< 0)))
         AP.<|> satisfy (> 0))
 

--- a/benchmark/Streamly/Benchmark/Data/ParserK.hs
+++ b/benchmark/Streamly/Benchmark/Data/ParserK.hs
@@ -2,7 +2,7 @@
 -- Module      : Streamly.Benchmark.Data.ParserK
 -- Copyright   : (c) 2020 Composewell Technologies
 --
--- License     : MIT
+-- License     : BSD-3-Clause
 -- Maintainer  : streamly@composewell.com
 
 {-# LANGUAGE FlexibleContexts #-}

--- a/benchmark/Streamly/Benchmark/FileIO/Stream.hs
+++ b/benchmark/Streamly/Benchmark/FileIO/Stream.hs
@@ -88,7 +88,7 @@ import qualified Streamly.Data.Unicode.Stream as SS
 import qualified Streamly.Internal.Data.Unicode.Stream as IUS
 import qualified Streamly.Internal.Memory.Unicode.Array as IUA
 import qualified Streamly.Internal.Data.Unfold as IUF
-import qualified Streamly.Internal.Data.Parser as PR
+import qualified Streamly.Internal.Data.Parser.ParserD as PR
 import qualified Streamly.Internal.Prelude as IP
 import qualified Streamly.Internal.Data.Stream.StreamD as D
 

--- a/benchmark/streamly-benchmarks.cabal
+++ b/benchmark/streamly-benchmarks.cabal
@@ -259,6 +259,18 @@ benchmark parser
     buildable: True
     build-depends: exceptions >= 0.8   && < 0.11
 
+benchmark parserK
+  import: bench-options
+  type: exitcode-stdio-1.0
+  ghc-options: -with-rtsopts "-T -K128K -M32M"
+  hs-source-dirs: Streamly/Benchmark/Data
+  main-is: ParserK.hs
+  if impl(ghcjs)
+    buildable: False
+  else
+    buildable: True
+    build-depends: exceptions >= 0.8   && < 0.11
+
 -------------------------------------------------------------------------------
 -- Raw Streams
 -------------------------------------------------------------------------------

--- a/benchmark/streamly-benchmarks.cabal
+++ b/benchmark/streamly-benchmarks.cabal
@@ -247,12 +247,12 @@ benchmark unfold
   else
     buildable: True
 
-benchmark parser
+benchmark parserD
   import: bench-options
   type: exitcode-stdio-1.0
   ghc-options: -with-rtsopts "-T -K36K -M16M"
   hs-source-dirs: ., Streamly/Benchmark/Data
-  main-is: Parser.hs
+  main-is: ParserD.hs
   if impl(ghcjs)
     buildable: False
   else

--- a/benchmark/streamly-benchmarks.cabal
+++ b/benchmark/streamly-benchmarks.cabal
@@ -271,6 +271,18 @@ benchmark parserK
     buildable: True
     build-depends: exceptions >= 0.8   && < 0.11
 
+benchmark parser
+  import: bench-options
+  type: exitcode-stdio-1.0
+  ghc-options: -with-rtsopts "-T -K36K -M32M"
+  hs-source-dirs: Streamly/Benchmark/Data
+  main-is: Parser.hs
+  if impl(ghcjs)
+    buildable: False
+  else
+    buildable: True
+    build-depends: exceptions >= 0.8   && < 0.11
+
 -------------------------------------------------------------------------------
 -- Raw Streams
 -------------------------------------------------------------------------------

--- a/src/Streamly/Internal/Data/Parser.hs
+++ b/src/Streamly/Internal/Data/Parser.hs
@@ -1,0 +1,871 @@
+{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -Wno-orphans  #-}
+#endif
+
+-- |
+-- Module      : Streamly.Internal.Data.Parser
+-- Copyright   : (c) 2020 Composewell Technologies
+-- License     : BSD3
+-- Maintainer  : streamly@composewell.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- Fast backtracking parsers with stream fusion and native streaming
+-- capability.
+--
+-- 'Applicative' and 'Control.Applicative.Alternative' type class based
+-- combinators from the
+-- <http://hackage.haskell.org/package/parser-combinators parser-combinators>
+-- package can also be used with the 'Parser' type. However, there are two
+-- important differences between @parser-combinators@ and the equivalent ones
+-- provided in this module in terms of performance:
+--
+-- 1) @parser-combinators@ use plain Haskell lists to collect the results, in a
+-- strict Monad like IO, the results are necessarily buffered before they can
+-- be consumed.  This may not perform optimally in streaming applications
+-- processing large amounts of data.  Equivalent combinators in this module can
+-- consume the results of parsing using a 'Fold', thus providing a scalability
+-- and a composable consumer.
+--
+-- 2) Several combinators in this module can be many times faster because of
+-- stream fusion. For example, 'Streamly.Internal.Data.Parser.many' combinator
+-- in this module is much faster than the 'Control.Applicative.many' combinator
+-- of 'Control.Applicative.Alternative' type class.
+--
+-- = Errors
+--
+-- Failing parsers in this module throw the 'D.ParseError' exception.
+--
+-- = Naming
+--
+-- As far as possible, try that the names of the combinators in this module are
+-- consistent with:
+--
+-- * <https://hackage.haskell.org/package/base/docs/Text-ParserCombinators-ReadP.html base/Text.ParserCombinators.ReadP>
+-- * <http://hackage.haskell.org/package/parser-combinators parser-combinators>
+-- * <http://hackage.haskell.org/package/megaparsec megaparsec>
+-- * <http://hackage.haskell.org/package/attoparsec attoparsec>
+-- * <http://hackage.haskell.org/package/parsec parsec>
+
+module Streamly.Internal.Data.Parser
+    (
+      K.Parser (..)
+    , D.ParseError (..)
+    , D.Step (..)
+
+    -- First order parsers
+    -- * Accumulators
+    , fromFold
+    , any
+    , all
+    , yield
+    , yieldM
+    , die
+    , dieM
+
+    -- * Element parsers
+    , peek
+    , eof
+    , satisfy
+
+    -- * Sequence parsers
+    --
+    -- | Parsers chained in series, if one parser terminates the composition
+    -- terminates.
+    --
+    -- TODO: Currently we are using folds to collect the output of the parsers
+    -- but we can use Parsers instead of folds to make the composition more
+    -- powerful. For example, we can do:
+    --
+    -- @
+    -- sliceSepByMax cond n p = sliceBy cond (take n p)
+    -- sliceSepByBetween cond m n p = sliceBy cond (takeBetween m n p)
+    -- takeWhileBetween cond m n p = takeWhile cond (takeBetween m n p)
+    -- @
+    --
+    -- TODO: Like toList fold we can have toNonEmpty Parser to fold to a
+    -- nonempty list. If we cannot collect even one element the parser will
+    -- fail.  toNonEmpty can be used in takeWhile to implement takeWhile1.
+
+    -- | Grab a sequence of input elements without inspecting them
+    , take
+    -- $take
+    -- | Unimplemented
+    --
+    -- @
+    -- , takeBetween
+    -- , takeLE -- take   -- takeBetween 0 n
+    -- , takeLE1 -- take1 -- takeBetween 1 n
+    -- @
+    , takeEQ -- takeBetween n n
+    , takeGE -- takeBetween n maxBound
+
+    -- Grab a sequence of input elements by inspecting them
+    , lookAhead
+    , takeWhile
+    -- $takeWhile
+    , takeWhile1
+    , sliceSepBy
+    , sliceSepByMax
+    -- | Unimplemented
+    --
+    -- @
+    -- , sliceSepByBetween
+    -- @
+    , sliceEndWith
+    , sliceBeginWith
+    -- | Unimplemented
+    --
+    -- @
+    -- , sliceSepWith
+    --
+    -- , frameSepBy -- parse frames escaped by an escape char/sequence
+    -- , frameEndWith
+    -- @
+    , wordBy
+    , groupBy
+    , eqBy
+    -- | Unimplemented
+    --
+    -- @
+    -- , prefixOf -- match any prefix of a given string
+    -- , suffixOf -- match any suffix of a given string
+    -- , infixOf -- match any substring of a given string
+    -- @
+
+    -- Second order parsers (parsers using parsers)
+    -- * Binary Combinators
+
+    -- ** Sequential Applicative
+    , splitWith
+    , split_
+
+    -- ** Parallel Applicatives
+    , teeWith
+    , teeWithFst
+    , teeWithMin
+    -- , teeTill -- like manyTill but parallel
+
+    -- ** Sequential Interleaving
+    -- Use two folds, run a primary parser, its rejected values go to the
+    -- secondary parser.
+    , deintercalate
+
+    -- ** Sequential Alternative
+    , alt
+
+    -- ** Parallel Alternatives
+    , shortest
+    , longest
+    -- , fastest
+
+    -- * N-ary Combinators
+    -- ** Sequential Collection
+    , sequence
+    , concatMap
+
+    -- ** Sequential Repetition
+    , count
+    , countBetween
+    -- , countBetweenTill
+
+    , many
+    , some
+    , manyTill
+
+    -- ** Special cases
+    -- | TODO: traditional implmentations of these may be of limited use. For
+    -- example, consider parsing lines separated by @\\r\\n@. The main parser
+    -- will have to detect and exclude the sequence @\\r\\n@ anyway so that we
+    -- can apply the "sep" parser.
+    --
+    -- We can instead implement these as special cases of deintercalate.
+    --
+    -- @
+    -- , endBy
+    -- , sepBy
+    -- , sepEndBy
+    -- , beginBy
+    -- , sepBeginBy
+    -- , sepAroundBy
+    -- @
+
+    -- * Distribution
+    --
+    -- | A simple and stupid impl would be to just convert the stream to an
+    -- array and give the array reference to all consumers. The array can be
+    -- grown on demand by any consumer and truncated when nonbody needs it.
+
+    -- ** Distribute to collection
+    -- ** Distribute to repetition
+
+    -- ** Interleaved collection
+    -- |
+    --
+    -- 1. Round robin
+    -- 2. Priority based
+
+    -- ** Interleaved repetition
+    -- | repeat one parser and when it fails run an error recovery parser
+    -- e.g. to find a key frame in the stream after an error
+
+    -- ** Collection of Alternatives
+    -- | Unimplemented
+    --
+    -- @
+    -- , shortestN
+    -- , longestN
+    -- , fastestN -- first N successful in time
+    -- , choiceN  -- first N successful in position
+    -- @
+    , choice   -- first successful in position
+
+    -- ** Repeated Alternatives
+    -- |
+    --
+    -- @
+    -- , retryMax    -- try N times
+    -- , retryUntil  -- try until successful
+    -- , retryUntilN -- try until successful n times
+    -- @
+    )
+where
+
+import Control.Monad.Catch (MonadCatch)
+import Prelude
+       hiding (any, all, take, takeWhile, sequence, concatMap)
+
+import Streamly.Internal.Data.Fold.Types (Fold(..))
+import Streamly.Internal.Data.Parser.ParserK.Types (Parser)
+
+import qualified Streamly.Internal.Data.Parser.ParserD as D
+import qualified Streamly.Internal.Data.Parser.ParserK.Types as K
+
+-------------------------------------------------------------------------------
+-- Upgrade folds to parses
+-------------------------------------------------------------------------------
+--
+-- | Make a 'Parser' from a 'Fold'.
+--
+-- /Internal/
+--
+{-# INLINE fromFold #-}
+fromFold :: MonadCatch m => Fold m a b -> Parser m a b
+fromFold = D.toParserK . D.fromFold
+
+-------------------------------------------------------------------------------
+-- Terminating but not failing folds
+-------------------------------------------------------------------------------
+--
+-- |
+-- >>> S.parse (PR.any (== 0)) $ S.fromList [1,0,1]
+-- > True
+--
+{-# INLINE any #-}
+any :: MonadCatch m => (a -> Bool) -> Parser m a Bool
+any = D.toParserK . D.any
+
+-- |
+-- >>> S.parse (PR.all (== 0)) $ S.fromList [1,0,1]
+-- > False
+--
+{-# INLINE all #-}
+all :: MonadCatch m => (a -> Bool) -> Parser m a Bool
+all = D.toParserK . D.all
+
+-- This is the dual of stream "yield".
+--
+-- | A parser that always yields a pure value without consuming any input.
+--
+-- /Internal/
+--
+{-# INLINE [3] yield #-}
+yield :: MonadCatch m => b -> Parser m a b
+yield = D.toParserK . D.yield
+{-# RULES "yield fallback to CPS" [2]
+    forall a. D.toParserK (D.yield a) = K.yield a #-}
+
+-- This is the dual of stream "yieldM".
+--
+-- | A parser that always yields the result of an effectful action without
+-- consuming any input.
+--
+-- /Internal/
+--
+{-# INLINE yieldM #-}
+yieldM :: MonadCatch m => m b -> Parser m a b
+yieldM = D.toParserK . D.yieldM
+
+-- This is the dual of "nil".
+--
+-- | A parser that always fails with an error message without consuming
+-- any input.
+--
+-- /Internal/
+--
+{-# INLINE [3] die #-}
+die :: MonadCatch m => String -> Parser m a b
+die = D.toParserK . D.die
+{-# RULES "die fallback to CPS" [2]
+    forall a. D.toParserK (D.die a) = K.die a #-}
+
+-- This is the dual of "nilM".
+--
+-- | A parser that always fails with an effectful error message and without
+-- consuming any input.
+--
+-- /Internal/
+--
+{-# INLINE dieM #-}
+dieM :: MonadCatch m => m String -> Parser m a b
+dieM = D.toParserK . D.dieM
+
+-------------------------------------------------------------------------------
+-- Failing Parsers
+-------------------------------------------------------------------------------
+
+-- | Peek the head element of a stream, without consuming it. Fails if it
+-- encounters end of input.
+--
+-- >>> S.parse ((,) <$> PR.peek <*> PR.satisfy (> 0)) $ S.fromList [1]
+-- (1,1)
+--
+-- @
+-- peek = lookAhead (satisfy True)
+-- @
+--
+-- /Internal/
+--
+{-# INLINE peek #-}
+peek :: MonadCatch m => Parser m a a
+peek = D.toParserK D.peek
+
+-- | Succeeds if we are at the end of input, fails otherwise.
+--
+-- >>> S.parse ((,) <$> PR.satisfy (> 0) <*> PR.eof) $ S.fromList [1]
+-- > (1,())
+--
+-- /Internal/
+--
+{-# INLINE eof #-}
+eof :: MonadCatch m => Parser m a ()
+eof = D.toParserK D.eof
+
+-- | Returns the next element if it passes the predicate, fails otherwise.
+--
+-- >>> S.parse (PR.satisfy (== 1)) $ S.fromList [1,0,1]
+-- > 1
+--
+-- /Internal/
+--
+{-# INLINE satisfy #-}
+satisfy :: MonadCatch m => (a -> Bool) -> Parser m a a
+satisfy = D.toParserK . D.satisfy
+
+-------------------------------------------------------------------------------
+-- Taking elements
+-------------------------------------------------------------------------------
+--
+-- $take
+-- Note: this is called takeP in some parser libraries.
+--
+-- TODO Once we have terminating folds, this Parse should get replaced by Fold.
+-- Alternatively, we can name it "chunkOf" and the corresponding time domain
+-- combinator as "intervalOf" or even "chunk" and "interval".
+
+-- | Take at most @n@ input elements and fold them using the supplied fold.
+--
+-- Stops after @n@ elements.
+-- Never fails.
+--
+-- >>> S.parse (PR.take 1 FL.toList) $ S.fromList [1]
+-- [1]
+--
+-- @
+-- S.chunksOf n f = S.splitParse (FL.take n f)
+-- @
+--
+-- /Internal/
+--
+{-# INLINE take #-}
+take :: MonadCatch m => Int -> Fold m a b -> Parser m a b
+take n = D.toParserK . D.take n
+
+-- | Stops after taking exactly @n@ input elements.
+--
+-- * Stops - after @n@ elements.
+-- * Fails - if the stream ends before it can collect @n@ elements.
+--
+-- >>> S.parse (PR.takeEQ 4 FL.toList) $ S.fromList [1,0,1]
+-- > "takeEQ: Expecting exactly 4 elements, got 3"
+--
+-- /Internal/
+--
+{-# INLINE takeEQ #-}
+takeEQ :: MonadCatch m => Int -> Fold m a b -> Parser m a b
+takeEQ n = D.toParserK . D.takeEQ n
+
+-- | Take at least @n@ input elements, but can collect more.
+--
+-- * Stops - never.
+-- * Fails - if the stream end before producing @n@ elements.
+--
+-- >>> S.parse (PR.takeGE 4 FL.toList) $ S.fromList [1,0,1]
+-- > "takeGE: Expecting at least 4 elements, got only 3"
+--
+-- >>> S.parse (PR.takeGE 4 FL.toList) $ S.fromList [1,0,1,0,1]
+-- > [1,0,1,0,1]
+--
+-- /Internal/
+--
+{-# INLINE takeGE #-}
+takeGE :: MonadCatch m => Int -> Fold m a b -> Parser m a b
+takeGE n = D.toParserK . D.takeGE n
+
+-- $takeWhile
+-- Note: This is called @takeWhileP@ and @munch@ in some parser libraries.
+
+-- | Collect stream elements until an element fails the predicate. The element
+-- on which the predicate fails is returned back to the input stream.
+--
+-- * Stops - when the predicate fails.
+-- * Fails - never.
+--
+-- >>> S.parse (PR.takeWhile (== 0) FL.toList) $ S.fromList [0,0,1,0,1]
+-- > [0,0]
+--
+-- We can implement a @breakOn@ using 'takeWhile':
+--
+-- @
+-- breakOn p = takeWhile (not p)
+-- @
+--
+-- /Internal/
+--
+{-# INLINE takeWhile #-}
+takeWhile :: MonadCatch m => (a -> Bool) -> Fold m a b -> Parser m a b
+takeWhile cond = D.toParserK . D.takeWhile cond
+
+-- | Like 'takeWhile' but takes at least one element otherwise fails.
+--
+-- /Internal/
+--
+{-# INLINE takeWhile1 #-}
+takeWhile1 :: MonadCatch m => (a -> Bool) -> Fold m a b -> Parser m a b
+takeWhile1 cond = D.toParserK . D.takeWhile1 cond
+
+-- | Collect stream elements until an element succeeds the predicate. Drop the
+-- element on which the predicate succeeded. The succeeding element is treated
+-- as an infix separator which is dropped from the output.
+--
+-- * Stops - when the predicate succeeds.
+-- * Fails - never.
+--
+-- >>> S.parse (PR.sliceSepBy (== 1) FL.toList) $ S.fromList [0,0,1,0,1]
+-- > [0,0]
+--
+-- S.splitOn pred f = S.splitParse (PR.sliceSepBy pred f)
+--
+-- >>> S.toList $ S.splitParse (PR.sliceSepBy (== 1) FL.toList) $ S.fromList [0,0,1,0,1]
+-- > [[0,0],[0],[]]
+--
+-- /Internal/
+--
+{-# INLINABLE sliceSepBy #-}
+sliceSepBy :: MonadCatch m => (a -> Bool) -> Fold m a b -> Parser m a b
+sliceSepBy cond = D.toParserK . D.sliceSepBy cond
+
+-- | Collect stream elements until an element succeeds the predicate. Also take
+-- the element on which the predicate succeeded. The succeeding element is
+-- treated as a suffix separator which is kept in the output segement.
+--
+-- * Stops - when the predicate succeeds.
+-- * Fails - never.
+--
+-- S.splitWithSuffix pred f = S.splitParse (PR.sliceEndWith pred f)
+--
+-- /Unimplemented/
+--
+{-# INLINABLE sliceEndWith #-}
+sliceEndWith ::
+    -- Monad m =>
+    (a -> Bool) -> Fold m a b -> Parser m a b
+sliceEndWith = undefined
+
+-- | Collect stream elements until an elements passes the predicate, return the
+-- last element on which the predicate succeeded back to the input stream.  If
+-- the predicate succeeds on the first element itself then it is kept in the
+-- stream and we continue collecting. The succeeding element is treated as a
+-- prefix separator which is kept in the output segement.
+--
+-- * Stops - when the predicate succeeds in non-leading position.
+-- * Fails - never.
+--
+-- S.splitWithPrefix pred f = S.splitParse (PR.sliceBeginWith pred f)
+--
+-- /Unimplemented/
+--
+{-# INLINABLE sliceBeginWith #-}
+sliceBeginWith ::
+    -- Monad m =>
+    (a -> Bool) -> Fold m a b -> Parser m a b
+sliceBeginWith = undefined
+
+-- | Split using a condition or a count whichever occurs first. This is a
+-- hybrid of 'splitOn' and 'take'. The element on which the condition succeeds
+-- is dropped.
+--
+-- /Internal/
+--
+{-# INLINABLE sliceSepByMax #-}
+sliceSepByMax :: MonadCatch m
+    => (a -> Bool) -> Int -> Fold m a b -> Parser m a b
+sliceSepByMax cond cnt = D.toParserK . D.sliceSepByMax cond cnt
+
+-- | Like 'splitOn' but strips leading, trailing, and repeated separators.
+-- Therefore, @".a..b."@ having '.' as the separator would be parsed as
+-- @["a","b"]@.  In other words, its like parsing words from whitespace
+-- separated text.
+--
+-- * Stops - when it finds a word separator after a non-word element
+-- * Fails - never.
+--
+-- @
+-- S.wordsBy pred f = S.splitParse (PR.wordBy pred f)
+-- @
+--
+-- /Unimplemented/
+--
+{-# INLINABLE wordBy #-}
+wordBy ::
+    -- Monad m =>
+    (a -> Bool) -> Fold m a b -> Parser m a b
+wordBy = undefined
+
+-- | @groupBy cmp f $ S.fromList [a,b,c,...]@ assigns the element @a@ to the
+-- first group, then if @a \`cmp` b@ is 'True' @b@ is also assigned to the same
+-- group.  If @a \`cmp` c@ is 'True' then @c@ is also assigned to the same
+-- group and so on. When the comparison fails a new group is started. Each
+-- group is folded using the 'Fold' @f@ and the result of the fold is emitted
+-- in the output stream.
+--
+-- * Stops - when the comparison fails.
+-- * Fails - never.
+--
+-- @
+-- S.groupsBy cmp f = S.splitParse (PR.groupBy cmp f)
+-- @
+--
+-- /Unimplemented/
+--
+{-# INLINABLE groupBy #-}
+groupBy ::
+    -- Monad m =>
+    (a -> a -> Bool) -> Fold m a b -> Parser m a b
+groupBy = undefined
+
+-- | Match the given sequence of elements using the given comparison function.
+--
+-- /Internal/
+--
+{-# INLINE eqBy #-}
+eqBy :: MonadCatch m => (a -> a -> Bool) -> [a] -> Parser m a ()
+eqBy cmp = D.toParserK . D.eqBy cmp
+
+-------------------------------------------------------------------------------
+-- nested parsers
+-------------------------------------------------------------------------------
+
+-- | Sequential parser application. Apply two parsers sequentially to an input
+-- stream.  The input is provided to the first parser, when it is done the
+-- remaining input is provided to the second parser. If both the parsers
+-- succeed their outputs are combined using the supplied function. The
+-- operation fails if any of the parsers fail.
+--
+-- Note: This is a parsing dual of appending streams using
+-- 'Streamly.Prelude.serial', it splits the streams using two parsers and zips
+-- the results.
+--
+-- This implementation is strict in the second argument, therefore, the
+-- following will fail:
+--
+-- >>> S.parse (PR.splitWith const (PR.satisfy (> 0)) undefined) $ S.fromList [1]
+--
+-- Compare with 'Applicative' instance method '<*>'. This implementation allows
+-- stream fusion but has quadratic complexity. This can fuse with other
+-- operations and can be faster than 'Applicative' instance for small number
+-- (less than 8) of compositions.
+--
+-- /Internal/
+--
+{-# INLINE splitWith #-}
+splitWith :: MonadCatch m
+    => (a -> b -> c) -> Parser m x a -> Parser m x b -> Parser m x c
+splitWith f p1 p2 =
+    D.toParserK $ D.splitWith f (D.fromParserK p1) (D.fromParserK p2)
+
+-- | Sequential parser application ignoring the output of the first parser.
+-- Apply two parsers sequentially to an input stream.  The input is provided to
+-- the first parser, when it is done the remaining input is provided to the
+-- second parser. The output of the parser is the output of the second parser.
+-- The operation fails if any of the parsers fail.
+--
+-- This implementation is strict in the second argument, therefore, the
+-- following will fail:
+--
+-- >>> S.parse (split_ (PR.satisfy (> 0)) undefined) $ S.fromList [1]
+--
+-- Compare with 'Applicative' instance method '*>'. This implementation allows
+-- stream fusion but has quadratic complexity. This can fuse with other
+-- operations, and can be faster than 'Applicative' instance for small
+-- number (less than 8) of compositions.
+--
+-- /Internal/
+--
+{-# INLINE split_ #-}
+split_ :: MonadCatch m => Parser m x a -> Parser m x b -> Parser m x b
+split_ p1 p2 = D.toParserK $ D.split_ (D.fromParserK p1) (D.fromParserK p2)
+
+-- | @teeWith f p1 p2@ distributes its input to both @p1@ and @p2@ until both
+-- of them succeed or anyone of them fails and combines their output using @f@.
+-- The parser succeeds if both the parsers succeed.
+--
+-- /Internal/
+--
+{-# INLINE teeWith #-}
+teeWith :: MonadCatch m
+    => (a -> b -> c) -> Parser m x a -> Parser m x b -> Parser m x c
+teeWith f p1 p2 =
+    D.toParserK $ D.teeWith f (D.fromParserK p1) (D.fromParserK p2)
+
+-- | Like 'teeWith' but ends parsing and zips the results, if available,
+-- whenever the first parser ends.
+--
+-- /Internal/
+--
+{-# INLINE teeWithFst #-}
+teeWithFst :: MonadCatch m
+    => (a -> b -> c) -> Parser m x a -> Parser m x b -> Parser m x c
+teeWithFst f p1 p2 =
+    D.toParserK $ D.teeWithFst f (D.fromParserK p1) (D.fromParserK p2)
+
+-- | Like 'teeWith' but ends parsing and zips the results, if available,
+-- whenever any of the parsers ends or fails.
+--
+-- /Unimplemented/
+--
+{-# INLINE teeWithMin #-}
+teeWithMin :: MonadCatch m
+    => (a -> b -> c) -> Parser m x a -> Parser m x b -> Parser m x c
+teeWithMin f p1 p2 =
+    D.toParserK $ D.teeWithMin f (D.fromParserK p1) (D.fromParserK p2)
+
+-- | Sequential alternative. Apply the input to the first parser and return the
+-- result if the parser succeeds. If the first parser fails then backtrack and
+-- apply the same input to the second parser and return the result.
+--
+-- Note: This implementation is not lazy in the second argument. The following
+-- will fail:
+--
+-- >>> S.parse (PR.satisfy (> 0) `PR.alt` undefined) $ S.fromList [1..10]
+--
+-- Compare with 'Alternative' instance method '<|>'. This implementation allows
+-- stream fusion but has quadratic complexity. This can fuse with other
+-- operations and can be much faster than 'Alternative' instance for small
+-- number (less than 8) of alternatives.
+--
+-- /Internal/
+--
+{-# INLINE alt #-}
+alt :: MonadCatch m => Parser m x a -> Parser m x a -> Parser m x a
+alt p1 p2 = D.toParserK $ D.alt (D.fromParserK p1) (D.fromParserK p2)
+
+-- | Shortest alternative. Apply both parsers in parallel but choose the result
+-- from the one which consumed least input i.e. take the shortest succeeding
+-- parse.
+--
+-- /Internal/
+--
+{-# INLINE shortest #-}
+shortest :: MonadCatch m
+    => Parser m x a -> Parser m x a -> Parser m x a
+shortest p1 p2 = D.toParserK $ D.shortest (D.fromParserK p1) (D.fromParserK p2)
+
+-- | Longest alternative. Apply both parsers in parallel but choose the result
+-- from the one which consumed more input i.e. take the longest succeeding
+-- parse.
+--
+-- /Internal/
+--
+{-# INLINE longest #-}
+longest :: MonadCatch m
+    => Parser m x a -> Parser m x a -> Parser m x a
+longest p1 p2 = D.toParserK $ D.longest (D.fromParserK p1) (D.fromParserK p2)
+
+-- | Run a parser without consuming the input.
+--
+-- /Internal/
+--
+{-# INLINE lookAhead #-}
+lookAhead :: MonadCatch m => Parser m a b -> Parser m a b
+lookAhead p = D.toParserK $ D.lookAhead $ D.fromParserK p
+
+-------------------------------------------------------------------------------
+-- Interleaving
+-------------------------------------------------------------------------------
+--
+-- To deinterleave we can chain two parsers one behind the other. The input is
+-- given to the first parser and the input definitively rejected by the first
+-- parser is given to the second parser.
+--
+-- We can either have the parsers themselves buffer the input or use the shared
+-- global buffer to hold it until none of the parsers need it. When the first
+-- parser returns Skip (i.e. rewind) we let the second parser consume the
+-- rejected input and when it is done we move the cursor forward to the first
+-- parser again. This will require a "move forward" command as well.
+--
+-- To implement grep we can use three parsers, one to find the pattern, one
+-- to store the context behind the pattern and one to store the context in
+-- front of the pattern. When a match occurs we need to emit the accumulator of
+-- all the three parsers. One parser can count the line numbers to provide the
+-- line number info.
+--
+-- | Apply two parsers alternately to an input stream. The input stream is
+-- considered an interleaving of two patterns. The two parsers represent the
+-- two patterns.
+--
+-- This undoes a "gintercalate" of two streams.
+--
+-- /Unimplemented/
+--
+{-# INLINE deintercalate #-}
+deintercalate ::
+    -- Monad m =>
+       Fold m a y -> Parser m x a
+    -> Fold m b z -> Parser m x b
+    -> Parser m x (y, z)
+deintercalate = undefined
+
+-------------------------------------------------------------------------------
+-- Sequential Collection
+-------------------------------------------------------------------------------
+--
+-- | @sequence f t@ collects sequential parses of parsers in the container @t@
+-- using the fold @f@. Fails if the input ends or any of the parsers fail.
+--
+-- /Unimplemented/
+--
+{-# INLINE sequence #-}
+sequence ::
+    -- Foldable t =>
+    Fold m b c -> t (Parser m a b) -> Parser m a c
+sequence _f _p = undefined
+
+-- | Map a 'Parser' returning function on the result of a 'Parser'.
+--
+-- Compare with 'Monad' instance method '>>='. This implementation allows
+-- stream fusion but has quadratic complexity. This can fuse with other
+-- operations and can be much faster than 'Monad' instance for small number
+-- (less than 8) of compositions.
+--
+-- /Internal/
+--
+{-# INLINE concatMap #-}
+concatMap :: MonadCatch m
+    => (b -> Parser m a c) -> Parser m a b -> Parser m a c
+concatMap f p = D.toParserK $ D.concatMap (D.fromParserK . f) (D.fromParserK p)
+
+-------------------------------------------------------------------------------
+-- Alternative Collection
+-------------------------------------------------------------------------------
+--
+-- | @choice parsers@ applies the @parsers@ in order and returns the first
+-- successful parse.
+--
+{-# INLINE choice #-}
+choice ::
+    -- Foldable t =>
+    t (Parser m a b) -> Parser m a b
+choice _ps = undefined
+
+-------------------------------------------------------------------------------
+-- Sequential Repetition
+-------------------------------------------------------------------------------
+--
+-- $many
+-- TODO "many" is essentially a Fold because it cannot fail. So it can be
+-- downgraded to a Fold. Or we can make the return type a Fold instead and
+-- upgrade that to a parser when needed.
+
+-- | Collect zero or more parses. Apply the parser repeatedly on the input
+-- stream, stop when the parser fails, accumulate zero or more parse results
+-- using the supplied 'Fold'. This parser never fails, in case the first
+-- application of parser fails it returns an empty result.
+--
+-- Compare with 'Control.Applicative.many'.
+--
+-- /Internal/
+--
+{-# INLINE many #-}
+many :: MonadCatch m => Fold m b c -> Parser m a b -> Parser m a c
+many f p = D.toParserK $ D.many f (D.fromParserK p)
+-- many = countBetween 0 maxBound
+
+-- | Collect one or more parses. Apply the supplied parser repeatedly on the
+-- input stream and accumulate the parse results as long as the parser
+-- succeeds, stop when it fails.  This parser fails if not even one result is
+-- collected.
+--
+-- Compare with 'Control.Applicative.some'.
+--
+-- /Internal/
+--
+{-# INLINE some #-}
+some :: MonadCatch m => Fold m b c -> Parser m a b -> Parser m a c
+some f p = D.toParserK $ D.some f (D.fromParserK p)
+-- some f p = many (takeGE 1 f) p
+-- many = countBetween 1 maxBound
+
+-- | @countBetween m n f p@ collects between @m@ and @n@ sequential parses of
+-- parser @p@ using the fold @f@. Stop after collecting @n@ results. Fails if
+-- the input ends or the parser fails before @m@ results are collected.
+--
+-- /Unimplemented/
+--
+{-# INLINE countBetween #-}
+countBetween ::
+    -- MonadCatch m =>
+    Int -> Int -> Fold m b c -> Parser m a b -> Parser m a c
+countBetween _m _n _f = undefined
+-- countBetween m n f p = many (takeBetween m n f) p
+
+-- | @count n f p@ collects exactly @n@ sequential parses of parser @p@ using
+-- the fold @f@.  Fails if the input ends or the parser fails before @n@
+-- results are collected.
+--
+-- /Unimplemented/
+--
+{-# INLINE count #-}
+count ::
+    -- MonadCatch m =>
+    Int -> Fold m b c -> Parser m a b -> Parser m a c
+count n = countBetween n n
+-- count n f p = many (takeEQ n f) p
+
+-- | @manyTill f collect test@ tries the parser @test@ on the input, if @test@
+-- fails it backtracks and tries @collect@, after @collect@ succeeds @test@ is
+-- tried again and so on. The parser stops when @test@ succeeds.  The output of
+-- @test@ is discarded and the output of @collect@ is accumulated by the
+-- supplied fold. The parser fails if @collect@ fails.
+--
+-- /Internal/
+--
+{-# INLINE manyTill #-}
+manyTill :: MonadCatch m
+    => Fold m b c -> Parser m a b -> Parser m a x -> Parser m a c
+manyTill f p1 p2 =
+    D.toParserK $ D.manyTill f (D.fromParserK p1) (D.fromParserK p2)

--- a/src/Streamly/Internal/Data/Parser.hs
+++ b/src/Streamly/Internal/Data/Parser.hs
@@ -9,7 +9,7 @@
 -- |
 -- Module      : Streamly.Internal.Data.Parser
 -- Copyright   : (c) 2020 Composewell Technologies
--- License     : BSD3
+-- License     : BSD-3-Clause
 -- Maintainer  : streamly@composewell.com
 -- Stability   : experimental
 -- Portability : GHC

--- a/src/Streamly/Internal/Data/Parser/ParserD.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
--- Module      : Streamly.Internal.Data.Parser
+-- Module      : Streamly.Internal.Data.Parser.ParserD
 -- Copyright   : (c) 2020 Composewell Technologies
 -- License     : BSD3
 -- Maintainer  : streamly@composewell.com
@@ -36,7 +36,7 @@
 -- "Text.ParserCombinators.ReadP/parser-combinators/parsec/megaparsec/attoparsec"
 -- have consistent names. takeP/takeWhileP/munch?
 
-module Streamly.Internal.Data.Parser
+module Streamly.Internal.Data.Parser.ParserD
     (
       Parser (..)
 
@@ -183,11 +183,11 @@ import Prelude
 
 import Streamly.Internal.Data.Fold.Types (Fold(..))
 
-import qualified Streamly.Internal.Data.ParserK.Types as K
+import qualified Streamly.Internal.Data.Parser.ParserK.Types as K
 import qualified Streamly.Internal.Data.Zipper as Z
 
-import Streamly.Internal.Data.Parser.Tee
-import Streamly.Internal.Data.Parser.Types
+import Streamly.Internal.Data.Parser.ParserD.Tee
+import Streamly.Internal.Data.Parser.ParserD.Types
 import Streamly.Internal.Data.Strict
 
 -------------------------------------------------------------------------------

--- a/src/Streamly/Internal/Data/Parser/ParserD.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD.hs
@@ -7,7 +7,7 @@
 -- |
 -- Module      : Streamly.Internal.Data.Parser.ParserD
 -- Copyright   : (c) 2020 Composewell Technologies
--- License     : BSD3
+-- License     : BSD-3-Clause
 -- Maintainer  : streamly@composewell.com
 -- Stability   : experimental
 -- Portability : GHC

--- a/src/Streamly/Internal/Data/Parser/ParserD/Tee.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD/Tee.hs
@@ -8,7 +8,7 @@
 #include "inline.hs"
 
 -- |
--- Module      : Streamly.Internal.Data.Parser.Tee
+-- Module      : Streamly.Internal.Data.Parser.ParserD.Tee
 -- Copyright   : (c) 2020 Composewell Technologies
 -- License     : BSD3
 -- Maintainer  : streamly@composewell.com
@@ -29,7 +29,7 @@
 -- some legit warnings, therefore, we have segregated only the code that uses
 -- uni-pattern matches in this module.
 
-module Streamly.Internal.Data.Parser.Tee
+module Streamly.Internal.Data.Parser.ParserD.Tee
     (
     -- Parallel zipped
       teeWith
@@ -48,7 +48,8 @@ import Prelude
        hiding (any, all, takeWhile)
 
 import Fusion.Plugin.Types (Fuse(..))
-import Streamly.Internal.Data.Parser.Types (Parser(..), Step(..), ParseError)
+import Streamly.Internal.Data.Parser.ParserD.Types
+       (Parser(..), Step(..), ParseError)
 
 -------------------------------------------------------------------------------
 -- Distribute input to two parsers and collect both results

--- a/src/Streamly/Internal/Data/Parser/ParserD/Tee.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD/Tee.hs
@@ -80,9 +80,7 @@ data Res = Yld Int | Stp Int | Skp | Err String
 -- line/column fold running in parallel with the main parser, whenever an error
 -- occurs we can zip the error with the context fold.
 --
--- | @teeWith f p1 p2@ distributes its input to both @p1@ and @p2@ until both
--- of them succeed or fail and combines their output using @f@. The parser
--- succeeds if both the parsers succeed.
+-- | See 'Streamly.Internal.Data.Parser.teeWith'.
 --
 -- /Internal/
 --
@@ -200,8 +198,7 @@ teeWith zf (Parser stepL initialL extractL) (Parser stepR initialR extractR) =
             TeePair (_, StepResult rL, _, _) (_, StepResult rR, _, _) ->
                 return $ zf rL rR
 
--- | Like 'teeWith' but ends parsing and zips the results, if available,
--- whenever the first parser ends.
+-- | See 'Streamly.Internal.Data.Parser.teeWithFst'.
 --
 -- /Internal/
 --
@@ -310,8 +307,7 @@ teeWithFst zf (Parser stepL initialL extractL)
                 return $ zf rL rR
             _ -> error "unreachable"
 
--- | Like 'teeWith' but ends parsing and zips the results, if available,
--- whenever any of the parsers ends or fails.
+-- | See 'Streamly.Internal.Data.Parser.teeWithMin'.
 --
 -- /Unimplemented/
 --
@@ -325,9 +321,7 @@ teeWithMin = undefined
 -- Distribute input to two parsers and choose one result
 -------------------------------------------------------------------------------
 
--- | Shortest alternative. Apply both parsers in parallel but choose the result
--- from the one which consumed least input i.e. take the shortest succeeding
--- parse.
+-- | See 'Streamly.Internal.Data.Parser.shortest'.
 --
 -- /Internal/
 --
@@ -403,9 +397,7 @@ shortest (Parser stepL initialL extractL) (Parser stepR initialR _) =
             TeePair (_, StepState sL, _, _) _ -> extractL sL
             _ -> error "unreachable"
 
--- | Longest alternative. Apply both parsers in parallel but choose the result
--- from the one which consumed more input i.e. take the longest succeeding
--- parse.
+-- | See 'Streamly.Internal.Data.Parser.longest'.
 --
 -- /Internal/
 --

--- a/src/Streamly/Internal/Data/Parser/ParserD/Tee.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD/Tee.hs
@@ -10,7 +10,7 @@
 -- |
 -- Module      : Streamly.Internal.Data.Parser.ParserD.Tee
 -- Copyright   : (c) 2020 Composewell Technologies
--- License     : BSD3
+-- License     : BSD-3-Clause
 -- Maintainer  : streamly@composewell.com
 -- Stability   : experimental
 -- Portability : GHC

--- a/src/Streamly/Internal/Data/Parser/ParserD/Types.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD/Types.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
--- Module      : Streamly.Parser.Types
+-- Module      : Streamly.Internal.Data.Parser.ParserD.Types
 -- Copyright   : (c) 2020 Composewell Technologies
 -- License     : BSD3
 -- Maintainer  : streamly@composewell.com
@@ -107,7 +107,7 @@
 -- merge the resulting streams using different merge strategies (e.g.
 -- interleaving or serial).
 
-module Streamly.Internal.Data.Parser.Types
+module Streamly.Internal.Data.Parser.ParserD.Types
     (
       Step (..)
     , Parser (..)

--- a/src/Streamly/Internal/Data/Parser/ParserD/Types.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD/Types.hs
@@ -7,7 +7,7 @@
 -- |
 -- Module      : Streamly.Internal.Data.Parser.ParserD.Types
 -- Copyright   : (c) 2020 Composewell Technologies
--- License     : BSD3
+-- License     : BSD-3-Clause
 -- Maintainer  : streamly@composewell.com
 -- Stability   : experimental
 -- Portability : GHC

--- a/src/Streamly/Internal/Data/Parser/ParserK/Types.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserK/Types.hs
@@ -6,7 +6,7 @@
 #include "inline.hs"
 
 -- |
--- Module      : Streamly.ParserK.Types
+-- Module      : Streamly.Internal.Data.Parser.ParserK.Types
 -- Copyright   : (c) 2020 Composewell Technologies
 -- License     : BSD3
 -- Maintainer  : streamly@composewell.com
@@ -15,7 +15,7 @@
 --
 -- CPS style implementation of parsers.
 
-module Streamly.Internal.Data.ParserK.Types
+module Streamly.Internal.Data.Parser.ParserK.Types
     (
       Parser (..)
     )

--- a/src/Streamly/Internal/Data/Parser/ParserK/Types.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserK/Types.hs
@@ -8,7 +8,7 @@
 -- |
 -- Module      : Streamly.Internal.Data.Parser.ParserK.Types
 -- Copyright   : (c) 2020 Composewell Technologies
--- License     : BSD3
+-- License     : BSD-3-Clause
 -- Maintainer  : streamly@composewell.com
 -- Stability   : experimental
 -- Portability : GHC

--- a/src/Streamly/Internal/Data/ParserK/Types.hs
+++ b/src/Streamly/Internal/Data/ParserK/Types.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+#include "inline.hs"
+
+-- |
+-- Module      : Streamly.ParserK.Types
+-- Copyright   : (c) 2020 Composewell Technologies
+-- License     : BSD3
+-- Maintainer  : streamly@composewell.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- CPS style implementation of parsers.
+
+module Streamly.Internal.Data.ParserK.Types
+    (
+      Parser (..)
+    )
+where
+
+import Control.Monad (MonadPlus(..), ap)
+import Control.Applicative (Alternative(..))
+import Streamly.Internal.Data.Zipper (Zipper)
+import qualified Streamly.Internal.Data.Zipper as Z
+
+newtype Parser m a b =
+    MkParser { runParser :: forall r.
+        Zipper m a -> ((Zipper m a, Either String b) -> m r) -> m r }
+
+-- | Maps a function over the output of the fold.
+--
+instance Functor m => Functor (Parser m a) where
+    {-# INLINE fmap #-}
+    fmap f parser =
+        MkParser $ \inp yieldk -> runParser parser inp (yieldk . fmap (fmap f))
+
+{-# INLINE yield #-}
+yield :: b -> Parser m a b
+yield b = MkParser (\_ yieldk -> yieldk (Z.nil, Right b))
+
+-------------------------------------------------------------------------------
+-- Sequential applicative
+-------------------------------------------------------------------------------
+--
+-- | 'Applicative' form of 'splitWith'.
+instance Monad m => Applicative (Parser m a) where
+    {-# INLINE pure #-}
+    pure = yield
+
+    {-# INLINE (<*>) #-}
+    (<*>) = ap
+
+{-# INLINE die #-}
+die :: String -> Parser m a b
+die err = MkParser (\z yieldk -> yieldk (z, Left err))
+
+instance Monad m => Monad (Parser m a) where
+    {-# INLINE return #-}
+    return = pure
+
+    {-# INLINE (>>=) #-}
+    m >>= k = MkParser $ \inp yieldk ->
+        let yield1 (z, b) = case b of
+                Right x -> runParser (k x) z yieldk
+                Left err -> runParser (die err) z yieldk
+        in runParser m inp yield1
+
+-- | 'Alternative' instance using 'alt'.
+--
+-- The "some" and "many" operations of alternative collect results in a pure
+-- list which is not scalable and streaming. Instead use the "splitParse"
+-- operation to apply a 'Parser' repeatedly on a stream in a scalable manner.
+--
+instance Monad m => Alternative (Parser m a) where
+    {-# INLINE empty #-}
+    empty = die "empty"
+
+    {-# INLINE (<|>) #-}
+    m1 <|> m2 = MkParser $ \inp yieldk ->
+        let yield1 (z, b) = case b of
+                Right _ -> yieldk (Z.release z, b)
+                Left _ -> runParser m2 (Z.restore z) yieldk
+        in runParser m1 (Z.checkpoint inp) yield1
+    -- XXX INLINE some and many?
+
+-- | 'mzero' is same as 'empty', it aborts the parser. 'mplus' is same as
+-- '<|>', it selects the first succeeding parser.
+--
+-- /Internal/
+--
+instance Monad m => MonadPlus (Parser m a) where
+    {-# INLINE mzero #-}
+    mzero = die "mzero"
+
+    {-# INLINE mplus #-}
+    mplus = (<|>)

--- a/src/Streamly/Internal/Data/Stream/Prelude.hs
+++ b/src/Streamly/Internal/Data/Stream/Prelude.hs
@@ -74,7 +74,7 @@ import Prelude hiding (foldr, minimum, maximum)
 import qualified Prelude
 
 import Streamly.Internal.Data.Fold.Types (Fold (..))
-import Streamly.Internal.Data.Parser.Types (Step)
+import Streamly.Internal.Data.Parser.ParserD.Types (Step)
 
 #ifdef USE_STREAMK_ONLY
 import qualified Streamly.Internal.Data.Stream.StreamK as S

--- a/src/Streamly/Internal/Data/Stream/Prelude.hs
+++ b/src/Streamly/Internal/Data/Stream/Prelude.hs
@@ -74,7 +74,7 @@ import Prelude hiding (foldr, minimum, maximum)
 import qualified Prelude
 
 import Streamly.Internal.Data.Fold.Types (Fold (..))
-import Streamly.Internal.Data.Parser.ParserD.Types (Step)
+import Streamly.Internal.Data.Parser (Step)
 
 #ifdef USE_STREAMK_ONLY
 import qualified Streamly.Internal.Data.Stream.StreamK as S

--- a/src/Streamly/Internal/Data/Stream/StreamD.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD.hs
@@ -362,7 +362,7 @@ import Streamly.Internal.Data.Time.Units
 import Streamly.Internal.Data.Atomics (atomicModifyIORefCAS_)
 import Streamly.Internal.Memory.Array.Types (Array(..))
 import Streamly.Internal.Data.Fold.Types (Fold(..))
-import Streamly.Internal.Data.Parser.ParserD.Types (Parser(..), ParseError(..))
+import Streamly.Internal.Data.Parser (ParseError(..))
 import Streamly.Internal.Data.Pipe.Types (Pipe(..), PipeState(..))
 import Streamly.Internal.Data.Time.Clock (Clock(Monotonic), getTime)
 import Streamly.Internal.Data.Time.Units
@@ -379,7 +379,8 @@ import qualified Streamly.Internal.Memory.Array.Types as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Memory.Ring as RB
 import qualified Streamly.Internal.Data.Stream.StreamK as K
-import qualified Streamly.Internal.Data.Parser.ParserD.Types as PR
+import qualified Streamly.Internal.Data.Parser as PR
+import qualified Streamly.Internal.Data.Parser.ParserD as PRD
 
 ------------------------------------------------------------------------------
 -- Construction
@@ -1039,10 +1040,10 @@ data ParseChunksState x inpBuf st pst =
 {-# INLINE_NORMAL splitParse #-}
 splitParse
     :: MonadThrow m
-    => Parser m a b
+    => PRD.Parser m a b
     -> Stream m a
     -> Stream m b
-splitParse (Parser pstep initial extract) (Stream step state) =
+splitParse (PRD.Parser pstep initial extract) (Stream step state) =
     Stream stepOuter (ParseChunksInit [] state)
 
     where

--- a/src/Streamly/Internal/Data/Stream/StreamD.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD.hs
@@ -362,7 +362,7 @@ import Streamly.Internal.Data.Time.Units
 import Streamly.Internal.Data.Atomics (atomicModifyIORefCAS_)
 import Streamly.Internal.Memory.Array.Types (Array(..))
 import Streamly.Internal.Data.Fold.Types (Fold(..))
-import Streamly.Internal.Data.Parser.Types (Parser(..), ParseError(..))
+import Streamly.Internal.Data.Parser.ParserD.Types (Parser(..), ParseError(..))
 import Streamly.Internal.Data.Pipe.Types (Pipe(..), PipeState(..))
 import Streamly.Internal.Data.Time.Clock (Clock(Monotonic), getTime)
 import Streamly.Internal.Data.Time.Units
@@ -379,7 +379,7 @@ import qualified Streamly.Internal.Memory.Array.Types as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Memory.Ring as RB
 import qualified Streamly.Internal.Data.Stream.StreamK as K
-import qualified Streamly.Internal.Data.Parser.Types as PR
+import qualified Streamly.Internal.Data.Parser.ParserD.Types as PR
 
 ------------------------------------------------------------------------------
 -- Construction

--- a/src/Streamly/Internal/Data/Zipper.hs
+++ b/src/Streamly/Internal/Data/Zipper.hs
@@ -1,0 +1,380 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+#include "inline.hs"
+
+-- |
+-- Module      : Streamly.Internal.Data.Zipper
+-- Copyright   : (c) 2020 Composewell Technologies
+-- License     : BSD3
+-- Maintainer  : streamly@composewell.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- A special zipper derived from a stream  to facilitate stream parsing.
+--
+-- = Zipper
+--
+-- The zipper is designed to enable moving backward and forward in the stream
+-- efficiently to be able to implement backtracking parsers. The zipper can
+-- buffer data until the parser indicates that it is not needed, we can move
+-- back in the buffered data if the parser needs to backtrack.
+--
+-- = Checkpointing
+--
+-- We have a checkpointing mechanism built into the zipper to handle
+-- backtracking. Whenever we enter a computation that can fail and has an
+-- alternative to run then we add a checkpoint to the zipper. The checkpoint
+-- ensures that we do not release the buffer upto the checkpoint until this
+-- computation succeeds, if the computation fails we can backtrack to focus the
+-- cursor back to the checkpoint position.
+--
+-- = Future Work
+--
+-- We can possibly have a typeclass providing a zipper interface so that we can
+-- derive a zipper from different data sources efficiently. For example,
+--
+-- * stream zipper
+-- * zippers from different types of arrays
+-- * zipper from a tree of arrays for dynamic in-memory storage
+-- * file handle zipper can utilize the seek to go back and forth in the file
+--
+-- A tree of zippers where a lower level zipper is dependent on (references
+-- data in) a higher level zipper could be useful in implementing distributive
+-- parsers.
+--
+-- See https://hackage.haskell.org/package/zipper for an existing type class.
+-- We need a monadic one.
+
+module Streamly.Internal.Data.Zipper
+    (
+      Zipper (..)
+
+    -- * Construction
+    , nil
+    , fromStream
+    , fromList
+
+    -- * Checkpointing
+    , checkpoint
+    , release
+    , restore
+
+    -- * Parsing
+    , parse
+    )
+where
+
+import Control.Exception (assert, Exception(..))
+import Control.Monad.Catch (MonadCatch, try, SomeException)
+-- import GHC.Types (SPEC(..))
+import Prelude hiding (splitAt)
+
+import Streamly.Internal.Data.Stream.StreamK.Type (Stream(..))
+import Streamly.Internal.Data.SVar (defState)
+
+import qualified Streamly.Internal.Data.Parser.Types as PR
+import qualified Streamly.Internal.Data.Stream.StreamK as K
+
+-------------------------------------------------------------------------------
+-- Zipper type
+-------------------------------------------------------------------------------
+
+-- | @Zipper checkpoints lefts rights tail@.  The focus is on the first element
+-- of @rights@.  @lefts@ is buffered data on the right of the cursor.  @tail@
+-- is a stream that is used to generate more data if the cursor moves past
+-- @rights@.
+--
+-- @checkpoints@ is a stack of checkpoints. A new checkpoint is created by a
+-- @checkpoint@ operation. A checkpoint consists of a count that tracks how
+-- many elements we have yielded after the checkpoint was taken.  We need this
+-- information to backtrack to the checkpoint.  If we enter a nested
+-- alternative we add another checkpoint in the stack.  When we exit an
+-- alternative we call a @release@ on the checkpoint. The @release@ removes the
+-- checkpoint from the stack and adds its element count to the previous
+-- checkpoint in the stack. When the last checkpoint is removed the buffer is
+-- released.
+--
+-- /Internal/
+--
+data Zipper m a = Zipper [Int] [a] [a] (Stream m a)
+
+-------------------------------------------------------------------------------
+-- Construction
+-------------------------------------------------------------------------------
+
+-- | Empty zipper.
+--
+-- /Internal/
+--
+{-# INLINE nil #-}
+nil :: Zipper m a
+nil = Zipper [] [] [] K.nil
+
+-- | Create a zipper from a stream.
+--
+-- /Internal/
+--
+{-# INLINE fromStream #-}
+fromStream :: Stream m a -> Zipper m a
+fromStream = Zipper [] [] []
+
+-- | Create a zipper from a list.
+--
+-- /Internal/
+--
+{-# INLINE fromList #-}
+fromList :: [a] -> Zipper m a
+fromList xs = Zipper [] [] xs K.nil
+
+-- | Add a checkpoint to the Zipper so that we do not release the buffer beyond
+-- the checkpoint.
+--
+-- /Internal/
+--
+{-# INLINE checkpoint #-}
+checkpoint :: Zipper m a -> Zipper m a
+checkpoint (Zipper cps xs ys stream) = Zipper (0:cps) xs ys stream
+
+-- | Release the latest checkpoint, releases any values held by the checkpoint.
+--
+-- /Internal/
+--
+{-# INLINE release #-}
+release :: Zipper m a -> Zipper m a
+release (Zipper [] _ _ _) = error "Bug: release, no checkpoint exists!"
+release (Zipper (n:cps) xs ys stream) =
+    assert (n <= length xs) $
+            case cps of
+                [] -> assert (n == length xs) $ Zipper [] [] ys stream
+                cp:rest -> Zipper ((cp + n) : rest) xs ys stream
+
+-- | Rewind to restore the cursor to the latest checkpoint.
+--
+-- /Internal/
+--
+{-# INLINE restore #-}
+restore :: Zipper m a -> Zipper m a
+restore (Zipper [] _ _ _) = error "Bug: restore, no checkpoint exists!"
+restore (Zipper (n:cps) xs ys stream) =
+    assert (n <= length xs) $
+        let (src0, buf1) = splitAt n xs
+            src  = Prelude.reverse src0
+         in Zipper cps buf1 (src ++ ys) stream
+
+-------------------------------------------------------------------------------
+-- Parse driver for a Zipper
+-------------------------------------------------------------------------------
+
+-- Inlined definition. Without the inline "serially/parser/take" benchmark
+-- degrades and splitParse does not fuse. Even using "inline" at the callsite
+-- does not help.
+{-# INLINE splitAt #-}
+splitAt :: Int -> [a] -> ([a],[a])
+splitAt n ls
+  | n <= 0 = ([], ls)
+  | otherwise          = splitAt' n ls
+    where
+        splitAt' :: Int -> [a] -> ([a], [a])
+        splitAt' _  []     = ([], [])
+        splitAt' 1  (x:xs) = ([x], xs)
+        splitAt' m  (x:xs) = (x:xs', xs'')
+          where
+            (xs', xs'') = splitAt' (m - 1) xs
+
+-- | Parse a stream zipper using a parser's @step@, @initial@ and @extract@
+-- functions.
+--
+{-# INLINE_NORMAL parse #-}
+parse
+    :: MonadCatch m
+    => (s -> a -> m (PR.Step s b))
+    -> m s
+    -> (s -> m b)
+    -> Zipper m a
+    -> m (Zipper m a, Either String b)
+
+-- The case when no checkpoints exist
+parse pstep initial extract (Zipper [] ls rs stream) =
+    case rs of
+        [] -> go stream ls initial
+        _ -> gobuf stream ls rs initial
+
+    where
+
+    {-# INLINE go #-}
+    go st buf !acc =
+        let stop = do
+                pst <- acc
+                r <- try $ extract pst
+                return $ case r of
+                    Left (e :: SomeException) ->
+                        (nil, Left (displayException e))
+                    Right b -> (nil, Right b)
+            single x = do
+                acc1 <- acc >>= \b -> pstep b x
+                case acc1 of
+                    -- PR.Yield 0 pst1 -> go SPEC s [] pst1
+                    PR.Yield n pst1 -> do
+                        assert (n <= length (x:buf)) (return ())
+                        go K.nil (Prelude.take n (x:buf)) (return pst1)
+                    PR.Skip 0 pst1 -> go K.nil (x:buf) (return pst1)
+                    PR.Skip n pst1 -> do
+                        assert (n <= length (x:buf)) (return ())
+                        let (src0, buf1) = splitAt n (x:buf)
+                            src  = Prelude.reverse src0
+                        gobuf K.nil buf1 src (return pst1)
+                    PR.Stop n b -> do
+                        assert (n <= length (x:buf)) (return ())
+                        let (src0, buf1) = splitAt n (x:buf)
+                            src  = Prelude.reverse src0
+                        return (Zipper [] buf1 src K.nil, Right b)
+                    PR.Error err ->
+                        return (Zipper [] (x:buf) [] K.nil, Left err)
+            yieldk x r = do
+                acc1 <- acc >>= \b -> pstep b x
+                case acc1 of
+                    -- PR.Yield 0 pst1 -> go SPEC s [] pst1
+                    PR.Yield n pst1 -> do
+                        assert (n <= length (x:buf)) (return ())
+                        go r (Prelude.take n (x:buf)) (return pst1)
+                    PR.Skip 0 pst1 -> go r (x:buf) (return pst1)
+                    PR.Skip n pst1 -> do
+                        assert (n <= length (x:buf)) (return ())
+                        let (src0, buf1) = splitAt n (x:buf)
+                            src  = Prelude.reverse src0
+                        gobuf r buf1 src (return pst1)
+                    PR.Stop n b -> do
+                        assert (n <= length (x:buf)) (return ())
+                        let (src0, buf1) = splitAt n (x:buf)
+                            src  = Prelude.reverse src0
+                        return (Zipper [] buf1 src r, Right b)
+                    PR.Error err ->
+                        return (Zipper [] (x:buf) [] r, Left err)
+         in K.foldStream defState yieldk single stop st
+
+    gobuf s buf [] !pst = go s buf pst
+    gobuf s buf (x:xs) !pst = do
+        r <- pst
+        pRes <- pstep r x
+        case pRes of
+            -- PR.Yield 0 pst1 -> go SPEC s [] pst1
+            PR.Yield n pst1 -> do
+                assert (n <= length (x:buf)) (return ())
+                gobuf s (Prelude.take n (x:buf)) xs (return pst1)
+            PR.Skip 0 pst1 -> gobuf s (x:buf) xs (return pst1)
+            PR.Skip n pst1 -> do
+                assert (n <= length (x:buf)) (return ())
+                let (src0, buf1) = splitAt n (x:buf)
+                    src  = Prelude.reverse src0 ++ xs
+                gobuf s buf1 src (return pst1)
+            PR.Stop n b -> do
+                assert (n <= length (x:buf)) (return ())
+                let (src0, buf1) = splitAt n (x:buf)
+                    src  = Prelude.reverse src0 ++ xs
+                return (Zipper [] buf1 src s, Right b)
+            PR.Error err ->
+                return (Zipper [] (x:buf) xs s, Left err)
+
+-- The case when checkpoints exist
+-- XXX code duplication alert!
+parse pstep initial extract (Zipper (cp:cps) ls rs stream) =
+    case rs of
+        [] -> go 0 stream ls initial
+        _ -> gobuf 0 stream ls rs initial
+
+    where
+
+    {-# INLINE go #-}
+    go cnt st buf !acc =
+        let stop = do
+                pst <- acc
+                r <- try $ extract pst
+                return $ case r of
+                    Left (e :: SomeException) ->
+                        (nil, Left (displayException e))
+                    Right b -> (nil, Right b)
+            single x = do
+                acc1 <- acc >>= \b -> pstep b x
+                let cnt1 = cnt + 1
+                case acc1 of
+                    -- PR.Yield 0 pst1 -> go SPEC s [] pst1
+                    PR.Yield n pst1 -> do
+                        assert (n <= length (x:buf)) (return ())
+                        go cnt1 K.nil (x:buf) (return pst1)
+                    PR.Skip 0 pst1 -> go cnt1 K.nil (x:buf) (return pst1)
+                    PR.Skip n pst1 -> do
+                        assert (n <= length (x:buf)) (return ())
+                        let (src0, buf1) = splitAt n (x:buf)
+                            src  = Prelude.reverse src0
+                        assert (cnt1 - n >= 0) (return ())
+                        gobuf (cnt1 - n) K.nil buf1 src (return pst1)
+                    PR.Stop n b -> do
+                        assert (n <= length (x:buf)) (return ())
+                        let (src0, buf1) = splitAt n (x:buf)
+                            src  = Prelude.reverse src0
+                        assert (cp + cnt1 - n >= 0) (return ())
+                        return ( Zipper (cp + cnt1 - n : cps) buf1 src K.nil
+                               , Right b
+                               )
+                    PR.Error err ->
+                        return ( Zipper (cp + cnt1 : cps) (x:buf) [] K.nil
+                               , Left err
+                               )
+            yieldk x r = do
+                acc1 <- acc >>= \b -> pstep b x
+                let cnt1 = cnt + 1
+                case acc1 of
+                    -- PR.Yield 0 pst1 -> go SPEC s [] pst1
+                    PR.Yield n pst1 -> do
+                        assert (n <= length (x:buf)) (return ())
+                        go cnt1 r (x:buf) (return pst1)
+                    PR.Skip 0 pst1 -> go cnt1 r (x:buf) (return pst1)
+                    PR.Skip n pst1 -> do
+                        assert (n <= length (x:buf)) (return ())
+                        let (src0, buf1) = splitAt n (x:buf)
+                            src  = Prelude.reverse src0
+                        assert (cnt1 - n >= 0) (return ())
+                        gobuf (cnt1 - n) r buf1 src (return pst1)
+                    PR.Stop n b -> do
+                        assert (n <= length (x:buf)) (return ())
+                        let (src0, buf1) = splitAt n (x:buf)
+                            src  = Prelude.reverse src0
+                        assert (cp + cnt1 - n >= 0) (return ())
+                        return ( Zipper (cp + cnt1 - n : cps) buf1 src r
+                               , Right b
+                               )
+                    PR.Error err ->
+                        return ( Zipper (cp + cnt1 : cps) (x:buf) [] r
+                               , Left err
+                               )
+         in K.foldStream defState yieldk single stop st
+
+    gobuf cnt s buf [] !pst = go cnt s buf pst
+    gobuf cnt s buf (x:xs) !pst = do
+        r <- pst
+        pRes <- pstep r x
+        let cnt1 = cnt + 1
+        case pRes of
+            -- PR.Yield 0 pst1 -> go SPEC s [] pst1
+            PR.Yield n pst1 -> do
+                assert (n <= length (x:buf)) (return ())
+                gobuf cnt1 s (x:buf) xs (return pst1)
+            PR.Skip 0 pst1 -> gobuf cnt1 s (x:buf) xs (return pst1)
+            PR.Skip n pst1 -> do
+                assert (n <= length (x:buf)) (return ())
+                let (src0, buf1) = splitAt n (x:buf)
+                    src  = Prelude.reverse src0 ++ xs
+                assert (cnt1 - n >= 0) (return ())
+                gobuf (cnt1 - n) s buf1 src (return pst1)
+            PR.Stop n b -> do
+                assert (n <= length (x:buf)) (return ())
+                let (src0, buf1) = splitAt n (x:buf)
+                    src  = Prelude.reverse src0 ++ xs
+                assert (cp + cnt1 - n >= 0) (return ())
+                return (Zipper (cp + cnt1 - n : cps) buf1 src s, Right b)
+            PR.Error err ->
+                return (Zipper (cp + cnt1 : cps) (x:buf) xs s, Left err)

--- a/src/Streamly/Internal/Data/Zipper.hs
+++ b/src/Streamly/Internal/Data/Zipper.hs
@@ -76,7 +76,7 @@ import Prelude hiding (splitAt)
 import Streamly.Internal.Data.Stream.StreamK.Type (Stream(..))
 import Streamly.Internal.Data.SVar (defState)
 
-import qualified Streamly.Internal.Data.Parser.Types as PR
+import qualified Streamly.Internal.Data.Parser.ParserD.Types as PR
 import qualified Streamly.Internal.Data.Stream.StreamK as K
 
 -------------------------------------------------------------------------------

--- a/src/Streamly/Internal/Data/Zipper.hs
+++ b/src/Streamly/Internal/Data/Zipper.hs
@@ -9,7 +9,7 @@
 -- |
 -- Module      : Streamly.Internal.Data.Zipper
 -- Copyright   : (c) 2020 Composewell Technologies
--- License     : BSD3
+-- License     : BSD-3-Clause
 -- Maintainer  : streamly@composewell.com
 -- Stability   : experimental
 -- Portability : GHC

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -540,7 +540,7 @@ import qualified System.IO as IO
 
 import Streamly.Internal.Data.Stream.Enumeration (Enumerable(..), enumerate, enumerateTo)
 import Streamly.Internal.Data.Fold.Types (Fold (..), Fold2 (..))
-import Streamly.Internal.Data.Parser.Types (Parser (..))
+import Streamly.Internal.Data.Parser.ParserD.Types (Parser (..))
 import Streamly.Internal.Data.Unfold.Types (Unfold)
 import Streamly.Internal.Memory.Array.Types (Array, writeNUnsafe)
 -- import Streamly.Memory.Ring (Ring)
@@ -577,7 +577,7 @@ import qualified Streamly.Internal.Data.Stream.StreamD as S
 import qualified Streamly.Internal.Data.Stream.Serial as Serial
 import qualified Streamly.Internal.Data.Stream.Parallel as Par
 import qualified Streamly.Internal.Data.Stream.Zip as Z
-import qualified Streamly.Internal.Data.ParserK.Types as PRK
+import qualified Streamly.Internal.Data.Parser.ParserK.Types as PRK
 import qualified Streamly.Internal.Data.Zipper as ZR
 
 ------------------------------------------------------------------------------

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -325,6 +325,8 @@ library
                      , Streamly.Internal.Memory.ArrayStream
                      , Streamly.Internal.Data.Fold.Types
                      , Streamly.Internal.Data.Fold
+                     , Streamly.Internal.Data.Zipper
+                     , Streamly.Internal.Data.ParserK.Types
                      , Streamly.Internal.Data.Parser
                      , Streamly.Internal.Data.Parser.Types
                      , Streamly.Internal.Data.Parser.Tee

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -341,6 +341,7 @@ library
                      , Streamly.Internal.Data.Parser.ParserD.Types
                      , Streamly.Internal.Data.Parser.ParserD.Tee
                      , Streamly.Internal.Data.Parser.ParserD
+                     , Streamly.Internal.Data.Parser
 
                      -- Base streams
                      , Streamly.Internal.Data.Stream.StreamK.Type

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -315,6 +315,11 @@ library
                      , Streamly.Internal.Data.Time.Units
                      , Streamly.Internal.Data.Time.Clock
                      , Streamly.Internal.Data.SVar
+
+                     -- Mutable data
+                     , Streamly.Internal.Mutable.Prim.Var
+
+                     -- Arrays
                      , Streamly.Internal.Data.Array
                      , Streamly.Internal.Data.Prim.Array.Types
                      , Streamly.Internal.Data.Prim.Array
@@ -323,15 +328,19 @@ library
                      , Streamly.Internal.Memory.Array.Types
                      , Streamly.Internal.Memory.Array
                      , Streamly.Internal.Memory.ArrayStream
+
+                     -- Folds
                      , Streamly.Internal.Data.Fold.Types
                      , Streamly.Internal.Data.Fold
-                     , Streamly.Internal.Data.Zipper
-                     , Streamly.Internal.Data.ParserK.Types
-                     , Streamly.Internal.Data.Parser
-                     , Streamly.Internal.Data.Parser.Types
-                     , Streamly.Internal.Data.Parser.Tee
                      , Streamly.Internal.Data.Sink.Types
                      , Streamly.Internal.Data.Sink
+
+                     -- Parsers
+                     , Streamly.Internal.Data.Zipper
+                     , Streamly.Internal.Data.Parser.ParserK.Types
+                     , Streamly.Internal.Data.Parser.ParserD.Types
+                     , Streamly.Internal.Data.Parser.ParserD.Tee
+                     , Streamly.Internal.Data.Parser.ParserD
 
                      -- Base streams
                      , Streamly.Internal.Data.Stream.StreamK.Type
@@ -351,21 +360,26 @@ library
                      , Streamly.Internal.Data.Stream.Ahead
                      , Streamly.Internal.Data.Stream.Zip
                      , Streamly.Internal.Data.Stream.Combinators
+                     , Streamly.Internal.Data.List
+                     , Streamly.Internal.Prelude
+
+                     -- Unfolds
                      , Streamly.Internal.Data.Unfold.Types
                      , Streamly.Internal.Data.Unfold
+
+                     -- Pipes
                      , Streamly.Internal.Data.Pipe.Types
                      , Streamly.Internal.Data.Pipe
-                     , Streamly.Internal.Data.List
+
+                     -- Filesystem
                      , Streamly.Internal.FileSystem.Handle
                      , Streamly.Internal.FileSystem.Dir
                      , Streamly.Internal.FileSystem.File
+
+                     -- Text Processing
                      , Streamly.Internal.Data.Unicode.Stream
                      , Streamly.Internal.Data.Unicode.Char
                      , Streamly.Internal.Memory.Unicode.Array
-                     , Streamly.Internal.Prelude
-
-                     -- Mutable data
-                     , Streamly.Internal.Mutable.Prim.Var
 
     if !impl(ghcjs)
        exposed-modules:

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -253,10 +253,11 @@ common test-options
 
   ghc-options:  -O0
                 -fno-ignore-asserts
-  if flag(fusion-plugin) && !impl(ghcjs) && !impl(ghc < 8.6)
-    ghc-options: -fplugin Fusion.Plugin
-    build-depends:
-        fusion-plugin     >= 0.2   && < 0.3
+  -- XXX we need -O for plugin to work
+  -- if flag(fusion-plugin) && !impl(ghcjs) && !impl(ghc < 8.6)
+  --   ghc-options: -fplugin Fusion.Plugin
+  --   build-depends:
+  --       fusion-plugin     >= 0.2   && < 0.3
 
 -- Used by maxrate test, benchmarks and executables
 common exe-options


### PR DESCRIPTION
CPS is good at scalable applicative/monad/alternative operations and direct style is good at stream fusion providing better performance. We use both via rewrite rules depending on the situation.