### PR TITLE
Put fs event executable under manual-tests flag

### DIFF
--- a/src/Streamly/Internal/FileSystem/Event/Darwin.hs
+++ b/src/Streamly/Internal/FileSystem/Event/Darwin.hs
@@ -1020,4 +1020,11 @@ showEvent ev@Event{..} =
         where showev f str = if f ev then "\n" ++ str else ""
 #else
 module Streamly.Internal.FileSystem.Event.Darwin () where
+#warning "Autoconf did not find the definition \
+kFSEventStreamCreateFlagFileEvents in Darwin header files.\
+Do you have Cocoa framework header files installed?\
+Not compiling the Streamly.Internal.FileSystem.Event.Darwin module. \
+Programs depending on this module may not compile. \
+Check if HAVE_DECL_KFSEVENTSTREAMCREATEFLAGFILEEVENTS is defined in config.h \
+generated from src/config.h.in"
 #endif

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -210,6 +210,11 @@ flag use-c-malloc
   manual: True
   default: False
 
+flag manual-tests
+  description: Builds tests that are to be run manually
+  manual: True
+  default: False
+
 -------------------------------------------------------------------------------
 -- Common stanzas
 -------------------------------------------------------------------------------
@@ -881,7 +886,7 @@ executable FileSystem.Event
   build-depends:
       streamly
     , base >= 4.8 && < 5
-  if os(windows)
+  if !flag(manual-tests) || os(windows)
     buildable: False
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Otherwise it is always built when we build the library.