### PR TITLE
Add encodeUtf8Lax.

### DIFF
--- a/src/Streamly/Data/Unicode/Stream.hs
+++ b/src/Streamly/Data/Unicode/Stream.hs
@@ -75,6 +75,7 @@ module Streamly.Data.Unicode.Stream
     , encodeLatin1
     , encodeLatin1Lax
     , encodeUtf8
+    , encodeUtf8Lax
     {-
     -- * Operations on character strings
     , strip -- (dropAround isSpace)


### PR DESCRIPTION
There is not much performance penalty for using the lenient variant instead of the normal one. Maybe we should use the same implementation for both the functions.