### PR TITLE
Updated type signature of `concatMapWith` to remove explicit forall.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 * Change the signature of `foldlM'` to make the initial value of the
   accumulator monadic.
+* Change the signature of `concatMapWith` to ensure that it can be
+  used with a wide variety of combining functions.
 
 ### Bug Fixes
 

--- a/src/Streamly/Internal/Data/Parser/ParserK/Types.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserK/Types.hs
@@ -52,7 +52,7 @@ instance Functor m => Functor (Parser m a) where
 --
 {-# INLINE yield #-}
 yield :: b -> Parser m a b
-yield b = MkParser (\_ yieldk -> yieldk (Z.nil, Right b))
+yield b = MkParser (\inp yieldk -> yieldk (inp, Right b))
 
 -------------------------------------------------------------------------------
 -- Sequential applicative

--- a/src/Streamly/Internal/Data/Stream/StreamK/Type.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamK/Type.hs
@@ -1008,7 +1008,7 @@ apSerialDiscardSnd fstream stream = go1 fstream
 {-# INLINE bindWith #-}
 bindWith
     :: IsStream t
-    => (forall c. t m c -> t m c -> t m c)
+    => (t m b -> t m b -> t m b)
     -> t m a
     -> (a -> t m b)
     -> t m b
@@ -1039,7 +1039,7 @@ bindWith par m1 f = go m1
 {-# INLINE concatMapBy #-}
 concatMapBy
     :: IsStream t
-    => (forall c. t m c -> t m c -> t m c)
+    => (t m b -> t m b -> t m b)
     -> (a -> t m b)
     -> t m a
     -> t m b

--- a/src/Streamly/Internal/Prelude.hs
+++ b/src/Streamly/Internal/Prelude.hs
@@ -3036,7 +3036,7 @@ mergeAsyncByM f m1 m2 = fromStreamD $
 {-# INLINE concatMapWith #-}
 concatMapWith
     :: IsStream t
-    => (forall c. t m c -> t m c -> t m c)
+    => (t m b -> t m b -> t m b)
     -> (a -> t m b)
     -> t m a
     -> t m b
@@ -3353,7 +3353,7 @@ interposeSuffix x unf str =
 {-# INLINE concatMapIterateWith #-}
 concatMapIterateWith
     :: IsStream t
-    => (forall c. t m c -> t m c -> t m c)
+    => (t m a -> t m a -> t m a)
     -> (a -> t m a)
     -> t m a
     -> t m a
@@ -3388,7 +3388,7 @@ concatMapIterateWith combine f = concatMapWith combine go
 {-# INLINE concatMapTreeWith #-}
 concatMapTreeWith
     :: IsStream t
-    => (forall c. t m c -> t m c -> t m c)
+    => (t m (Either a b) -> t m (Either a b) -> t m (Either a b))
     -> (a -> t m (Either a b))
     -> t m (Either a b) -- Should be t m a?
     -> t m (Either a b)


### PR DESCRIPTION
- Do the same with `bindWith`, `concatMapBy`, `concatMapIterateWith`,
  `concatMapTreeWith`.
- `concatMapLoopWith`,`concatMapTreeYieldLeavesWith` are not updated
  in the same way as they necessarily need the combining function to be
  polymorphic.
- Update Changelog to reflect this change.