### PR TITLE
Add some time related combinators

### DIFF
--- a/benchmark/lib/Streamly/Benchmark/Prelude.hs
+++ b/benchmark/lib/Streamly/Benchmark/Prelude.hs
@@ -262,12 +262,10 @@ sourceFromFoldable value n = S.fromFoldable [n..n+value]
 sourceFromFoldableM :: (S.IsStream t, S.MonadAsync m) => Int -> Int -> t m Int
 sourceFromFoldableM value n = S.fromFoldableM (P.fmap return [n..n+value])
 
-{-# INLINE times #-}
-times :: (S.IsStream t, S.MonadAsync m)
-    => Int -> Double -> Int -> t m AbsTime
-times value g _ = S.take value
-    $ S.map (\(a,r) -> addToAbsTime64 a r)
-    $ Internal.times g
+{-# INLINE absTimes #-}
+absTimes :: (S.IsStream t, S.MonadAsync m)
+    => Int -> Int -> t m AbsTime
+absTimes value _ = S.take value $ Internal.absTimes
 
 -------------------------------------------------------------------------------
 -- Elimination
@@ -548,8 +546,8 @@ tapAsync :: S.MonadAsync m => Int -> Stream m Int -> m ()
 tapAsync n = composeN n $ Internal.tapAsync FL.sum
 
 {-# INLINE timestamped #-}
-timestamped :: (S.MonadAsync m) => Double -> Stream m Int -> m ()
-timestamped g = transform . Internal.timestamped g
+timestamped :: (S.MonadAsync m) => Stream m Int -> m ()
+timestamped = transform . Internal.timestamped
 
 {-# INLINE mapMaybe #-}
 mapMaybe :: MonadIO m => Int -> Stream m Int -> m ()
@@ -1662,8 +1660,8 @@ o_1_space_serial_generation value =
                       serially
                       "fromFoldableM"
                       (sourceFromFoldableM value)
-                , benchIOSrc serially "times/0.001s" $
-                  times value 0.001
+                , benchIOSrc serially "absTimes" $
+                  absTimes value
                 ]
           ]
     ]
@@ -1844,7 +1842,7 @@ o_1_space_serial_transformation value =
                 , benchIOSink value "pollCounts 1 second" (pollCounts 1)
                 , benchIOSink value "tapAsync" (tapAsync 1)
                 , benchIOSink value "tapAsyncS" (tapAsyncS 1)
-                , benchIOSink value "timestamped/0.001s" (timestamped 0.001)
+                , benchIOSink value "timestamped" timestamped
                 ]
           ]
     ]

--- a/src/Streamly/Internal/Data/Stream/StreamD.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD.hs
@@ -4071,7 +4071,7 @@ intersperseSuffix_ m (Stream step1 state1) = Stream step (Left state1)
         case r of
             Yield x s -> return $ Yield x (Right s)
             Skip s -> return $ Skip $ Left s
-            Stop -> m >> return Stop
+            Stop -> return Stop
 
     step _ (Right st) = m >> return (Skip (Left st))
 

--- a/src/Streamly/Internal/Data/Time/Units.hs
+++ b/src/Streamly/Internal/Data/Time/Units.hs
@@ -280,34 +280,38 @@ instance TimeUnit64 NanoSecond64 where
 
 instance TimeUnit MicroSecond64 where
     {-# INLINE toTimeSpec #-}
-    toTimeSpec (MicroSecond64 t) = TimeSpec s us
+    toTimeSpec (MicroSecond64 t) = TimeSpec s (us * tenPower3)
         where (s, us) = t `divMod` tenPower6
 
     {-# INLINE fromTimeSpec #-}
-    fromTimeSpec (TimeSpec s us) =
-        MicroSecond64 $ s * tenPower6 + us
+    fromTimeSpec (TimeSpec s ns) =
+        -- XXX round ns to nearest microsecond?
+        MicroSecond64 $ s * tenPower6 + (ns `div` tenPower3)
 
 instance TimeUnit64 MicroSecond64 where
     {-# INLINE toNanoSecond64 #-}
     toNanoSecond64 (MicroSecond64 us) = NanoSecond64 $ us * tenPower3
 
     {-# INLINE fromNanoSecond64 #-}
+    -- XXX round ns to nearest microsecond?
     fromNanoSecond64 (NanoSecond64 ns) = MicroSecond64 $ ns `div` tenPower3
 
 instance TimeUnit MilliSecond64 where
     {-# INLINE toTimeSpec #-}
-    toTimeSpec (MilliSecond64 t) = TimeSpec s us
-        where (s, us) = t `divMod` tenPower3
+    toTimeSpec (MilliSecond64 t) = TimeSpec s (ms * tenPower6)
+        where (s, ms) = t `divMod` tenPower3
 
     {-# INLINE fromTimeSpec #-}
-    fromTimeSpec (TimeSpec s us) =
-        MilliSecond64 $ s * tenPower3 + us
+    fromTimeSpec (TimeSpec s ns) =
+        -- XXX round ns to nearest millisecond?
+        MilliSecond64 $ s * tenPower3 + (ns `div` tenPower6)
 
 instance TimeUnit64 MilliSecond64 where
     {-# INLINE toNanoSecond64 #-}
-    toNanoSecond64 (MilliSecond64 us) = NanoSecond64 $ us * tenPower6
+    toNanoSecond64 (MilliSecond64 ms) = NanoSecond64 $ ms * tenPower6
 
     {-# INLINE fromNanoSecond64 #-}
+    -- XXX round ns to nearest millisecond?
     fromNanoSecond64 (NanoSecond64 ns) = MilliSecond64 $ ns `div` tenPower6
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
add: times, relTimes, timestamped
unimplemented skeletons: durations, ticks, timeout

Changes to the original currentTime combinator: remove delay from the first
event, cap the granularity to 1 ms to guarantee reasonable cpu usage.