### PR TITLE
Fix sliceSepByMax

### DIFF
--- a/src/Streamly/Internal/Data/Parser.hs
+++ b/src/Streamly/Internal/Data/Parser.hs
@@ -570,6 +570,11 @@ groupBy = undefined
 
 -- | Match the given sequence of elements using the given comparison function.
 --
+-- >>> S.parse $ S.eqBy (==) "string" $ S.fromList "string"
+--
+-- >>> S.parse $ S.eqBy (==) "mismatch" $ S.fromList "match"
+-- > *** Exception: ParseError "eqBy: failed, yet to match 7 elements"
+--
 -- /Internal/
 --
 {-# INLINE eqBy #-}

--- a/src/Streamly/Internal/Data/Parser/ParserD.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD.hs
@@ -553,16 +553,16 @@ eqBy cmp str = Parser step initial extract
 
     initial = return str
 
-    step [] _ = error "Bug: unreachable"
+    step [] _ = return $ Stop 0 ()
     step [x] a = return $
         if x `cmp` a
         then Stop 0 ()
-        else Error "eqBy: failed, at the last element"
+        else Error "eqBy: failed, yet to match the last element"
     step (x:xs) a = return $
         if x `cmp` a
         then Skip 0 xs
         else Error $
-            "eqBy: failed, yet to match " ++ show (length xs) ++ " elements"
+            "eqBy: failed, yet to match " ++ show (length xs + 1) ++ " elements"
 
     extract xs = throwM $ ParseError $
         "eqBy: end of input, yet to match " ++ show (length xs) ++ " elements"

--- a/src/Streamly/Internal/Data/Parser/ParserD.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD.hs
@@ -505,15 +505,17 @@ sliceSepByMax predicate cnt (Fold fstep finitial fextract) =
     where
 
     initial = Tuple' 0 <$> finitial
-    step (Tuple' i r) a = do
-        res <- fstep r a
-        let i1 = i + 1
-            s1 = Tuple' i1 res
-        if not (predicate a) && i1 < cnt
-        then return $ Yield 0 s1
-        else do
-            b <- fextract res
-            return $ Stop 0 b
+    step (Tuple' i r) a
+        | not (predicate a) = do
+            res <- fstep r a
+            let i1 = i + 1
+                s1 = Tuple' i1 res
+            if i1 < cnt
+            then return $ Yield 0 s1
+            else do
+                b <- fextract res
+                return $ Stop 0 b
+        | otherwise = Stop 0 <$> fextract r
     extract (Tuple' _ r) = fextract r
 
 -- | See 'Streamly.Internal.Data.Parser.wordBy'.


### PR DESCRIPTION
- Fix `sliceSepByMax`
- Add examples for `Parser.eqBy`