### PR TITLE
New encoding/decoding routines.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Enhancements
+
+* New encoding/decoding routines, `encodeUtf8'`, `encodeLatin1'`, `decodeUtf8'`,
+  are added, these routines fail when they encounter any invalid characters.
+
 ### Breaking changes
 
 * Deprecate `Streamly.Memory.Array` in favor of `Streamly.Data.Array.Storable.Foreign`
@@ -14,6 +19,12 @@
   constraint.
 * Change the associativity of combinators `serial`, `wSerial`,
   `ahead`, `async`, `wAsync`, `parallel` to be the same as `<>`.
+* `encodeUtf8`, `decodeUtf8` now replace any invalid character encountered
+  during encoding/decoding with the Unicode replacement character. Use
+  `encodeUtf8'`, `decodeUtf8'` to recover the previous functionality.
+* `encodeLatin1` now silently truncates any character beyond 255 to incorrect
+  characters in the input stream. Use `encodeLatin1'` to recover previous
+  functionality.
 * Drop support for GHC 7.10.3.
 
 ### Bug Fixes
@@ -33,9 +44,13 @@
 * The `Streamly` module is now deprecated, its functionality is subsumed
   by `Streamly.Prelude`.
 * Some functions from `Streamly` module have been renamed in `Streamly.Prelude` module:
-    * `foldWith` has been replaced by `concatFoldableWith`
-    * `foldMapWith` has been replaced by `concatMapFoldableWith`
-    * `forEachWith` has been replaced by `concatForFoldableWith`
+    * `foldWith` to `concatFoldableWith`
+    * `foldMapWith` to `concatMapFoldableWith`
+    * `forEachWith` to `concatForFoldableWith`
+* The following encoding/decoding routines have been renamed:
+    * `encodeUtf8Lax` to `encodeUtf8`
+    * `encodeLatin1Lax` to `encodeLatin1`
+    * `decodeUtf8Lenient` to `decodeUtf8`
 
 ## 0.7.2
 

--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/Read.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/Read.hs
@@ -120,12 +120,12 @@ inspect $ hasNoTypeClasses 'toChunksCountBytes
 inspect $ 'toChunksCountBytes `hasNoType` ''Step
 #endif
 
-toChunksDecodeUtf8ArraysLenient :: Handle -> IO ()
-toChunksDecodeUtf8ArraysLenient =
-   S.drain . IUS.decodeUtf8ArraysLenient . IFH.toChunks
+toChunksDecodeUtf8Arrays :: Handle -> IO ()
+toChunksDecodeUtf8Arrays =
+   S.drain . IUS.decodeUtf8Arrays . IFH.toChunks
 
 #ifdef INSPECTION
-inspect $ hasNoTypeClasses 'toChunksDecodeUtf8ArraysLenient
+inspect $ hasNoTypeClasses 'toChunksDecodeUtf8Arrays
 -- inspect $ 'toChunksDecodeUtf8ArraysLenient `hasNoType` ''Step
 #endif
 
@@ -146,8 +146,8 @@ o_1_space_read_chunked env =
             toChunksSplitOn inH
         , mkBench "countBytes" env $ \inH _ ->
             toChunksCountBytes inH
-        , mkBenchSmall "US.decodeUtf8ArraysLenient" env $ \inH _ ->
-            toChunksDecodeUtf8ArraysLenient inH
+        , mkBenchSmall "US.decodeUtf8Arrays" env $ \inH _ ->
+            toChunksDecodeUtf8Arrays inH
         ]
     ]
 
@@ -240,14 +240,14 @@ readDecodeLatin1 inh =
      $ SS.decodeLatin1
      $ S.unfold FH.read inh
 
-readDecodeUtf8Lax :: Handle -> IO ()
-readDecodeUtf8Lax inh =
+readDecodeUtf8 :: Handle -> IO ()
+readDecodeUtf8 inh =
    S.drain
-     $ SS.decodeUtf8Lax
+     $ SS.decodeUtf8
      $ S.unfold FH.read inh
 
 #ifdef INSPECTION
