### PR TITLE
Allow QuickCheck version to be >= 2.13

### DIFF
--- a/streamly.cabal
+++ b/streamly.cabal
@@ -330,7 +330,7 @@ common prelude-test-options
   build-depends:
       streamly
     , base              >= 4.9   && < 5
-    , QuickCheck        >= 2.14  && < 2.15
+    , QuickCheck        >= 2.13  && < 2.15
     , hspec             >= 2.0   && < 3
     , exceptions        >= 0.8   && < 0.11
   default-language: Haskell2010
@@ -555,7 +555,7 @@ test-suite internal-prelude-test
   build-depends:
       streamly
     , base              >= 4.9   && < 5
-    , QuickCheck        >= 2.14  && < 2.15
+    , QuickCheck        >= 2.13  && < 2.15
     , hspec             >= 2.0   && < 3
   default-language: Haskell2010
 
@@ -683,7 +683,7 @@ test-suite array-test
   build-depends:
       streamly
     , base              >= 4.9   && < 5
-    , QuickCheck        >= 2.14  && < 2.15
+    , QuickCheck        >= 2.13  && < 2.15
     , hspec             >= 2.0   && < 3
   default-language: Haskell2010
 
@@ -697,7 +697,7 @@ test-suite internal-data-fold-test
       streamly
     , base              >= 4.9   && < 5
     , hspec             >= 2.0   && < 3
-    , QuickCheck        >= 2.14  && < 2.15
+    , QuickCheck        >= 2.13  && < 2.15
   default-language: Haskell2010
 
 test-suite internal-data-parser-test
@@ -711,8 +711,9 @@ test-suite internal-data-parser-test
       streamly
     , base              >= 4.9   && < 5
     , hspec             >= 2.0   && < 3
-    , QuickCheck        >= 2.14  && < 2.15
+    , QuickCheck        >= 2.13  && < 2.15
     , transformers      >= 0.4 && < 0.6
+    , random            >= 1.0.0 && < 2
   default-language: Haskell2010
 
 test-suite internal-data-parser-parserd-test
@@ -725,8 +726,9 @@ test-suite internal-data-parser-parserd-test
       streamly
     , base              >= 4.9   && < 5
     , hspec             >= 2.0   && < 3
-    , QuickCheck        >= 2.14  && < 2.15
+    , QuickCheck        >= 2.13  && < 2.15
     , transformers      >= 0.4 && < 0.6
+    , random            >= 1.0.0 && < 2
   default-language: Haskell2010
 
 test-suite data-array-test
@@ -738,7 +740,7 @@ test-suite data-array-test
   build-depends:
       streamly
     , base              >= 4.9   && < 5
-    , QuickCheck        >= 2.14  && < 2.15
+    , QuickCheck        >= 2.13  && < 2.15
     , hspec             >= 2.0   && < 3
   default-language: Haskell2010
 
@@ -752,7 +754,7 @@ test-suite smallarray-test
   build-depends:
       streamly
     , base              >= 4.9   && < 5
-    , QuickCheck        >= 2.14  && < 2.15
+    , QuickCheck        >= 2.13  && < 2.15
     , hspec             >= 2.0   && < 3
   default-language: Haskell2010
 
@@ -766,7 +768,7 @@ test-suite primarray-test
   build-depends:
       streamly
     , base              >= 4.9   && < 5
-    , QuickCheck        >= 2.14  && < 2.15
+    , QuickCheck        >= 2.13  && < 2.15
     , hspec             >= 2.0   && < 3
   default-language: Haskell2010
 
@@ -780,7 +782,7 @@ test-suite prim-pinned-array-test
   build-depends:
       streamly
     , base              >= 4.9   && < 5
-    , QuickCheck        >= 2.14  && < 2.15
+    , QuickCheck        >= 2.13  && < 2.15
     , hspec             >= 2.0   && < 3
   default-language: Haskell2010
 
@@ -793,7 +795,7 @@ test-suite string-test
   build-depends:
       streamly
     , base              >= 4.9   && < 5
-    , QuickCheck        >= 2.14  && < 2.15
+    , QuickCheck        >= 2.13  && < 2.15
     , hspec             >= 2.0   && < 3
   default-language: Haskell2010
 

--- a/test/Streamly/Test/Internal/Data/Parser.hs
+++ b/test/Streamly/Test/Internal/Data/Parser.hs
@@ -9,7 +9,7 @@ import Test.Hspec (Spec, hspec, describe)
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
        (arbitrary, forAll, choose, elements, Property, property, listOf,
-        vectorOf, counterexample, Gen, chooseAny)
+        vectorOf, counterexample, Gen)
 import Test.QuickCheck.Monadic (monadicIO, PropertyM, assert, monitor, run)
 
 import Prelude hiding (sequence)
@@ -20,6 +20,22 @@ import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
 import qualified Test.Hspec as H
 import qualified Prelude
+
+#if MIN_VERSION_QuickCheck(2,14,0)
+
+import Test.QuickCheck (chooseAny)
+
+#else
+
+import System.Random (Random(random))
+import Test.QuickCheck.Gen (Gen(MkGen))
+
+-- | Generates a random element over the natural range of `a`.
+chooseAny :: Random a => Gen a
+chooseAny = MkGen (\r _ -> let (x,_) = random r in x)
+
+#endif
+
 
 maxTestCount :: Int
 maxTestCount = 100

--- a/test/Streamly/Test/Internal/Data/Parser/ParserD.hs
+++ b/test/Streamly/Test/Internal/Data/Parser/ParserD.hs
@@ -8,7 +8,7 @@ import Data.Word (Word8, Word32, Word64)
 import Test.Hspec (Spec, hspec, describe)
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
-       (arbitrary, forAll, choose, chooseAny, elements, Property,
+       (arbitrary, forAll, choose, elements, Property,
         property, listOf, vectorOf, counterexample, (.&&.), Gen)
 import Test.QuickCheck.Monadic
        (monadicIO, PropertyM, assert, monitor, run)
@@ -21,6 +21,21 @@ import qualified Prelude
 import qualified Test.Hspec as H
 
 import Prelude hiding (sequence)
+
+#if MIN_VERSION_QuickCheck(2,14,0)
+
+import Test.QuickCheck (chooseAny)
+
+#else
+
+import System.Random (Random(random))
+import Test.QuickCheck.Gen (Gen(MkGen))
+
+-- | Generates a random element over the natural range of `a`.
+chooseAny :: Random a => Gen a
+chooseAny = MkGen (\r _ -> let (x,_) = random r in x)
+
+#endif
 
 maxTestCount :: Int
 maxTestCount = 100


### PR DESCRIPTION
Closes #711 .

Should we try to relax lower bound even more?