### PR TITLE
Benchmarks for exposed

### DIFF
--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/Read.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/Read.hs
@@ -418,6 +418,19 @@ inspect $ 'splitOnSuffix `hasNoType` ''IUF.ConcatState -- FH.read/UF.concat
 inspect $ 'splitOnSuffix `hasNoType` ''A.ReadUState  -- FH.read/A.read
 #endif
 
+-- | Split suffix with line feed.
+splitWithSuffix :: Handle -> IO Int
+splitWithSuffix inh =
+    (S.length $ S.splitWithSuffix (== lf) FL.drain
+        $ S.unfold FH.read inh) -- >>= print
+
+#ifdef INSPECTION
+inspect $ hasNoTypeClasses 'splitWithSuffix
+inspect $ 'splitWithSuffix `hasNoType` ''Step
+inspect $ 'splitWithSuffix `hasNoType` ''IUF.ConcatState -- FH.read/UF.concat
+inspect $ 'splitWithSuffix `hasNoType` ''A.ReadUState  -- FH.read/A.read
+#endif
+
 -- | Split on line feed.
 parseManySepBy :: Handle -> IO Int
 parseManySepBy inh =
@@ -477,6 +490,8 @@ o_1_space_reduce_read_split env =
             splitOn inh
         , mkBench "S.splitOnSuffix (== lf) FL.drain" env $ \inh _ ->
             splitOnSuffix inh
+        , mkBench "S.splitWithSuffix (== lf) FL.drain" env $ \inh _ ->
+            splitWithSuffix inh
         , mkBench "S.splitOnSeq \"\" FL.drain" env $ \inh _ ->
             splitOnSeq "" inh
         , mkBench "S.splitOnSuffixSeq \"\" FL.drain" env $ \inh _ ->

--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
@@ -190,11 +190,28 @@ inspect $ 'copyStream `hasNoType` ''AT.ArrayUnsafe -- FH.write/writeNUnsafe
 inspect $ 'copyStream `hasNoType` ''Strict.Tuple3' -- FH.write/lchunksOf
 #endif
 
--- | Copy file
+-- | Copy file (encodeLatin1')
+copyStreamLatin1' :: Handle -> Handle -> IO ()
+copyStreamLatin1' inh outh =
+   S.fold (FH.write outh)
+     $ SS.encodeLatin1'
+     $ SS.decodeLatin1
+     $ S.unfold FH.read inh
+
+#ifdef INSPECTION
+inspect $ hasNoTypeClasses 'copyStreamLatin1'
+inspect $ 'copyStreamLatin1' `hasNoType` ''Step
+inspect $ 'copyStreamLatin1' `hasNoType` ''IUF.ConcatState -- FH.read/UF.concat
+inspect $ 'copyStreamLatin1' `hasNoType` ''A.ReadUState  -- FH.read/A.read
+inspect $ 'copyStreamLatin1' `hasNoType` ''AT.ArrayUnsafe -- FH.write/writeNUnsafe
+inspect $ 'copyStreamLatin1' `hasNoType` ''Strict.Tuple3' -- FH.write/lchunksOf
+#endif
+
+-- | Copy file (encodeLatin1)
 copyStreamLatin1 :: Handle -> Handle -> IO ()
 copyStreamLatin1 inh outh =
    S.fold (FH.write outh)
-     $ SS.encodeLatin1'
+     $ SS.encodeLatin1
      $ SS.decodeLatin1
      $ S.unfold FH.read inh
 
@@ -246,6 +263,8 @@ o_1_space_copy_read env =
             copyStream inh outh
         -- This needs an ascii file, as decode just errors out.
         , mkBench "SS.encodeLatin1' . SS.decodeLatin1" env $ \inh outh ->
+            copyStreamLatin1' inh outh
+        , mkBench "SS.encodeLatin1 . SS.decodeLatin1" env $ \inh outh ->
             copyStreamLatin1 inh outh
 #ifdef DEVBUILD
         , mkBench "copyUtf8" env $ \inh outh ->

--- a/benchmark/Streamly/Benchmark/Prelude/Ahead.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Ahead.hs
@@ -57,6 +57,10 @@ o_1_space_concatFoldable value =
             (sourceFoldMapWithStream value)
         , benchIOSrc aheadly "foldMapWithM (<>) (List)"
             (sourceFoldMapWithM value)
+        , benchIOSrc serially "S.concatFoldableWith (<>) (List)"
+            (concatFoldableWith value)
+        , benchIOSrc serially "S.concatForFoldableWith (<>) (List)"
+            (concatForFoldableWith value)
         , benchIOSrc aheadly "foldMapM (List)" (sourceFoldMapM value)
         ]
     ]

--- a/benchmark/Streamly/Benchmark/Prelude/Async.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Async.hs
@@ -114,6 +114,10 @@ o_1_space_concatFoldable value =
             (sourceFoldMapWithStream value)
         , benchIOSrc asyncly "foldMapWithM (<>) (List)"
             (sourceFoldMapWithM value)