-inspect $ hasNoTypeClasses 'readDecodeUtf8Lax
+inspect $ hasNoTypeClasses 'readDecodeUtf8
 -- inspect $ 'readDecodeUtf8Lax `hasNoType` ''Step
 #endif
 
@@ -273,8 +273,8 @@ o_1_space_reduce_read env =
             readCountWords inh
 
         -- read with utf8 decoding
-        , mkBenchSmall "SS.decodeUtf8Lax" env $ \inh _ ->
-            readDecodeUtf8Lax inh
+        , mkBenchSmall "SS.decodeUtf8" env $ \inh _ ->
+            readDecodeUtf8 inh
         ]
     ]
 
@@ -505,14 +505,14 @@ o_1_space_reduce_read_split env =
 splitOnSeqUtf8 :: String -> Handle -> IO Int
 splitOnSeqUtf8 str inh =
     (S.length $ IP.splitOnSeq (A.fromList str) FL.drain
-        $ IUS.decodeUtf8ArraysLenient
+        $ IUS.decodeUtf8Arrays
         $ IFH.toChunks inh) -- >>= print
 
 o_1_space_reduce_toChunks_split :: BenchEnv -> [Benchmark]
 o_1_space_reduce_toChunks_split env =
     [ bgroup "reduce/toChunks"
         [ mkBenchSmall ("S.splitOnSeqUtf8 \"abcdefgh\" FL.drain "
-            ++ ". US.decodeUtf8ArraysLenient") env $ \inh _ ->
+            ++ ". US.decodeUtf8Arrays") env $ \inh _ ->
                 splitOnSeqUtf8 "abcdefgh" inh
         , mkBenchSmall "S.splitOnSeqUtf8 \"abcdefghijklmnopqrstuvwxyz\" FL.drain"
             env $ \inh _ -> splitOnSeqUtf8 "abcdefghijklmnopqrstuvwxyz" inh

--- a/examples/FileSinkServer.hs
+++ b/examples/FileSinkServer.hs
@@ -23,7 +23,7 @@ main = do
     file <- fmap head getArgs
     withFile file AppendMode
         (\src -> S.fold (FH.write src)
-        $ encodeLatin1Lax
+        $ encodeLatin1
         $ S.concatUnfold A.read
         $ S.concatMapWith S.parallel use
         $ S.unfold TCP.acceptOnPort 8090)

--- a/examples/WordCount.hs
+++ b/examples/WordCount.hs
@@ -335,7 +335,7 @@ countCharSerial (Counts l w c wasSpace) ch =
 _wc_mwl_serial :: Handle -> IO ()
 _wc_mwl_serial src = print =<< (
       S.foldl' countCharSerial (Counts 0 0 0 True)
-    $ S.decodeUtf8Lax
+    $ S.decodeUtf8
     $ S.unfold FH.read src)
 
 -------------------------------------------------------------------------------

--- a/src/Streamly/Data/Unicode/Stream.hs
+++ b/src/Streamly/Data/Unicode/Stream.hs
@@ -33,7 +33,7 @@
 -- stream as @Array Char@ using the array 'Streamly.Data.Array.Storable.Foreign.write' fold.
 -- The 'Array' type provides a more compact representation and pinned memory
 -- reducing GC overhead. If space efficiency is a concern you can use
--- 'encodeUtf8' on the 'Char' stream before writing it to an 'Array' providing
+-- 'encodeUtf8'' on the 'Char' stream before writing it to an 'Array' providing
 -- an even more compact representation.
 --
 -- = String Literals
@@ -65,18 +65,15 @@
 -- lived strings in memory.
 --
 module Streamly.Data.Unicode.Stream
-    {-# DEPRECATED "Use Streamly.Unicode.Stream instead" #-}
+    {-# DEPRECATED "Use \"Streamly.Unicode.Stream\" instead" #-}
     (
     -- * Construction (Decoding)
       decodeLatin1
     , decodeUtf8
-    , decodeUtf8Lax
 
     -- * Elimination (Encoding)
     , encodeLatin1
-    , encodeLatin1Lax
     , encodeUtf8
-    , encodeUtf8Lax
     {-
     -- * Operations on character strings
     , strip -- (dropAround isSpace)
@@ -90,6 +87,11 @@ module Streamly.Data.Unicode.Stream
     -- , words
     -- , unlines
     -- , unwords
+
+    -- * Deprecations
+    , decodeUtf8Lax
+    , encodeLatin1Lax
+    , encodeUtf8Lax
     )
 where
 

--- a/src/Streamly/Internal/FileSystem/Event/Darwin.hs
+++ b/src/Streamly/Internal/FileSystem/Event/Darwin.hs
@@ -980,7 +980,7 @@ isLastHardLink = getFlag kFSEventStreamEventFlagItemIsLastHardlink
 -- | Convert an 'Event' record to a String representation.
 showEvent :: Event -> String
 showEvent ev@Event{..} =
-    let path = runIdentity $ S.toList $ U.decodeUtf8 $ A.toStream eventAbsPath
+    let path = runIdentity $ S.toList $ U.decodeUtf8' $ A.toStream eventAbsPath
     in "--------------------------"
         ++ "\nId = " ++ show eventId
         ++ "\nPath = " ++ show path

--- a/src/Streamly/Internal/FileSystem/Event/Linux.hs
+++ b/src/Streamly/Internal/FileSystem/Event/Linux.hs
@@ -552,7 +552,7 @@ foreign import ccall unsafe
         :: CInt -> CString -> CUInt -> IO CInt
 
 utf8ToString :: Array Word8 -> String
-utf8ToString = runIdentity . S.toList . U.decodeUtf8 . A.toStream
+utf8ToString = runIdentity . S.toList . U.decodeUtf8' . A.toStream
 
 #if !MIN_VERSION_base(4,10,0)
 -- | Turn an existing Handle into a file descriptor. This function throws an

--- a/src/Streamly/Unicode/Stream.hs
+++ b/src/Streamly/Unicode/Stream.hs
@@ -33,7 +33,7 @@
 -- stream as @Array Char@ using the array 'Streamly.Data.Array.Storable.Foreign.write' fold.
 -- The 'Array' type provides a more compact representation and pinned memory
 -- reducing GC overhead. If space efficiency is a concern you can use
--- 'encodeUtf8' on the 'Char' stream before writing it to an 'Array' providing
+-- 'encodeUtf8'' on the 'Char' stream before writing it to an 'Array' providing
 -- an even more compact representation.
 --
 -- = String Literals
@@ -69,13 +69,13 @@ module Streamly.Unicode.Stream
     -- * Construction (Decoding)
       decodeLatin1
     , decodeUtf8
-    , decodeUtf8Lax
+    , decodeUtf8'
 
     -- * Elimination (Encoding)
     , encodeLatin1
-    , encodeLatin1Lax
+    , encodeLatin1'
     , encodeUtf8
-    , encodeUtf8Lax
+    , encodeUtf8'
     {-
     -- * Operations on character strings
     , strip -- (dropAround isSpace)

--- a/test/Streamly/Test/FileSystem/Event.hs
+++ b/test/Streamly/Test/FileSystem/Event.hs
@@ -36,7 +36,7 @@ import qualified Streamly.Internal.Data.Array.Storable.Foreign as Array
 -------------------------------------------------------------------------------
 
 toUtf8 :: MonadIO m => String -> m (Array Word8)
-toUtf8 = Array.fromStream . Unicode.encodeUtf8 . Stream.fromList
+toUtf8 = Array.fromStream . Unicode.encodeUtf8' . Stream.fromList
 
 -------------------------------------------------------------------------------
 -- Main


### PR DESCRIPTION
 Add `encodeUtf8_`, `encodeLatin1_`, `encodeUtf8'`, `encodeLatin1'`, `decodeUtf8_`, `decodeUtf8'`, `decodeUtf8Arrays'`, `decodeUtf8Arrays_`. 

See #658. 

Closes #658 