### PR TITLE
Provide a build flag to use C malloc for pinned arrays instead of using GHC malloc

### DIFF
--- a/src/Streamly/Internal/Foreign/Malloc.hs
+++ b/src/Streamly/Internal/Foreign/Malloc.hs
@@ -1,15 +1,15 @@
 #include "inline.hs"
 
 -- |
--- Module      : Streamly.Memory.Malloc
+-- Module      : Streamly.Internal.Foreign.Malloc
 -- Copyright   : (c) 2019 Composewell Technologies
 --
--- License     : BSD3
+-- License     : BSD-3-Clause
 -- Maintainer  : streamly@composewell.com
 -- Stability   : experimental
 -- Portability : GHC
 --
-module Streamly.Memory.Malloc
+module Streamly.Internal.Foreign.Malloc
     (
       mallocForeignPtrAlignedBytes
     , mallocForeignPtrAlignedUnmanagedBytes

--- a/src/Streamly/Internal/Memory/Mutable/Array/Types.hs
+++ b/src/Streamly/Internal/Memory/Mutable/Array/Types.hs
@@ -119,7 +119,7 @@ import Text.Read (readPrec, readListPrec, readListPrecDefault)
 #ifdef DEVBUILD
 import qualified Data.Foldable as F
 #endif
-import qualified Streamly.Memory.Malloc as Malloc
+import qualified Streamly.Internal.Foreign.Malloc as Malloc
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
 import qualified Streamly.Internal.Data.Stream.StreamK as K
 import qualified GHC.Exts as Exts

--- a/src/Streamly/Memory/Malloc.hs
+++ b/src/Streamly/Memory/Malloc.hs
@@ -16,11 +16,12 @@ module Streamly.Memory.Malloc
     )
 where
 
-#define USE_GHC_MALLOC
+
+-- We use GHC malloc by default
 
 import Foreign.ForeignPtr (ForeignPtr, newForeignPtr_)
 import Foreign.Marshal.Alloc (mallocBytes)
-#ifndef USE_GHC_MALLOC
+#ifdef USE_C_MALLOC
 import Foreign.ForeignPtr (newForeignPtr)
 import Foreign.Marshal.Alloc (finalizerFree)
 #endif
@@ -29,13 +30,13 @@ import qualified GHC.ForeignPtr as GHC
 
 {-# INLINE mallocForeignPtrAlignedBytes #-}
 mallocForeignPtrAlignedBytes :: Int -> Int -> IO (GHC.ForeignPtr a)
-#ifdef USE_GHC_MALLOC
-mallocForeignPtrAlignedBytes =
-    GHC.mallocPlainForeignPtrAlignedBytes
-#else
+#ifdef USE_C_MALLOC
 mallocForeignPtrAlignedBytes size _alignment = do
     p <- mallocBytes size
     newForeignPtr finalizerFree p
+#else
+mallocForeignPtrAlignedBytes =
+    GHC.mallocPlainForeignPtrAlignedBytes
 #endif
 
 -- memalign alignment size

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -360,7 +360,6 @@ library
                      , Streamly.Data.SmallArray
 
                     -- Memory storage
-                       Streamly.Memory.Malloc
                      , Streamly.Memory.Ring
 
                      , Streamly.FileSystem.IOVec
@@ -374,7 +373,7 @@ library
                      , Streamly.Data.Unfold
                      , Streamly.Data.Unicode.Stream
 
-                    -- IO devices
+                     -- IO devices
                      , Streamly.Memory.Array
                      , Streamly.FileSystem.Handle
 
@@ -392,6 +391,9 @@ library
                      , Streamly.Internal.Data.Time.Units
                      , Streamly.Internal.Data.Time.Clock
                      , Streamly.Internal.Data.SVar
+
+                     -- Memory storage
+                     ,  Streamly.Internal.Foreign.Malloc
 
                      -- Mutable data
                      , Streamly.Internal.Data.IORef.Prim

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -204,6 +204,11 @@ flag examples-sdl
   manual: True
   default: False
 
+flag use-c-malloc
+  description: Use C malloc instead of GHC malloc
+  manual: True
+  default: False
+
 -------------------------------------------------------------------------------
 -- Common stanzas
 -------------------------------------------------------------------------------
@@ -221,6 +226,9 @@ common compile-options
 
     if flag(inspection)
       cpp-options:    -DINSPECTION
+
+    if flag(use-c-malloc)
+      cpp-options:    -DUSE_C_MALLOC
 
     ghc-options:      -Wall
                       -Wcompat


### PR DESCRIPTION
Closes #644 