### PR TITLE
Enable TypeFamilies extension with NoMonoLocalBinds

### DIFF
--- a/src/Streamly/Internal/Data/List.hs
+++ b/src/Streamly/Internal/Data/List.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- |

--- a/src/Streamly/Internal/Data/Prim/Array/Types.hs
+++ b/src/Streamly/Internal/Data/Prim/Array/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UnboxedTuples #-}
 
 -- |

--- a/src/Streamly/Internal/Data/SmallArray/Types.hs
+++ b/src/Streamly/Internal/Data/SmallArray/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UnboxedTuples #-}
 
 -- |

--- a/src/Streamly/Internal/Data/Stream/Serial.hs
+++ b/src/Streamly/Internal/Data/Stream/Serial.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- |

--- a/src/Streamly/Internal/Data/Stream/Zip.hs
+++ b/src/Streamly/Internal/Data/Stream/Zip.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- |

--- a/src/Streamly/Internal/Memory/Array/Types.hs
+++ b/src/Streamly/Internal/Memory/Array/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UnboxedTuples #-}
 
 #include "inline.hs"

--- a/src/Streamly/Memory/Malloc.hs
+++ b/src/Streamly/Memory/Malloc.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
-
 #include "inline.hs"
 
 -- |

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -266,10 +266,15 @@ common default-extensions
         RecordWildCards
         ScopedTypeVariables
         TupleSections
+        TypeFamilies
         ViewPatterns
 
+        -- MonoLocalBinds, enabled by TypeFamilies, causes performance
+        -- regressions. Disable it. This must come after TypeFamilies,
+        -- otherwise TypeFamilies will enable it again.
+        NoMonoLocalBinds
+
         -- UndecidableInstances -- Does not show any perf impact
-        -- TypeFamilies         -- Causes large regressions and improvements
         -- UnboxedTuples        -- interferes with (#.)
 
 common optimization-options

--- a/test/Prop.hs
+++ b/test/Prop.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedLists #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Main (main) where
 

--- a/test/PureStreams.hs
+++ b/test/PureStreams.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MonadComprehensions #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE OverloadedLists #-}
 


### PR DESCRIPTION
MonoLocalBinds enabled by TypeFamilies causes performance regressions
see #567, however we can enable TypeFamilies without it.