### PR TITLE
Add concatParse for chained parsing

### DIFF
--- a/benchmark/FileIO.hs
+++ b/benchmark/FileIO.hs
@@ -212,12 +212,12 @@ main = do
             , mkBench "sumChunksOf 1" href $ do
                 Handles inh _ <- readIORef href
                 BFS.chunksOfSum 1 inh
-            , mkBench "sumChunksOf (single chunk) (splitParse)" href $ do
+            , mkBench "sumChunksOf (single chunk) (parseMany)" href $ do
                 Handles inh _ <- readIORef href
-                BFS.splitParseChunksOfSum fileSize inh
-            , mkBench "sumChunksOf 1 (splitParse)" href $ do
+                BFS.parseManyChunksOfSum fileSize inh
+            , mkBench "sumChunksOf 1 (parseMany)" href $ do
                 Handles inh _ <- readIORef href
-                BFS.splitParseChunksOfSum 1 inh
+                BFS.parseManyChunksOfSum 1 inh
 
             , mkBench "arraysOf 1" href $ do
                 Handles inh _ <- readIORef href
@@ -268,9 +268,9 @@ main = do
                 , mkBench "splitOnSuffix \\n (line count)" href $ do
                     Handles inh _ <- readIORef href
                     BFS.splitOnSuffix inh
-                , mkBench "splitOn \\n (line count) (splitParse)" href $ do
+                , mkBench "splitOn \\n (line count) (parseMany)" href $ do
                     Handles inh _ <- readIORef href
-                    BFS.splitParseSepBy inh
+                    BFS.parseManySepBy inh
                 , mkBench "wordsBy isSpace (word count)" href $ do
                     Handles inh _ <- readIORef href
                     BFS.wordsBy inh

--- a/benchmark/Streamly/Benchmark/Data/Fold.hs
+++ b/benchmark/Streamly/Benchmark/Data/Fold.hs
@@ -10,7 +10,7 @@
 module Main (main) where
 
 import Control.DeepSeq (NFData(..))