+        , benchIOSrc serially "S.concatFoldableWith (<>) (List)"
+            (concatFoldableWith value)
+        , benchIOSrc serially "S.concatForFoldableWith (<>) (List)"
+            (concatForFoldableWith value)
         , benchIOSrc asyncly "foldMapM (List)" (sourceFoldMapM value)
         ]
     ]

--- a/benchmark/Streamly/Benchmark/Prelude/Async.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Async.hs
@@ -64,6 +64,14 @@ o_1_space_mapping value =
     ]
 
 -------------------------------------------------------------------------------
+-- Size conserving transformations (reordering, buffering, etc.)
+-------------------------------------------------------------------------------
+
+o_n_heap_buffering :: Int -> [Benchmark]
+o_n_heap_buffering value =
+    [bgroup "buffered" [benchIOSink value "mkAsync" (mkAsync asyncly)]]
+
+-------------------------------------------------------------------------------
 -- Joining
 -------------------------------------------------------------------------------
 
@@ -190,5 +198,6 @@ main = do
             , o_1_space_outerProduct value
             , o_1_space_joining value
             ]
+        , bgroup (o_n_heap_prefix moduleName) (o_n_heap_buffering value)
         , bgroup (o_n_space_prefix moduleName) (o_n_space_outerProduct value)
         ]

--- a/benchmark/Streamly/Benchmark/Prelude/Parallel.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Parallel.hs
@@ -116,6 +116,24 @@ o_n_heap_mapping value =
         ]
     ]
 
