### PR TITLE
Improve performance of parseMany

### DIFF
--- a/src/Streamly/Internal/Data/Stream/StreamD.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD.hs
@@ -1022,8 +1022,8 @@ parselMx' pstep initial extract (Stream step state) = do
 data ParseChunksState x inpBuf st pst =
       ParseChunksInit inpBuf st
     | ParseChunksInitLeftOver inpBuf
-    | ParseChunksStream st inpBuf pst
-    | ParseChunksBuf inpBuf st inpBuf pst
+    | ParseChunksStream st inpBuf !pst
+    | ParseChunksBuf inpBuf st inpBuf !pst
     | ParseChunksYield x (ParseChunksState x inpBuf st pst)
 
 {-# INLINE_NORMAL parseMany #-}
@@ -1068,14 +1068,16 @@ parseMany (PRD.Parser pstep initial extract) (Stream step state) =
                         let src0 = Prelude.take n (x:buf)
                             src  = Prelude.reverse src0
                         return $ Skip $ ParseChunksBuf src s [] pst1
-                    -- PR.Continue 0 pst1 ->
-                    --     return $ Skip $ ParseChunksStream s (x:buf) pst1
+                    PR.Continue 0 pst1 ->
+                        return $ Skip $ ParseChunksStream s (x:buf) pst1
                     PR.Continue n pst1 -> do
                         assert (n <= length (x:buf)) (return ())
                         let (src0, buf1) = splitAt n (x:buf)
                             src  = Prelude.reverse src0
                         return $ Skip $ ParseChunksBuf src s buf1 pst1
-                    -- XXX Specialize for Stop 0 common case?
+                    PR.Done 0 b -> do
+                        return $ Skip $
+                            ParseChunksYield b (ParseChunksInit [] s)
                     PR.Done n b -> do
                         assert (n <= length (x:buf)) (return ())
                         let src = Prelude.reverse (Prelude.take n (x:buf))
@@ -1104,13 +1106,15 @@ parseMany (PRD.Parser pstep initial extract) (Stream step state) =
                 let src0 = Prelude.take n (x:buf)
                     src  = Prelude.reverse src0 ++ xs
                 return $ Skip $ ParseChunksBuf src s [] pst1
-         -- PR.Continue 0 pst1 -> return $ Skip $ ParseChunksBuf xs s (x:buf) pst1
+            PR.Continue 0 pst1 ->
+                return $ Skip $ ParseChunksBuf xs s (x:buf) pst1
             PR.Continue n pst1 -> do
                 assert (n <= length (x:buf)) (return ())
                 let (src0, buf1) = splitAt n (x:buf)
                     src  = Prelude.reverse src0 ++ xs
                 return $ Skip $ ParseChunksBuf src s buf1 pst1
-            -- XXX Specialize for Stop 0 common case?
+            PR.Done 0 b ->
+                return $ Skip $ ParseChunksYield b (ParseChunksInit xs s)
             PR.Done n b -> do
                 assert (n <= length (x:buf)) (return ())
                 let src = Prelude.reverse (Prelude.take n (x:buf)) ++ xs


### PR DESCRIPTION
1. Make the parser state strict so that it can fuse.
2. Use special paths for "Continue 0" and "Done 0" cases

Overall improvement from 440 us (6GB allocations) to 175 us (22 MB
allocations).