-import Data.Monoid (Last(..))
+import Data.Monoid (Last(..), Sum(..))
 
 import System.Random (randomRIO)
 import Prelude (IO, Int, Double, String, (>), (<*>), (<$>), (+), ($),
@@ -82,6 +82,7 @@ o_1_space_serial_folds value =
                 , benchIOSink value "lastN.10" (S.fold (IA.lastN 10))
                 , benchIOSink value "length" (S.fold FL.length)
                 , benchIOSink value "sum" (S.fold FL.sum)
+                , benchIOSink value "sum (foldMap)" (S.fold (FL.foldMap Sum))
                 , benchIOSink value "product" (S.fold FL.product)
                 , benchIOSink value "maximumBy" (S.fold (FL.maximumBy compare))
                 , benchIOSink value "maximum" (S.fold FL.maximum)

--- a/benchmark/Streamly/Benchmark/Data/Parser.hs
+++ b/benchmark/Streamly/Benchmark/Data/Parser.hs
@@ -177,20 +177,20 @@ choice value =
 -- Stream transformation
 -------------------------------------------------------------------------------
 
-{-# INLINE splitParse #-}
-splitParse :: MonadCatch m => SerialT m Int -> m ()
-splitParse =
+{-# INLINE parseMany #-}
+parseMany :: MonadCatch m => SerialT m Int -> m ()
+parseMany =
       S.drain
     . S.map getSum
-    . IP.splitParse (PR.take 2 FL.mconcat)
+    . IP.parseMany (PR.take 2 FL.mconcat)
     . S.map Sum
 
-{-# INLINE concatParse #-}
-concatParse :: MonadCatch m => SerialT m Int -> m ()
-concatParse =
+{-# INLINE parseIterate #-}
+parseIterate :: MonadCatch m => SerialT m Int -> m ()
+parseIterate =
       S.drain
     . S.map getSum
-    . IP.concatParse (\b -> (PR.take 2 (FL.mconcatTo b))) (Sum 0)
+    . IP.parseIterate (\b -> (PR.take 2 (FL.mconcatTo b))) (Sum 0)
     . S.map Sum
 
 -------------------------------------------------------------------------------
@@ -211,8 +211,8 @@ o_1_space_serial_parse value =
     , benchIOSink value "teeFst (all,any)" $ teeFstAllAny value
     , benchIOSink value "shortest (all,any)" $ shortestAllAny value
     , benchIOSink value "longest (all,any)" $ longestAllAny value
-    , benchIOSink value "splitParse" splitParse
-    , benchIOSink value "concatParse" concatParse
+    , benchIOSink value "parseMany" parseMany
+    , benchIOSink value "parseIterate" parseIterate
     ]
 
 o_n_heap_serial_parse :: Int -> [Benchmark]

--- a/benchmark/Streamly/Benchmark/Data/ParserD.hs
+++ b/benchmark/Streamly/Benchmark/Data/ParserD.hs
@@ -192,14 +192,19 @@ o_1_space_serial_parse value =
     , benchIOSink value "longest (all,any)" $ longestAllAny value
     ]
 
--- These show non-linear time complexity
--- Increase in rss is 20-40% on doubling the stream size
 o_n_heap_serial_parse :: Int -> [Benchmark]
 o_n_heap_serial_parse value =
-    [ benchIOSink value "lookAhead" $ lookAhead value
+    [
+    -- lookahead benchmark holds the entire input till end
+      benchIOSink value "lookAhead" $ lookAhead value
+
+    -- XXX this should get better with "yield with backtrack" fix
+    , benchIOSink value "manyTill" $ manyTill value
+
+    -- These show non-linear time complexity
+    -- They accumulate the results in a list.
     , benchIOSink value "manyAlt" manyAlt
     , benchIOSink value "someAlt" someAlt
-    , benchIOSink value "manyTill" $ manyTill value
     ]
 
 -- accumulate results in a list in IO

--- a/benchmark/Streamly/Benchmark/FileIO/Stream.hs
+++ b/benchmark/Streamly/Benchmark/FileIO/Stream.hs
@@ -57,12 +57,12 @@ module Streamly.Benchmark.FileIO.Stream
     , decodeUtf8Lax
     , copyCodecUtf8Lenient
     , chunksOfSum
-    , splitParseChunksOfSum
+    , parseManyChunksOfSum
     , chunksOf
     , chunksOfD
     , splitOn
     , splitOnSuffix
-    , splitParseSepBy
+    , parseManySepBy
     , wordsBy
     , splitOnSeq
     , splitOnSeqUtf8
@@ -445,10 +445,10 @@ inspect $ 'chunksOfD `hasNoType` ''AT.FlattenState
 inspect $ 'chunksOfD `hasNoType` ''D.ConcatMapUState
 #endif
 
-{-# INLINE splitParseChunksOfSum #-}
-splitParseChunksOfSum :: Int -> Handle -> IO Int
-splitParseChunksOfSum n inh =
-    S.length $ IP.splitParse (PR.take n FL.sum) (S.unfold FH.read inh)
+{-# INLINE parseManyChunksOfSum #-}
+parseManyChunksOfSum :: Int -> Handle -> IO Int
+parseManyChunksOfSum n inh =
+    S.length $ IP.parseMany (PR.take n FL.sum) (S.unfold FH.read inh)
 
 {-# INLINE linesUnlinesCopy #-}
 linesUnlinesCopy :: Handle -> Handle -> IO ()
@@ -609,11 +609,11 @@ inspect $ 'splitOnSuffix `hasNoType` ''D.ConcatMapUState
 #endif
 
 -- | Split on line feed.
-{-# INLINE splitParseSepBy #-}
-splitParseSepBy :: Handle -> IO Int
-splitParseSepBy inh =
-    (S.length $ IP.splitParse (PR.sliceSepBy (== lf) FL.drain)
-                              (S.unfold FH.read inh)) -- >>= print
+{-# INLINE parseManySepBy #-}
+parseManySepBy :: Handle -> IO Int
+parseManySepBy inh =
+    (S.length $ IP.parseMany (PR.sliceSepBy (== lf) FL.drain)
+                             (S.unfold FH.read inh)) -- >>= print
 
 -- | Words by space
 {-# INLINE wordsBy #-}

--- a/benchmark/Streamly/Benchmark/FileIO/Stream.hs
+++ b/benchmark/Streamly/Benchmark/FileIO/Stream.hs
@@ -88,7 +88,7 @@ import qualified Streamly.Data.Unicode.Stream as SS
 import qualified Streamly.Internal.Data.Unicode.Stream as IUS
 import qualified Streamly.Internal.Memory.Unicode.Array as IUA
 import qualified Streamly.Internal.Data.Unfold as IUF
-import qualified Streamly.Internal.Data.Parser.ParserD as PR
+import qualified Streamly.Internal.Data.Parser as PR
 import qualified Streamly.Internal.Prelude as IP
 import qualified Streamly.Internal.Data.Stream.StreamD as D
 

--- a/benchmark/streamly-benchmarks.cabal
+++ b/benchmark/streamly-benchmarks.cabal
@@ -227,7 +227,7 @@ benchmark serial-o-n-space
 benchmark fold
   import: bench-options
   type: exitcode-stdio-1.0
-  ghc-options: -rtsopts
+  ghc-options: -with-rtsopts "-T -K128K -M16M"
   hs-source-dirs: Streamly/Benchmark/Data
   main-is: Fold.hs
   if impl(ghcjs)
@@ -250,7 +250,7 @@ benchmark unfold
 benchmark parserD
   import: bench-options
   type: exitcode-stdio-1.0
-  ghc-options: -with-rtsopts "-T -K36K -M16M"
+  ghc-options: -with-rtsopts "-T -K64K -M16M"
   hs-source-dirs: ., Streamly/Benchmark/Data
   main-is: ParserD.hs
   if impl(ghcjs)
@@ -274,7 +274,7 @@ benchmark parserK
 benchmark parser
   import: bench-options
   type: exitcode-stdio-1.0
-  ghc-options: -with-rtsopts "-T -K36K -M32M"
+  ghc-options: -with-rtsopts "-T -K128K -M32M"
   hs-source-dirs: Streamly/Benchmark/Data
   main-is: Parser.hs
   if impl(ghcjs)

--- a/src/Streamly/Data/Fold.hs
+++ b/src/Streamly/Data/Fold.hs
@@ -22,6 +22,12 @@
 -- constituent folds and then combines the resulting fold outputs.  Similarly,
 -- a partitioning combinator divides the input among constituent folds.
 --
+-- = Monoids
+--
+-- Monoids allow modular folding in general.  Most of the folds in this module
+-- can be expressed using 'mconcat' and a suitable 'Monoid'. Instead of writing
+-- folds we can write Monoids instead and turn them into folds.
+--
 -- = Performance Notes
 --
 -- 'Fold' representation is more efficient than using streams when splitting

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -744,7 +744,7 @@ head = _Fold1 const
 --
 -- @
 -- find p = fmap getFirst $
---     foldMap (\x -> First (if p x then Just x else Nothing))
+--     FL.foldMap (\x -> First (if p x then Just x else Nothing))
 -- @
 --
 -- @since 0.7.0

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -270,9 +270,13 @@ module Streamly.Internal.Prelude
 
     -- ** Parsing
     , splitParse
+    , splitParseTill
+    , concatParse
 
     -- ** Trimming
     , take
+    -- , takeGE
+    -- , takeBetween
     , takeByTime
     -- , takeEnd
     , takeWhile
@@ -3141,8 +3145,18 @@ concatMapTreeYieldLeavesWith combine f = concatMapLoopWith combine f yield
 -- expressed using splitParse. Operations like chunksOf, intervalsOf, split*,
 -- can be expressed using splitParse when used with an appropriate Parse.
 --
--- | Apply a 'Parse' repeatedly on a stream and emit the parsed values in the
+-- The name splitParse is supposed to be opposite of concatMap.  Alternative
+-- names could be "many", "parseMany" or "splitMany"? If we are going to have a
+-- separate combinators for Fold and Parser then having fold/parse in the name
+-- allows the distinction.
+--
+-- XXX We need takeGE/takeBetween to implement "some" using "many".
+
+-- | Apply a 'Parser' repeatedly on a stream and emit the parsed values in the
 -- output stream.
+--
+-- This is the streaming equivalent of the 'Streamly.Internal.Data.Parser.many'
+-- parse combinator.
 --
 -- >>> S.toList $ S.splitParse (PR.take 2 $ PR.fromFold FL.sum) $ S.fromList [1..10]
 -- > [3,7,11,15,19]
@@ -3150,13 +3164,57 @@ concatMapTreeYieldLeavesWith combine f = concatMapLoopWith combine f yield
 -- >>> S.toList $ S.splitParse (PR.line FL.toList) $ S.fromList "hello\nworld"
 -- > ["hello\n","world"]
 --
+-- /Internal
+--
 {-# INLINE splitParse #-}
 splitParse
     :: (IsStream t, MonadThrow m)
-    => PRD.Parser m a b
+    => Parser m a b
     -> t m a
     -> t m b
-splitParse f m = D.fromStreamD $ D.splitParse f (D.toStreamD m)
+splitParse p m =
+    D.fromStreamD $ D.splitParse (PRD.fromParserK p) (D.toStreamD m)
+
+-- | @splitParseTill collect test stream@ tries the parser @test@ on the input,
+-- if @test@ fails it backtracks and tries @collect@, after @collect@ succeeds
+-- @test@ is tried again and so on. The parser stops when @test@ succeeds.  The
+-- output of @test@ is discarded and the output of @collect@ is emitted in the
+-- output stream. The parser fails if @collect@ fails.
+--
+-- /Unimplemented/
+--
+{-# INLINE splitParseTill #-}
+splitParseTill ::
+    -- (IsStream t, MonadThrow m) =>
+       Parser m a b
+    -> Parser m a x
+    -> t m a
+    -> t m b
+splitParseTill = undefined
+
+-- Rename to iterateParse?
+--
+-- | Iterate a parser generating function on a stream. The initial value @b@ is
+-- used to generate the first parser, the parser is applied on the stream and
+-- the result is used generate the next parser and so on.
+--
+-- >>> S.toList $ S.concatParse (\b -> PR.take 2 (FL.mconcatTo b)) 0 $ S.fromList [1..10]
+-- > [3,10,21,36,55,55]
+--
+-- This is the streaming equivalent of monad like sequenced application of
+-- parsers where next parser is dependent on the previous parser.
+--
+-- /Internal/
+--
+{-# INLINE concatParse #-}
+concatParse
+    :: (IsStream t, MonadThrow m)
+    => (b -> Parser m a b)
+    -> b
+    -> t m a
+    -> t m b
+concatParse f i m = D.fromStreamD $
+    D.concatParse (\b -> PRD.fromParserK $ f b) i (D.toStreamD m)
 
 ------------------------------------------------------------------------------
 -- Grouping/Splitting

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -3196,9 +3196,9 @@ splitParseTill = undefined
 --
 -- | Iterate a parser generating function on a stream. The initial value @b@ is
 -- used to generate the first parser, the parser is applied on the stream and
--- the result is used generate the next parser and so on.
+-- the result is used to generate the next parser and so on.
 --
--- >>> S.toList $ S.concatParse (\b -> PR.take 2 (FL.mconcatTo b)) 0 $ S.fromList [1..10]
+-- >>> S.toList $ S.map getSum $ S.concatParse (\b -> PR.take 2 (FL.mconcatTo b)) 0 $ S.map Sum $ S.fromList [1..10]
 -- > [3,10,21,36,55,55]
 --
 -- This is the streaming equivalent of monad like sequenced application of

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -269,9 +269,9 @@ module Streamly.Internal.Prelude
     , reverse'
 
     -- ** Parsing
-    , splitParse
-    , splitParseTill
-    , concatParse
+    , parseMany
+    , parseManyTill
+    , parseIterate
 
     -- ** Trimming
     , take
@@ -3142,13 +3142,8 @@ concatMapTreeYieldLeavesWith combine f = concatMapLoopWith combine f yield
 ------------------------------------------------------------------------------
 
 -- Splitting operations that take a predicate and a Fold can be
--- expressed using splitParse. Operations like chunksOf, intervalsOf, split*,
--- can be expressed using splitParse when used with an appropriate Parse.
---
--- The name splitParse is supposed to be opposite of concatMap.  Alternative
--- names could be "many", "parseMany" or "splitMany"? If we are going to have a
--- separate combinators for Fold and Parser then having fold/parse in the name
--- allows the distinction.
+-- expressed using parseMany. Operations like chunksOf, intervalsOf, split*,
+-- can be expressed using parseMany when used with an appropriate Parser.
 --
 -- XXX We need takeGE/takeBetween to implement "some" using "many".
 
@@ -3158,24 +3153,24 @@ concatMapTreeYieldLeavesWith combine f = concatMapLoopWith combine f yield
 -- This is the streaming equivalent of the 'Streamly.Internal.Data.Parser.many'
 -- parse combinator.
 --
--- >>> S.toList $ S.splitParse (PR.take 2 $ PR.fromFold FL.sum) $ S.fromList [1..10]
+-- >>> S.toList $ S.parseMany (PR.take 2 $ PR.fromFold FL.sum) $ S.fromList [1..10]
 -- > [3,7,11,15,19]
 --
--- >>> S.toList $ S.splitParse (PR.line FL.toList) $ S.fromList "hello\nworld"
+-- >>> S.toList $ S.parseMany (PR.line FL.toList) $ S.fromList "hello\nworld"
 -- > ["hello\n","world"]
 --
 -- /Internal
 --
-{-# INLINE splitParse #-}
-splitParse
+{-# INLINE parseMany #-}
+parseMany
     :: (IsStream t, MonadThrow m)
     => Parser m a b
     -> t m a
     -> t m b
-splitParse p m =
-    D.fromStreamD $ D.splitParse (PRD.fromParserK p) (D.toStreamD m)
+parseMany p m =
+    D.fromStreamD $ D.parseMany (PRD.fromParserK p) (D.toStreamD m)
 
--- | @splitParseTill collect test stream@ tries the parser @test@ on the input,
+-- | @parseManyTill collect test stream@ tries the parser @test@ on the input,
 -- if @test@ fails it backtracks and tries @collect@, after @collect@ succeeds
 -- @test@ is tried again and so on. The parser stops when @test@ succeeds.  The
 -- output of @test@ is discarded and the output of @collect@ is emitted in the
@@ -3183,22 +3178,20 @@ splitParse p m =
 --
 -- /Unimplemented/
 --
-{-# INLINE splitParseTill #-}
-splitParseTill ::
+{-# INLINE parseManyTill #-}
+parseManyTill ::
     -- (IsStream t, MonadThrow m) =>
        Parser m a b
     -> Parser m a x
     -> t m a
     -> t m b
-splitParseTill = undefined
+parseManyTill = undefined
 
--- Rename to iterateParse?
---
 -- | Iterate a parser generating function on a stream. The initial value @b@ is
 -- used to generate the first parser, the parser is applied on the stream and
 -- the result is used to generate the next parser and so on.
 --
--- >>> S.toList $ S.map getSum $ S.concatParse (\b -> PR.take 2 (FL.mconcatTo b)) 0 $ S.map Sum $ S.fromList [1..10]
+-- >>> S.toList $ S.map getSum $ S.parseIterate (\b -> PR.take 2 (FL.mconcatTo b)) 0 $ S.map Sum $ S.fromList [1..10]
 -- > [3,10,21,36,55,55]
 --
 -- This is the streaming equivalent of monad like sequenced application of
@@ -3206,15 +3199,15 @@ splitParseTill = undefined
 --
 -- /Internal/
 --
-{-# INLINE concatParse #-}
-concatParse
+{-# INLINE parseIterate #-}
+parseIterate
     :: (IsStream t, MonadThrow m)
     => (b -> Parser m a b)
     -> b
     -> t m a
     -> t m b
-concatParse f i m = D.fromStreamD $
-    D.concatParse (\b -> PRD.fromParserK $ f b) i (D.toStreamD m)
+parseIterate f i m = D.fromStreamD $
+    D.parseIterate (\b -> PRD.fromParserK $ f b) i (D.toStreamD m)
 
 ------------------------------------------------------------------------------
 -- Grouping/Splitting

--- a/src/Streamly/Prelude.hs
+++ b/src/Streamly/Prelude.hs
@@ -120,15 +120,31 @@ module Streamly.Prelude
     -- ** Folding
 -- | In imperative terms a fold can be considered as a loop over the stream
 -- that reduces the stream to a single value.
--- Left and right folds use a fold function @f@ and an identity element @z@
--- (@zero@) to recursively deconstruct a structure and then combine and reduce
--- the values or transform and reconstruct a new container.
+-- Left and right folds both use a fold function @f@ and an identity element
+-- @z@ (@zero@) to deconstruct a recursive data structure and reconstruct a
+-- new data structure. The new structure may be a recursive construction (a
+-- container) or a non-recursive single value reduction of the original
+-- structure.
 --
--- In general, a right fold is suitable for transforming and reconstructing a
--- right associated structure (e.g. cons lists and streamly streams) and a left
--- fold is suitable for reducing a right associated structure.  The behavior of
--- right and left folds are described in detail in the individual fold's
--- documentation.  To illustrate the two folds for cons lists:
+-- Both right and left folds are mathematical duals of each other, they are
+-- functionally equivalent.  Operationally, a left fold on a left associated
+-- structure behaves exactly in the same way as a right fold on a right
+-- associated structure. Similarly, a left fold on a right associated structure
+-- behaves in the same way as a right fold on a left associated structure.
+-- However, the behavior of a right fold on a right associated structure is
+-- operationally different (even though functionally equivalent) than a left
+-- fold on the same structure.
+--
+-- On right associated structures like Haskell @cons@ lists or Streamly
+-- streams, a lazy right fold is naturally suitable for lazy recursive
+-- reconstruction of a new structure, while a strict left fold is naturally
+-- suitable for efficient reduction. In right folds control is in the hand of
+-- the @puller@ whereas in left folds the control is in the hand of the
+-- @pusher@.
+--
+-- The behavior of right and left folds are described in detail in the
+-- individual fold's documentation.  To illustrate the two folds for right
+-- associated @cons@ lists:
 --
 -- > foldr :: (a -> b -> b) -> b -> [a] -> b
 -- > foldr f z [] = z


### PR DESCRIPTION
Iterate parsers on a stream such that the next parser depends on the previous parser, generating an output stream from the intermediate parse results.