### PR TITLE
Configure storable array to work properly when building with "-f dev"

### DIFF
--- a/src/Streamly/Internal/Data/Array/Storable/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Storable/Foreign.hs
@@ -514,7 +514,11 @@ streamTransform f arr =
 --
 -- /Internal/
 --
-unsafeCast :: Array a -> Array b
+unsafeCast ::
+#ifdef DEVBUILD
+    Storable b =>
+#endif
+    Array a -> Array b
 unsafeCast (Array start end) = Array (castForeignPtr start) (castPtr end)
 
 -- | Cast an array into a Word8 array

--- a/src/Streamly/Internal/Data/Array/Storable/Foreign/Mut/Types.hs
+++ b/src/Streamly/Internal/Data/Array/Storable/Foreign/Mut/Types.hs
@@ -193,7 +193,11 @@ data Array a =
     }
 
 {-# INLINE mutableArray #-}
-mutableArray :: ForeignPtr a -> Ptr a -> Ptr a -> Array a
+mutableArray ::
+#ifdef DEVBUILD
+    Storable a =>
+#endif
+    ForeignPtr a -> Ptr a -> Ptr a -> Array a
 mutableArray = Array
 
 -------------------------------------------------------------------------------

--- a/src/Streamly/Internal/Data/Array/Storable/Foreign/Types.hs
+++ b/src/Streamly/Internal/Data/Array/Storable/Foreign/Types.hs
@@ -92,6 +92,9 @@ import Foreign.Storable (Storable(..))
 import GHC.Base (Addr#, nullAddr#)
 import GHC.Exts (IsList, IsString(..))
 import GHC.ForeignPtr (ForeignPtr(..), newForeignPtr_)
+#ifdef DEVBUILD
+import GHC.ForeignPtr (touchForeignPtr, unsafeForeignPtrToPtr)
+#endif
 import GHC.IO (unsafePerformIO)
 import GHC.Ptr (Ptr(..))
 import Streamly.Internal.Data.Fold.Types (Fold(..), lmap)
@@ -232,7 +235,11 @@ spliceTwo arr1 arr2 =
 -- /Internal/
 --
 {-# INLINE fromPtr #-}
-fromPtr :: Int -> Ptr a -> Array a
+fromPtr ::
+#ifdef DEVBUILD
+    Storable a =>
+#endif
+    Int -> Ptr a -> Array a
 fromPtr n ptr = MA.unsafeInlineIO $ do
     fptr <- newForeignPtr_ ptr
     let end = ptr `plusPtr` n
@@ -274,7 +281,11 @@ fromPtr n ptr = MA.unsafeInlineIO $ do
 -- /Internal/
 --
 {-# INLINE fromAddr# #-}
-fromAddr# :: Int -> Addr# -> Array a
+fromAddr# ::
+#ifdef DEVBUILD
+    Storable a =>
+#endif
+    Int -> Addr# -> Array a
 fromAddr# n addr# = fromPtr n (castPtr $ Ptr addr#)
 
 -- | Generate a byte array from an 'Addr#' that contains a sequence of NUL

--- a/test/MaxRate.hs
+++ b/test/MaxRate.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 import Streamly
 import qualified Streamly.Prelude as S
 import Streamly.Internal.Data.Time.Clock (getTime, Clock(..))


### PR DESCRIPTION
```
#ifdef DEVBUILD
    Storable a =>
#endif
```
Should be added to almost all the functions in `Foreign.Array`