+
+-------------------------------------------------------------------------------
+-- Joining
+-------------------------------------------------------------------------------
+
+{-# INLINE parallel2 #-}
+parallel2 :: Int -> Int -> IO ()
+parallel2 count n =
+    S.drain $
+        (sourceUnfoldrM count n) `parallel` (sourceUnfoldrM count (n + 1))
+
+o_1_space_joining :: Int -> [Benchmark]
+o_1_space_joining value =
+    [ bgroup "joining"
+        [ benchIOSrc1 "parallel (2 of n/2)" (parallel2 (value `div` 2))
+        ]
+    ]
+
 -------------------------------------------------------------------------------
 -- Concat
 -------------------------------------------------------------------------------
@@ -197,7 +215,10 @@ main = do
     where
 
     allBenchmarks value =
-        [ bgroup (o_1_space_prefix moduleName) (o_1_space_merge_app_tap value)
+        [ bgroup (o_1_space_prefix moduleName) $ concat
+            [ o_1_space_merge_app_tap value
+            , o_1_space_joining value
+            ]
         , bgroup (o_n_heap_prefix moduleName) $ concat
             [ o_n_heap_generation value
             , o_n_heap_mapping value

--- a/benchmark/Streamly/Benchmark/Prelude/Parallel.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Parallel.hs
@@ -130,6 +130,10 @@ o_n_heap_concatFoldable value =
             (sourceFoldMapWithStream value)
         , benchIOSrc parallely "foldMapWithM (<>) (List)"
             (sourceFoldMapWithM value)
+        , benchIOSrc serially "S.concatFoldableWith (<>) (List)"
+            (concatFoldableWith value)
+        , benchIOSrc serially "S.concatForFoldableWith (<>) (List)"
+            (concatForFoldableWith value)
         , benchIOSrc parallely "foldMapM (List)" (sourceFoldMapM value)
         ]
     ]

--- a/benchmark/Streamly/Benchmark/Prelude/Rate.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Rate.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
+
 -- |
 -- Module      : Main
 -- Copyright   : (c) 2018 Composewell Technologies
@@ -5,7 +7,7 @@
 -- License     : BSD3
 -- Maintainer  : streamly@composewell.com
 
-import Streamly.Prelude (asyncly, aheadly, maxThreads)
+import Streamly.Prelude (asyncly, aheadly, maxThreads, IsStream, MonadAsync)
 import qualified Streamly.Prelude as S
 
 import Streamly.Benchmark.Common
@@ -20,6 +22,19 @@ moduleName = "Prelude.Rate"
 -- Average Rate
 -------------------------------------------------------------------------------
 
+{-# INLINE rateNothing #-}
+rateNothing :: (MonadAsync m, IsStream t) => Int -> Int -> t m Int
+rateNothing value = S.rate Nothing . sourceUnfoldrM value
+
+{-# INLINE avgRate #-}
+avgRate :: (MonadAsync m, IsStream t) => Int -> Double -> Int -> t m Int
+avgRate value rate_ = S.avgRate rate_ . sourceUnfoldrM value
+
+{-# INLINE avgRateThreads1 #-}
+avgRateThreads1 :: (MonadAsync m, IsStream t) => Int -> Double -> Int -> t m Int
+avgRateThreads1 value rate_ =
+    maxThreads 1 . S.avgRate rate_ . sourceUnfoldrM value
+
 -- XXX arbitrarily large rate should be the same as rate Nothing
 o_1_space_async_avgRate :: Int -> [Benchmark]
 o_1_space_async_avgRate value =
@@ -27,18 +42,13 @@ o_1_space_async_avgRate value =
         [ bgroup "avgRate"
             -- benchIO "unfoldr" $ toNull asyncly
             -- benchIOSrc asyncly "unfoldrM" (sourceUnfoldrM value)
-            [ benchIOSrc asyncly "unfoldrM/Nothing"
-                (S.rate Nothing . sourceUnfoldrM value)
-            , benchIOSrc asyncly "unfoldrM/1,000,000"
-                (S.avgRate 1000000 . sourceUnfoldrM value)
-            , benchIOSrc asyncly "unfoldrM/3,000,000"
-                (S.avgRate 3000000 . sourceUnfoldrM value)
-            , benchIOSrc asyncly "unfoldrM/10,000,000/maxThreads1"
-                (maxThreads 1 .  S.avgRate 10000000 . sourceUnfoldrM value)
-            , benchIOSrc asyncly "unfoldrM/10,000,000"
-                (S.avgRate 10000000 . sourceUnfoldrM value)
-            , benchIOSrc asyncly "unfoldrM/20,000,000"
-                (S.avgRate 20000000 . sourceUnfoldrM value)
+            [ benchIOSrc asyncly "Nothing" $ rateNothing value
+            , benchIOSrc asyncly "1M" $ avgRate value 1000000
+            , benchIOSrc asyncly "3M" $ avgRate value 3000000
+            , benchIOSrc asyncly "10M/maxThreads1"
+                  $ avgRateThreads1 value 10000000
+            , benchIOSrc asyncly "10M" $ avgRate value 10000000
+            , benchIOSrc asyncly "20M" $ avgRate value 20000000
             ]
         ]
     ]
@@ -47,8 +57,7 @@ o_1_space_ahead_avgRate :: Int -> [Benchmark]
 o_1_space_ahead_avgRate value =
     [ bgroup "aheadly"
         [ bgroup "avgRate"
-            [ benchIOSrc aheadly "unfoldrM/1,000,000"
-                  (S.avgRate 1000000 . sourceUnfoldrM value)
+            [ benchIOSrc aheadly "1M" $ avgRate value 1000000
             ]
         ]
     ]

--- a/benchmark/Streamly/Benchmark/Prelude/Rate.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Rate.hs
@@ -38,28 +38,28 @@ avgRateThreads1 value rate_ =
 -- XXX arbitrarily large rate should be the same as rate Nothing
 o_1_space_async_avgRate :: Int -> [Benchmark]
 o_1_space_async_avgRate value =
-    [ bgroup "asyncly"
-        [ bgroup "avgRate"
-            -- benchIO "unfoldr" $ toNull asyncly
-            -- benchIOSrc asyncly "unfoldrM" (sourceUnfoldrM value)
-            [ benchIOSrc asyncly "Nothing" $ rateNothing value
-            , benchIOSrc asyncly "1M" $ avgRate value 1000000
-            , benchIOSrc asyncly "3M" $ avgRate value 3000000
-            , benchIOSrc asyncly "10M/maxThreads1"
-                  $ avgRateThreads1 value 10000000
-            , benchIOSrc asyncly "10M" $ avgRate value 10000000
-            , benchIOSrc asyncly "20M" $ avgRate value 20000000
-            ]
-        ]
+    [ bgroup
+          "asyncly"
+          [ bgroup
+                "avgRate"
+                -- benchIO "unfoldr" $ toNull asyncly
+                -- benchIOSrc asyncly "unfoldrM" (sourceUnfoldrM value)
+                [ benchIOSrc asyncly "Nothing" $ rateNothing value
+                , benchIOSrc asyncly "1M" $ avgRate value 1000000
+                , benchIOSrc asyncly "3M" $ avgRate value 3000000
+                , benchIOSrc asyncly "10M/maxThreads1"
+                      $ avgRateThreads1 value 10000000
+                , benchIOSrc asyncly "10M" $ avgRate value 10000000
+                , benchIOSrc asyncly "20M" $ avgRate value 20000000
+                ]
+          ]
     ]
 
 o_1_space_ahead_avgRate :: Int -> [Benchmark]
 o_1_space_ahead_avgRate value =
-    [ bgroup "aheadly"
-        [ bgroup "avgRate"
-            [ benchIOSrc aheadly "1M" $ avgRate value 1000000
-            ]
-        ]
+    [ bgroup
+          "aheadly"
+          [bgroup "avgRate" [benchIOSrc aheadly "1M" $ avgRate value 1000000]]
     ]
 
 -------------------------------------------------------------------------------
@@ -74,8 +74,9 @@ main = do
     where
 
     allBenchmarks value =
-        [ bgroup (o_1_space_prefix moduleName) $ concat
-            [ o_1_space_async_avgRate value
-            , o_1_space_ahead_avgRate value
-            ]
+        [ bgroup (o_1_space_prefix moduleName)
+              $ concat
+                    [ o_1_space_async_avgRate value
+                    , o_1_space_ahead_avgRate value
+                    ]
         ]

--- a/benchmark/Streamly/Benchmark/Prelude/Serial.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial.hs
@@ -1746,6 +1746,10 @@ o_1_space_concatFoldable value =
             (sourceFoldMapWithStream value)
         , benchIOSrc serially "foldMapWithM (<>) (List)"
             (sourceFoldMapWithM value)
+        , benchIOSrc serially "S.concatFoldableWith (<>) (List)"
+            (concatFoldableWith value)
+        , benchIOSrc serially "S.concatForFoldableWith (<>) (List)"
+            (concatForFoldableWith value)
         , benchIOSrc serially "foldMapM (List)" (sourceFoldMapM value)
         ]
     ]

--- a/benchmark/Streamly/Benchmark/Prelude/Serial.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial.hs
@@ -1405,7 +1405,7 @@ o_1_space_indexingX4 value =
     ]
 
 -------------------------------------------------------------------------------
--- Reordering
+-- Size conserving transformations (reordering, buffering, etc.)
 -------------------------------------------------------------------------------
 
 {-# INLINE reverse #-}
@@ -1416,13 +1416,15 @@ reverse n = composeN n S.reverse
 reverse' :: MonadIO m => Int -> SerialT m Int -> m ()
 reverse' n = composeN n Internal.reverse'
 
-o_n_heap_reordering :: Int -> [Benchmark]
-o_n_heap_reordering value =
+o_n_heap_buffering :: Int -> [Benchmark]
+o_n_heap_buffering value =
     [ bgroup "buffered"
         [
         -- Reversing/sorting a stream
           benchIOSink value "reverse" (reverse 1)
         , benchIOSink value "reverse'" (reverse' 1)
+
+        , benchIOSink value "mkAsync" (mkAsync serially)
         ]
     ]
 
@@ -2130,7 +2132,7 @@ main = do
             , o_n_heap_elimination_buffered size
 
             -- transformation
-            , o_n_heap_reordering size
+            , o_n_heap_buffering size
             , o_n_heap_transformer size
             ]
         , bgroup (o_n_space_prefix moduleName) $ Prelude.concat

--- a/benchmark/Streamly/Benchmark/Prelude/Serial.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial.hs
@@ -437,9 +437,9 @@ foldrMElem e =
                  else xs)
         (return P.False)
 
-{-# INLINE foldrMToStream #-}
-foldrMToStream :: Monad m => SerialT m Int -> m (SerialT Identity Int)
-foldrMToStream = S.foldr S.cons S.nil
+{-# INLINE foldrToStream #-}
+foldrToStream :: Monad m => SerialT m Int -> m (SerialT Identity Int)
+foldrToStream = S.foldr S.cons S.nil
 
 {-# INLINE foldrMBuild #-}
 foldrMBuild :: Monad m => SerialT m Int -> m [Int]
@@ -573,8 +573,8 @@ o_1_space_elimination_folds value =
                   ]
             , bgroup "Identity"
                   [ benchIdentitySink value "foldrMElem" (foldrMElem value)
-                  , benchIdentitySink value "foldrMToStreamLength"
-                        (S.length . runIdentity . foldrMToStream)
+                  , benchIdentitySink value "foldrToStreamLength"
+                        (S.length . runIdentity . foldrToStream)
                   , benchPureSink value "foldrMToListLength"
                         (P.length . runIdentity . foldrMBuild)
                   ]
@@ -855,9 +855,9 @@ o_n_space_traversable value =
 -- maps and scans
 -------------------------------------------------------------------------------
 
-{-# INLINE scan #-}
-scan :: MonadIO m => Int -> SerialT m Int -> m ()
-scan n = composeN n $ S.scanl' (+) 0
+{-# INLINE scanl' #-}
+scanl' :: MonadIO m => Int -> SerialT m Int -> m ()
+scanl' n = composeN n $ S.scanl' (+) 0
 
 {-# INLINE scanlM' #-}
 scanlM' :: MonadIO m => Int -> SerialT m Int -> m ()
@@ -949,7 +949,7 @@ o_1_space_mapping value =
         , benchIOSink value "timestamped" timestamped
 
         -- Scanning
-        , benchIOSink value "scanl'" (scan 1)
+        , benchIOSink value "scanl'" (scanl' 1)
         , benchIOSink value "scanl1'" (scanl1' 1)
         , benchIOSink value "scanlM'" (scanlM' 1)
         , benchIOSink value "postscanl'" (postscanl' 1)
@@ -965,7 +965,7 @@ o_1_space_mappingX4 value =
         , benchIOSink value "mapM" (mapM serially 4)
         , benchIOSink value "trace" (trace 4)
 
-        , benchIOSink value "scan" (scan 4)
+        , benchIOSink value "scanl'" (scanl' 4)
         , benchIOSink value "scanl1'" (scanl1' 4)
         , benchIOSink value "scanlM'" (scanlM' 4)
         , benchIOSink value "postscanl'" (postscanl' 4)

--- a/benchmark/Streamly/Benchmark/Prelude/Serial.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial.hs
@@ -876,6 +876,10 @@ scanl1' n = composeN n $ S.scanl1' (+)
 scanl1M' :: MonadIO m => Int -> SerialT m Int -> m ()
 scanl1M' n = composeN n $ S.scanl1M' (\b a -> return $ b + a)
 
+{-# INLINE scan #-}
+scan :: MonadIO m => Int -> SerialT m Int -> m ()
+scan n = composeN n $ S.scan FL.sum
+
 {-# INLINE postscanl' #-}
 postscanl' :: MonadIO m => Int -> SerialT m Int -> m ()
 postscanl' n = composeN n $ S.postscanl' (+) 0
@@ -883,6 +887,10 @@ postscanl' n = composeN n $ S.postscanl' (+) 0
 {-# INLINE postscanlM' #-}
 postscanlM' :: MonadIO m => Int -> SerialT m Int -> m ()
 postscanlM' n = composeN n $ S.postscanlM' (\b a -> return $ b + a) (return 0)
+
+{-# INLINE postscan #-}
+postscan :: MonadIO m => Int -> SerialT m Int -> m ()
+postscan n = composeN n $ S.postscan FL.sum
 
 {-# INLINE sequence #-}
 sequence ::
@@ -965,6 +973,8 @@ o_1_space_mapping value =
         , benchIOSink value "postscanl'" (postscanl' 1)
         , benchIOSink value "postscanlM'" (postscanlM' 1)
 
+        , benchIOSink value "scan" (scan 1)
+        , benchIOSink value "postscan" (postscan 1)
         ]
     ]
 

--- a/benchmark/Streamly/Benchmark/Prelude/WAsync.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/WAsync.hs
@@ -62,6 +62,10 @@ o_1_space_concatFoldable value =
             (sourceFoldMapWithStream value)
         , benchIOSrc wAsyncly "foldMapWithM (<>) (List)"
             (sourceFoldMapWithM value)
+        , benchIOSrc serially "S.concatFoldableWith (<>) (List)"
+            (concatFoldableWith value)
+        , benchIOSrc serially "S.concatForFoldableWith (<>) (List)"
+            (concatForFoldableWith value)
         , benchIOSrc wAsyncly "foldMapM (List)" (sourceFoldMapM value)
         ]
     ]

--- a/benchmark/Streamly/Benchmark/Prelude/WAsync.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/WAsync.hs
@@ -50,6 +50,43 @@ o_1_space_mapping value =
     ]
 
 -------------------------------------------------------------------------------
+-- Joining
+-------------------------------------------------------------------------------
+
+{-# INLINE wAsync2 #-}
+wAsync2 :: Int -> Int -> IO ()
+wAsync2 count n =
+    S.drain $
+        (sourceUnfoldrM count n) `wAsync` (sourceUnfoldrM count (n + 1))
+
+{-# INLINE wAsync4 #-}
+wAsync4 :: Int -> Int -> IO ()
+wAsync4 count n =
+    S.drain $
+                  (sourceUnfoldrM count (n + 0))
+        `wAsync` (sourceUnfoldrM count (n + 1))
+        `wAsync` (sourceUnfoldrM count (n + 2))
+        `wAsync` (sourceUnfoldrM count (n + 3))
+
+{-# INLINE wAsync2n2 #-}
+wAsync2n2 :: Int -> Int -> IO ()
+wAsync2n2 count n =
+    S.drain $
+        ((sourceUnfoldrM count (n + 0))
+            `wAsync` (sourceUnfoldrM count (n + 1)))
+        `wAsync` ((sourceUnfoldrM count (n + 2))
+            `wAsync` (sourceUnfoldrM count (n + 3)))
+
+o_1_space_joining :: Int -> [Benchmark]
+o_1_space_joining value =
+    [ bgroup "joining"
+        [ benchIOSrc1 "wAsync (2 of n/2)" (wAsync2 (value `div` 2))
+        , benchIOSrc1 "wAsync (4 of n/4)" (wAsync4 (value `div` 4))
+        , benchIOSrc1 "wAsync (2 of (2 of n/4)" (wAsync2n2 (value `div` 4))
+        ]
+    ]
+
+-------------------------------------------------------------------------------
 -- Concat
 -------------------------------------------------------------------------------
 
@@ -140,6 +177,7 @@ main = do
         [ bgroup (o_1_space_prefix moduleName) $ concat
             [ o_1_space_generation value
             , o_1_space_mapping value
+            , o_1_space_joining value
             , o_1_space_concatFoldable value
             , o_1_space_concatMap value
             ]

--- a/benchmark/Streamly/Benchmark/Prelude/ZipAsync.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/ZipAsync.hs
@@ -22,14 +22,14 @@ moduleName = "Prelude.ZipAsync"
 -- Zipping
 -------------------------------------------------------------------------------
 
-{-# INLINE zipAsync #-}
-zipAsync :: (S.IsStream t, S.MonadAsync m) => Int -> Int -> t m (Int, Int)
-zipAsync count n =
+{-# INLINE zipAsyncWith #-}
+zipAsyncWith :: (S.IsStream t, S.MonadAsync m) => Int -> Int -> t m (Int, Int)
+zipAsyncWith count n =
     S.zipAsyncWith (,) (sourceUnfoldrM count n) (sourceUnfoldrM count (n + 1))
 
-{-# INLINE zipAsyncM #-}
-zipAsyncM :: (S.IsStream t, S.MonadAsync m) => Int -> Int -> t m (Int, Int)
-zipAsyncM count n =
+{-# INLINE zipAsyncWithM #-}
+zipAsyncWithM :: (S.IsStream t, S.MonadAsync m) => Int -> Int -> t m (Int, Int)
+zipAsyncWithM count n =
     S.zipAsyncWithM
         (curry return)
         (sourceUnfoldrM count n)
@@ -44,8 +44,10 @@ zipAsyncAp count n =
 o_1_space_joining :: Int -> [Benchmark]
 o_1_space_joining value =
     [ bgroup "joining"
-        [ benchIOSrc serially "zipAsync (2,x/2)" (zipAsync (value `div` 2))
-        , benchIOSrc serially "zipAsyncM (2,x/2)" (zipAsyncM (value `div` 2))
+        [ benchIOSrc serially "zipAsyncWith (2,x/2)" (zipAsyncWith
+                                                      (value `div` 2))
+        , benchIOSrc serially "zipAsyncWithM (2,x/2)" (zipAsyncWithM
+                                                       (value `div` 2))
         , benchIOSrc serially "zipAsyncAp (2,x/2)" (zipAsyncAp (value `div` 2))
         , benchIOSink value "fmap zipAsyncly" $ fmapN S.zipAsyncly 1
         ]

--- a/benchmark/Streamly/Benchmark/Prelude/ZipSerial.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/ZipSerial.hs
@@ -19,7 +19,7 @@
 {-# OPTIONS_GHC -fplugin Test.Inspection.Plugin #-}
 #endif
 
-import Prelude hiding (zip)
+import Prelude hiding (zipWith)
 
 import Streamly.Prelude (MonadAsync)
 import qualified Streamly.Prelude  as S
@@ -54,9 +54,9 @@ sourceUnfoldrM count start = S.unfoldrM step start
         then return Nothing
         else return (Just (cnt, cnt + 1))
 
-{-# INLINE zip #-}
-zip :: Int -> Int -> IO ()
-zip count n =
+{-# INLINE zipWith #-}
+zipWith :: Int -> Int -> IO ()
+zipWith count n =
     S.drain $
     S.zipWith
         (,)
@@ -64,14 +64,14 @@ zip count n =
         (S.serially $ sourceUnfoldrM count (n + 1))
 
 #ifdef INSPECTION
-inspect $ hasNoTypeClasses 'zip
-inspect $ 'zip `hasNoType` ''SPEC
-inspect $ 'zip `hasNoType` ''D.Step
+inspect $ hasNoTypeClasses 'zipWith
+inspect $ 'zipWith `hasNoType` ''SPEC
+inspect $ 'zipWith `hasNoType` ''D.Step
 #endif
 
-{-# INLINE zipM #-}
-zipM :: Int -> Int -> IO ()
-zipM count n =
+{-# INLINE zipWithM #-}
+zipWithM :: Int -> Int -> IO ()
+zipWithM count n =
     S.drain $
     S.zipWithM
         (curry return)
@@ -79,16 +79,16 @@ zipM count n =
         (sourceUnfoldrM count (n + 1))
 
 #ifdef INSPECTION
-inspect $ hasNoTypeClasses 'zipM
-inspect $ 'zipM `hasNoType` ''SPEC
-inspect $ 'zipM `hasNoType` ''D.Step
+inspect $ hasNoTypeClasses 'zipWithM
+inspect $ 'zipWithM `hasNoType` ''SPEC
+inspect $ 'zipWithM `hasNoType` ''D.Step
 #endif
 
 o_1_space_joining :: Int -> [Benchmark]
 o_1_space_joining value =
     [ bgroup "joining"
-        [ benchIOSrc1 "zip (2,x/2)" (zip (value `div` 2))
-        , benchIOSrc1 "zipM (2,x/2)" (zipM (value `div` 2))
+        [ benchIOSrc1 "zip (2,x/2)" (zipWith (value `div` 2))
+        , benchIOSrc1 "zipM (2,x/2)" (zipWithM (value `div` 2))
         ]
     ]
 

--- a/benchmark/lib/Streamly/Benchmark/Prelude.hs
+++ b/benchmark/lib/Streamly/Benchmark/Prelude.hs
@@ -23,6 +23,7 @@ import GHC.Exception (ErrorCall)
 import System.Random (randomRIO)
 
 import qualified Data.Foldable as F
+import qualified Data.List as List
 import qualified Streamly.Prelude  as S
 import qualified Streamly.Internal.Data.Stream.IsStream as Internal
 import qualified Streamly.Internal.Data.Pipe as Pipe
@@ -286,6 +287,23 @@ transformZipMapM t n =
 sourceFoldMapWith :: (S.IsStream t, Semigroup (t m Int))
     => Int -> Int -> t m Int
 sourceFoldMapWith value n = S.concatMapFoldableWith (<>) S.yield [n..n+value]
+
+{-# INLINE concatForFoldableWith #-}
+concatForFoldableWith :: (S.IsStream t, Semigroup (t m Int))
+    => Int -> Int -> t m Int
+concatForFoldableWith value n =
+    S.concatForFoldableWith (<>) [n..n+value] S.yield
+
+{-# INLINE concatFoldableWith #-}
+concatFoldableWith :: (S.IsStream t, Semigroup (t m Int))
+    => Int -> Int -> t m Int
+concatFoldableWith value n =
+    let step x =
+            if x <= n + value
+            then Just (S.yield x, x + 1)
+            else Nothing
+        list = List.unfoldr step n
+     in S.concatFoldableWith (<>) list
 
 {-# INLINE sourceFoldMapWithStream #-}
 sourceFoldMapWithStream :: (S.IsStream t, Semigroup (t m Int))

--- a/benchmark/lib/Streamly/Benchmark/Prelude.hs
+++ b/benchmark/lib/Streamly/Benchmark/Prelude.hs
@@ -130,6 +130,14 @@ absTimes :: (S.IsStream t, S.MonadAsync m, Functor (t m))
 absTimes value _ = S.take value Internal.absTimes
 
 -------------------------------------------------------------------------------
+-- Buffering
+-------------------------------------------------------------------------------
+
+{-# INLINE mkAsync #-}
+mkAsync :: (S.MonadAsync m, S.IsStream t) => (t m a -> S.SerialT m a) -> t m a -> m ()
+mkAsync adapter = S.drain . adapter . S.mkAsync
+
+-------------------------------------------------------------------------------
 -- Elimination
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
## src/Streamly/Prelude.hs
- [x] mkAsync
- [ ] serially
- [ ] wSerially
- [ ] asyncly
- [ ] aheadly
- [ ] wAsyncly
- [ ] parallely
- [X] zipSerially
- [X] zipAsyncly
- [X] adapt
- [ ] nil
- [ ] cons
- [ ] (.:)
- [ ] consM
- [ ] (|:)
- [ ] yield
- [ ] yieldM
- [X] repeat
- [X] repeatM
- [X] replicate
- [X] replicateM
- [X] enumerate
- [X] enumerateTo
- [X] unfoldr
- [X] unfoldrM
- [x] unfold
- [X] iterate
- [X] iterateM
- [X] fromIndices
- [X] fromIndicesM
- [X] fromList
- [X] fromListM
- [X] fromFoldable
- [X] fromFoldableM
- [X] uncons
- [X] tail
- [X] init
- [X] foldrM
- [X] foldr
- [X] foldl'
- [X] foldl1'
- [X] foldlM'
- [x] fold
- [X] drain
- [X] last
- [X] length
- [X] sum
- [X] product
- [X] maximumBy
- [X] maximum
- [X] minimumBy
- [X] minimum
- [X] the
- [X] toList
- [X] drainN
- [X] drainWhile
- [X] (!!)
- [ ] head (Commented)
- [X] findM
- [X] find
- [X] lookup
- [X] findIndex
- [X] elemIndex
- [ ] null (Commented)
- [X] elem
- [X] notElem
- [X] all
- [X] any
- [X] and
- [X] or
- [X] eqBy
- [X] cmpBy
- [X] isPrefixOf
- [X] isSubsequenceOf
- [X] stripPrefix
- [X] (|$)
- [x] (|&)
- [X] (|$.)
- [x] (|&.)
- [X] map
- [X] sequence
- [X] mapM
- [X] mapM_
- [X] trace
- [X] tap
- [X] scanl'
- [X] scanlM'
- [X] postscanl'
- [X] postscanlM'
- [X] scanl1'
- [X] scanl1M'
- [x] scan
- [x] postscan
- [X] filter
- [X] filterM
- [X] mapMaybe
- [X] mapMaybeM
- [X] deleteBy
- [X] uniq
- [X] insertBy
- [X] intersperseM
- [X] intersperse
- [X] indexed
- [X] indexedR
- [X] reverse
- [X] take
- [X] takeWhile
- [ ] takeWhileM (Commented)
- [X] drop
- [X] dropWhile
- [X] dropWhileM
- [X] chunksOf
- [ ] intervalsOf (Commented)
- [X] findIndices
- [X] elemIndices
- [X] splitOn
- [X] splitOnSuffix
- [X] splitWithSuffix
- [X] groups
- [X] groupsBy
- [X] groupsByRolling
- [x] serial
- [x] wSerial
- [x] ahead
- [x] async
- [x] wAsync
- [x] parallel
- [X] mergeBy
- [X] mergeByM
- [X] mergeAsyncBy
- [X] mergeAsyncByM
- [X] zipWith
- [X] zipWithM
- [X] zipAsyncWith
- [X] zipAsyncWithM
- [X] concatMapWith
- [X] concatMap
- [X] concatMapM
- [X] concatUnfold
- [x] concatFoldableWith
- [X] concatMapFoldableWith
- [x] concatForFoldableWith
- [X] before
- [X] after
- [X] bracket
- [X] onException
- [X] finally
- [X] handle
- [X] maxThreads
- [X] maxBuffer
- [X] rate
- [X] avgRate
- [X] minRate
- [X] maxRate
- [X] constRate
- ~[ ] once (Depracated)~
- ~[ ] each (Depracated)~
- ~[ ] scanx (Depracated)~
- ~[ ] foldx (Depracated)~
- ~[ ] foldxM (Depracated)~
- ~[ ] foldr1 (Depracated)~
- ~[ ] runStream (Depracated)~
- ~[ ] runN (Depracated)~
- ~[ ] runWhile (Depracated)~
- ~[ ] fromHandle (Depracated)~
- ~[ ] toHandle (Depracated)~

## src/Streamly/Data/Fold.hs
The test suite is named internal, it should be renamed to just
Data.Fold.
- [X] drain
- [X] drainBy
- [X] last
- [X] length
- [X] sum
- [X] product
- [X] maximumBy
- [X] maximum
- [X] minimumBy
- [X] minimum
- [X] mean
- [X] variance
- [X] stdDev
- [X] mconcat
- [X] foldMap
- [X] foldMapM
- [X] toList
- [X] index
- [X] head
- [X] find
- [X] lookup
- [X] findIndex
- [X] elemIndex
- [X] null
- [X] elem
- [X] notElem
- [X] all
- [X] any
- [X] and
- [X] or
- [X] sequence
- [X] mapM
- [X] tee
- [X] distribute
- [X] partition
- [X] unzip

## src/Streamly/Data/Unfold.hs

## src/Streamly/Unicode/Stream.hs
- [X] decodeLatin1
- [X] decodeUtf8
- [ ] decodeUtf8' (Commented)
- [x] encodeLatin1
- [X] encodeLatin1'
- [X] encodeUtf8
- [ ] encodeUtf8' (Commented)

## src/Streamly/Data/Array/Storable/Foreign.hs
test-suite is named array-test, should be renamed.
- [X] A.fromListN
- [X] A.fromList
- [X] A.writeN
- [X] A.write
- [X] A.toList (Used in other tests)
- [X] A.read
- [X] A.length

## src/Streamly/FileSystem/Handle.hs
- [X] read
- [x] readWithBufferOf
- [ ] readChunks (Commented)
- [ ] readChunksWithBufferOf (Commented)
- [X] write
- [x] writeWithBufferOf
- [X] writeChunks

## ~src/Streamly/Data/Unicode/Stream.hs (Deprecated)~
- ~[ ] decodeLatin1~
- ~[ ] decodeUtf8~
- ~[ ] encodeLatin1~
- ~[ ] encodeUtf8~
- ~[ ] decodeUtf8Lax~
- ~[ ] encodeLatin1Lax~
- ~[ ] encodeUtf8Lax~

## ~src/Streamly/Memory/Array.hs (Deprecated)~
- ~[ ] A.fromListN~
- ~[ ] A.fromList~
- ~[ ] A.toList~
- ~[ ] A.read~
- ~[ ] A.length~

## src/Streamly/Network/Socket.hs
- [ ] accept
- [ ] read
- [ ] readWithBufferOf
- [ ] readChunks
- [ ] readChunksWithBufferOf
- [ ] write
- [ ] writeWithBufferOf
- [ ] writeChunks

## src/Streamly/Network/Inet/TCP.hs
- [ ] acceptOnAddr
- [ ] acceptOnPort
- [ ] acceptOnPortLocal
- [ ] connect
