### PR TITLE
Add tests for operations in Streamly.Prelude.

### DIFF
--- a/test/Streamly/Test/Prelude/Ahead.hs
+++ b/test/Streamly/Test/Prelude/Ahead.hs
@@ -55,6 +55,10 @@ main = hspec
 
     describe "Construction" $ do
         aheadOps    $ prop "aheadly replicateM" . constructWithReplicateM
+        aheadOps $ prop "aheadly cons" . constructWithCons S.cons
+        aheadOps $ prop "aheadly consM" . constructWithConsM S.consM id
+        aheadOps $ prop "aheadly (.:)" . constructWithCons (S..:)
+        aheadOps $ prop "aheadly (|:)" . constructWithConsM (S.|:) id
 
     describe "Functor operations" $ do
         aheadOps     $ functorOps S.fromFoldable "aheadly" (==)
@@ -121,7 +125,7 @@ main = hspec
     describe "Stream serial elimination operations" $ do
         aheadOps     $ eliminationOpsOrdered S.fromFoldable "aheadly"
         aheadOps     $ eliminationOpsOrdered folded "aheadly folded"
-    
+
     describe "Composed MonadThrow aheadly" $ composeWithMonadThrow S.aheadly
 
     -- Ad-hoc tests

--- a/test/Streamly/Test/Prelude/Ahead.hs
+++ b/test/Streamly/Test/Prelude/Ahead.hs
@@ -94,6 +94,8 @@ main = hspec
         -- We test only the serial zip with serial streams and the parallel
         -- stream, because the rate setting in these streams can slow down
         -- zipAsync.
+        aheadOps    $ prop "zip applicative aheadly" . zipAsyncApplicative S.fromFoldable (==)
+        aheadOps    $ prop "zip applicative aheadly folded" . zipAsyncApplicative folded (==)
         aheadOps    $ prop "zip monadic aheadly" . zipAsyncMonadic S.fromFoldable (==)
         aheadOps    $ prop "zip monadic aheadly folded" . zipAsyncMonadic folded (==)
 

--- a/test/Streamly/Test/Prelude/Ahead.hs
+++ b/test/Streamly/Test/Prelude/Ahead.hs
@@ -126,6 +126,7 @@ main = hspec
         aheadOps     $ eliminationOpsOrdered S.fromFoldable "aheadly"
         aheadOps     $ eliminationOpsOrdered folded "aheadly folded"
 
+    describe "Tests for exceptions" $ aheadOps $ exceptionOps "aheadly"
     describe "Composed MonadThrow aheadly" $ composeWithMonadThrow S.aheadly
 
     -- Ad-hoc tests

--- a/test/Streamly/Test/Prelude/Async.hs
+++ b/test/Streamly/Test/Prelude/Async.hs
@@ -36,6 +36,10 @@ main = hspec
 
     describe "Construction" $ do
         asyncOps    $ prop "asyncly replicateM" . constructWithReplicateM
+        asyncOps $ prop "asyncly cons" . constructWithCons S.cons
+        asyncOps $ prop "asyncly consM" . constructWithConsM S.consM sort
+        asyncOps $ prop "asyncly (.:)" . constructWithCons (S..:)
+        asyncOps $ prop "asyncly (|:)" . constructWithConsM (S.|:) sort
 
     describe "Functor operations" $ do
         asyncOps     $ functorOps S.fromFoldable "asyncly" sortEq

--- a/test/Streamly/Test/Prelude/Async.hs
+++ b/test/Streamly/Test/Prelude/Async.hs
@@ -68,6 +68,8 @@ main = hspec
         -- We test only the serial zip with serial streams and the parallel
         -- stream, because the rate setting in these streams can slow down
         -- zipAsync.
+        asyncOps    $ prop "zip applicative asyncly" . zipAsyncApplicative S.fromFoldable (==)
+        asyncOps    $ prop "zip applicative asyncly folded" . zipAsyncApplicative folded (==)
         asyncOps    $ prop "zip monadic asyncly" . zipAsyncMonadic S.fromFoldable (==)
         asyncOps    $ prop "zip monadic asyncly folded" . zipAsyncMonadic folded (==)
 

--- a/test/Streamly/Test/Prelude/Async.hs
+++ b/test/Streamly/Test/Prelude/Async.hs
@@ -101,6 +101,7 @@ main = hspec
     describe "Async mappend time order check" $ parallelCheck asyncly mappend
 #endif
 
+    describe "Tests for exceptions" $ asyncOps $ exceptionOps "asyncly"
     describe "Composed MonadThrow asyncly" $ composeWithMonadThrow asyncly
 
     -- Ad-hoc tests

--- a/test/Streamly/Test/Prelude/Common.hs
+++ b/test/Streamly/Test/Prelude/Common.hs
@@ -338,8 +338,10 @@ constructWithEnumerateTo ::
 constructWithEnumerateTo listT op len =
     withMaxSuccess maxTestCount $
     monadicIO $ do
-        strm <- run $ S.toList . op $ S.enumerateTo (fromIntegral len)
-        let list = enumFromTo minBound (fromIntegral len)
+        -- It takes forever to enumerate from minBound to len, so
+        -- instead we just do till len elements
+        strm <- run $ S.toList . op $ S.enumerateTo (minBound + fromIntegral len)
+        let list = enumFromTo minBound (minBound + fromIntegral len)
         listEquals (==) (listT strm) list
 
 constructWithFromList ::

--- a/test/Streamly/Test/Prelude/Common.hs
+++ b/test/Streamly/Test/Prelude/Common.hs
@@ -10,7 +10,9 @@
 module Streamly.Test.Prelude.Common
     (
     -- * Construction operations
-      constructWithReplicate
+      constructWithRepeat
+    , constructWithRepeatM 
+    , constructWithReplicate
     , constructWithReplicateM
     , constructWithIntFromThenTo
 #if __GLASGOW_HASKELL__ >= 806
@@ -18,10 +20,18 @@ module Streamly.Test.Prelude.Common
 #endif
     , constructWithIterate
     , constructWithIterateM
+    , constructWithEnumerate
+    , constructWithEnumerateTo
     , constructWithFromIndices
     , constructWithFromIndicesM
+    , constructWithFromList
+    , constructWithFromListM
+    , constructWithUnfoldr
     , constructWithCons
     , constructWithConsM
+    , constructWithYield
+    , constructWithYieldM
+    , simpleOps
     -- * Applicative operations
     , applicativeOps
     , applicativeOps1
@@ -196,12 +206,12 @@ constructWithRepeat, constructWithRepeatM
 constructWithRepeat = constructWithLenM stream list
   where
     stream n = S.take n $ S.repeat 1
-    list n = return $ take n $ repeat 1
+    list n = return $ replicate n 1
 
 constructWithRepeatM = constructWithLenM stream list
   where
     stream n = S.take n $ S.repeatM (return 1)
-    list n = return $ take n $ repeat 1
+    list n = return $ replicate n 1
 
 #if __GLASGOW_HASKELL__ >= 806
 -- XXX try very small steps close to 0
@@ -408,8 +418,7 @@ constructWithYieldM listT op len =
         listEquals (==) (listT strm) list
 
 simpleProps ::
-       IsStream t
-    => (Int -> t IO Int)
+       (Int -> t IO Int)
     -> (t IO Int -> SerialT IO Int)
     -> Int
     -> Property

--- a/test/Streamly/Test/Prelude/Common.hs
+++ b/test/Streamly/Test/Prelude/Common.hs
@@ -1148,8 +1148,6 @@ transformCombineOpsCommon constr desc eq t = do
                                        (S.scanlM' (\_ a -> return a) (return 0))
     prop (desc <> " postscanlM'") $ transform (tail . scanl' (const id) 0) t
                                        (S.postscanlM' (\_ a -> return a) (return 0))
-    prop (desc <> " scanl") $ transform (scanl' (const id) 0) t
-                                       (S.scanl' (const id) 0)
     prop (desc <> " scanl1'") $ transform (scanl1 (const id)) t
                                          (S.scanl1' (const id))
     prop (desc <> " scanl1M'") $ transform (scanl1 (const id)) t

--- a/test/Streamly/Test/Prelude/Common.hs
+++ b/test/Streamly/Test/Prelude/Common.hs
@@ -127,6 +127,7 @@ import Streamly.Prelude
 import qualified Streamly.Prelude as S
 import qualified Streamly.Data.Fold as FL
 import qualified Streamly.Internal.Data.Fold as FL
+import qualified Streamly.Internal.Data.Unfold as UF
 
 import Streamly.Test.Common
 
@@ -1178,6 +1179,15 @@ transformCombineOpsCommon constr desc eq t = do
         forAll (choose (0, 100)) $ \n ->
             transform (concatMap (const [1..n]))
                 t (S.concatMap (const (S.fromList [1..n])))
+    prop (desc <> " concatMapM") $
+        forAll (choose (0, 100)) $ \n ->
+            transform (concatMap (const [1..n]))
+                t (S.concatMapM (const (return $ S.fromList [1..n])))
+    prop (desc <> " concatUnfold") $
+        forAll (choose (0, 100)) $ \n ->
+            transform (concatMap (const [1..n]))
+                t (S.concatUnfold (UF.lmap (const undefined)
+                                   $ UF.supply UF.fromList [1..n]))
 
 toListFL :: Monad m => FL.Fold m a [a]
 toListFL = FL.toList

--- a/test/Streamly/Test/Prelude/Common.hs
+++ b/test/Streamly/Test/Prelude/Common.hs
@@ -391,7 +391,11 @@ constructWithUnfoldr listT op len =
             else Just (seed, seed + 1)
 
 constructWithYield ::
-       IsStream t
+       (IsStream t
+#if __GLASGOW_HASKELL__ < 806
+       , Monoid (t IO Int)
+#endif
+       )
     => ([Int] -> [Int])
     -> (t IO Int -> SerialT IO Int)
     -> Word8
@@ -407,7 +411,11 @@ constructWithYield listT op len =
         listEquals (==) (listT strm) list
 
 constructWithYieldM ::
-       IsStream t
+       (IsStream t
+#if __GLASGOW_HASKELL__ < 806
+       , Monoid (t IO Int)
+#endif
+       )
     => ([Int] -> [Int])
     -> (t IO Int -> SerialT IO Int)
     -> Word8
@@ -1067,7 +1075,11 @@ transformCombineFromList constr eq listOp t op a b c =
 -- transformCombineOpsOrdered work only for ordered stream types i.e. excluding
 -- the Async type.
 transformCombineOpsCommon
-    :: (IsStream t, Semigroup (t IO Int))
+    :: (IsStream t, Semigroup (t IO Int)
+#if __GLASGOW_HASKELL__ < 806
+       , Functor (t IO)
+#endif
+       )
     => ([Int] -> t IO Int)
     -> String
     -> ([Int] -> [Int] -> Bool)
@@ -1404,7 +1416,7 @@ afterProp t vec =
         assert refValue
         assert $ sort strm == sort vec
 
-bracketProp :: (IsStream t) => (t IO Int -> SerialT IO Int) -> [Int] -> Property
+bracketProp :: IsStream t => (t IO Int -> SerialT IO Int) -> [Int] -> Property
 bracketProp t vec =
     withMaxSuccess maxTestCount $
     monadicIO $ do
@@ -1444,7 +1456,11 @@ _bracketPartialStreamProp t vec =
                 assert $ refValue == 1
 
 bracketExceptionProp ::
-       (IsStream t, MonadThrow (t IO))
+       (IsStream t, MonadThrow (t IO)
+#if __GLASGOW_HASKELL__ < 806
+       , Semigroup (t IO Int)
+#endif
+       )
     => (t IO Int -> SerialT IO Int)
     -> Property
 bracketExceptionProp t =
@@ -1496,7 +1512,11 @@ _finallyPartialStreamProp t vec =
                 assert $ refValue == 1
 
 finallyExceptionProp ::
-       (IsStream t, MonadThrow (t IO))
+       (IsStream t, MonadThrow (t IO)
+#if __GLASGOW_HASKELL__ < 806
+       , Semigroup (t IO Int)
+#endif
+       )
     => (t IO Int -> SerialT IO Int)
     -> Property
 finallyExceptionProp t =
@@ -1514,7 +1534,11 @@ finallyExceptionProp t =
         assert $ refValue == 1
 
 onExceptionProp ::
-       (IsStream t, MonadThrow (t IO))
+       (IsStream t, MonadThrow (t IO)
+#if __GLASGOW_HASKELL__ < 806
+       , Semigroup (t IO Int)
+#endif
+       )
     => (t IO Int -> SerialT IO Int)
     -> Property
 onExceptionProp t =
@@ -1548,7 +1572,11 @@ handleProp t vec =
         assert $ res == vec ++ [0] ++ vec
 
 exceptionOps ::
-       (IsStream t, MonadThrow (t IO))
+       (IsStream t, MonadThrow (t IO)
+#if __GLASGOW_HASKELL__ < 806
+       , Semigroup (t IO Int)
+#endif
+       )
     => String
     -> (t IO Int -> SerialT IO Int)
     -> Spec

--- a/test/Streamly/Test/Prelude/Common.hs
+++ b/test/Streamly/Test/Prelude/Common.hs
@@ -293,9 +293,9 @@ constructWithCons cons op len =
     withMaxSuccess maxTestCount $
     monadicIO $ do
         strm <-
-            run $
-            S.toList . op . S.take (fromIntegral len) $
-            foldr cons S.nil (repeat 0)
+            run
+               $ S.toList . op . S.take (fromIntegral len)
+               $ foldr cons S.nil (repeat 0)
         let list = replicate (fromIntegral len) 0
         listEquals (==) strm list
 
@@ -387,8 +387,8 @@ constructWithUnfoldr listT op len =
   where
     unfoldStep seed =
         if seed > fromIntegral len
-            then Nothing
-            else Just (seed, seed + 1)
+        then Nothing
+        else Just (seed, seed + 1)
 
 constructWithYield ::
        (IsStream t
@@ -404,9 +404,9 @@ constructWithYield listT op len =
     withMaxSuccess maxTestCount $
     monadicIO $ do
         strm <-
-            run $
-            S.toList . op . S.take (fromIntegral len) $
-            foldMap S.yield (repeat 0)
+            run
+                $ S.toList . op . S.take (fromIntegral len)
+                $ foldMap S.yield (repeat 0)
         let list = replicate (fromIntegral len) 0
         listEquals (==) (listT strm) list
 
@@ -424,9 +424,9 @@ constructWithYieldM listT op len =
     withMaxSuccess maxTestCount $
     monadicIO $ do
         strm <-
-            run $
-            S.toList . op . S.take (fromIntegral len) $
-            foldMap S.yieldM (repeat (return 0))
+            run
+                $ S.toList . op . S.take (fromIntegral len)
+                $ foldMap S.yieldM (repeat (return 0))
         let list = replicate (fromIntegral len) 0
         listEquals (==) (listT strm) list
 

--- a/test/Streamly/Test/Prelude/Parallel.hs
+++ b/test/Streamly/Test/Prelude/Parallel.hs
@@ -40,6 +40,10 @@ main = hspec
 
     describe "Construction" $ do
         parallelOps $ prop "parallely replicateM" . constructWithReplicateM
+        parallelOps $ prop "parallely cons" . constructWithCons S.cons
+--      parallelOps $ prop "parallely consM" . constructWithConsM S.consM sort
+        parallelOps $ prop "parallely (.:)" . constructWithCons (S..:)
+--      parallelOps $ prop "parallely (|:)" . constructWithConsM (S.|:) sort
 
     describe "Functor operations" $ do
         parallelOps $ functorOps S.fromFoldable "parallely" sortEq

--- a/test/Streamly/Test/Prelude/Parallel.hs
+++ b/test/Streamly/Test/Prelude/Parallel.hs
@@ -105,6 +105,7 @@ main = hspec
     describe "Parallel mappend time order check" $ parallelCheck parallely mappend
 #endif
 
+    describe "Tests for exceptions" $ parallelOps $ exceptionOps "parallely"
     describe "Composed MonadThrow parallely" $ composeWithMonadThrow parallely
 
 #ifdef DEVBUILD

--- a/test/Streamly/Test/Prelude/Serial.hs
+++ b/test/Streamly/Test/Prelude/Serial.hs
@@ -470,6 +470,10 @@ main = hspec
         serialOps   $ prop "serially iterateM" . constructWithIterateM
         serialOps $ prop "serially fromIndices" . constructWithFromIndices
         serialOps $ prop "serially fromIndicesM" . constructWithFromIndicesM
+        serialOps $ prop "serially cons" . constructWithCons S.cons
+        serialOps $ prop "serially consM" . constructWithConsM S.consM id
+        serialOps $ prop "serially (.:)" . constructWithCons (S..:)
+        serialOps $ prop "serially (|:)" . constructWithConsM (S.|:) id
 
         describe "From Generators" $ do
             prop "unfold" unfold

--- a/test/Streamly/Test/Prelude/Serial.hs
+++ b/test/Streamly/Test/Prelude/Serial.hs
@@ -478,6 +478,9 @@ main = hspec
         --     (toListSerial mzero) `shouldReturn` ([] :: [Int])
 
     describe "Construction" $ do
+        -- Add all the construction tests for all stream types.
+        serialOps   $ prop "serially repeat" . constructWithRepeat
+        serialOps   $ prop "serially repeatM" . constructWithRepeatM
         serialOps   $ prop "serially replicate" . constructWithReplicate
         serialOps   $ prop "serially replicateM" . constructWithReplicateM
         serialOps   $ prop "serially intFromThenTo" .
@@ -489,8 +492,15 @@ main = hspec
         serialOps   $ prop "serially iterate" . constructWithIterate
         -- XXX test for all types of streams
         serialOps   $ prop "serially iterateM" . constructWithIterateM
+        serialOps $ prop "serially enumerate" . constructWithEnumerate id
+        serialOps $ prop "serially enumerateTo" . constructWithEnumerateTo id
         serialOps $ prop "serially fromIndices" . constructWithFromIndices
         serialOps $ prop "serially fromIndicesM" . constructWithFromIndicesM
+        serialOps $ prop "serially fromList" . constructWithFromList id
+        serialOps $ prop "serially fromListM" . constructWithFromListM id
+        serialOps $ prop "serially unfoldr" . constructWithUnfoldr id
+        serialOps $ prop "serially yield" . constructWithYield id
+        serialOps $ prop "serially yieldM" . constructWithYieldM id
         serialOps $ prop "serially cons" . constructWithCons S.cons
         serialOps $ prop "serially consM" . constructWithConsM S.consM id
         serialOps $ prop "serially (.:)" . constructWithCons (S..:)
@@ -499,6 +509,8 @@ main = hspec
         describe "From Generators" $ do
             prop "unfold" unfold
             prop "unfold0" unfold0
+
+    describe "Simple Operations" $ serialOps simpleOps
 
     describe "Functor operations" $ do
         serialOps    $ functorOps S.fromFoldable "serially" (==)

--- a/test/Streamly/Test/Prelude/Serial.hs
+++ b/test/Streamly/Test/Prelude/Serial.hs
@@ -296,6 +296,13 @@ testGroups =
             r <- run $ S.toList $ S.groups FL.toList $ S.fromList vec
             assert $ r == group vec
 
+testGroupsByRolling :: Property
+testGroupsByRolling =
+    forAll (choose (0, maxStreamLen)) $ \len ->
+        forAll (vectorOf len (arbitrary :: Gen Int)) $ \vec -> monadicIO $ do
+            r <- run $ S.toList $ S.groupsByRolling (==) FL.toList $ S.fromList vec
+            assert $ r == group vec
+
 -- |
 -- If the list is empty, returns Nothing,
 -- else wraps the minimum value of the list in Just.
@@ -323,6 +330,13 @@ testGroupsBySep =
                 $ S.groupsBy (>) FL.toList
                 $ S.fromList vec
             assert $ decreasing a == True
+
+groupingOps :: Spec
+groupingOps = do
+    prop "groupsBy" testGroupsBy
+    prop "S.groups = groups" testGroups
+    prop "S.groupsByRolling = groups" testGroupsByRolling
+    prop "testGroupsBySep" testGroupsBySep
 
 associativityCheck
     :: String
@@ -567,10 +581,7 @@ main = hspec
         serialOps    $ eliminationOpsOrdered S.fromFoldable "serially"
         serialOps    $ eliminationOpsOrdered folded "serially folded"
 
-    describe "Tests for S.groupsBy" $ do
-        prop "testGroupsBy" testGroupsBy
-        prop "S.groups = groups" testGroups
-        prop "testGroupsBySep" testGroupsBySep
+    describe "Tests for S.groupsBy" groupingOps
 
     describe "Composed MonadThrow serially" $ composeWithMonadThrow serially
 

--- a/test/Streamly/Test/Prelude/Serial.hs
+++ b/test/Streamly/Test/Prelude/Serial.hs
@@ -583,6 +583,8 @@ main = hspec
 
     describe "Tests for S.groupsBy" groupingOps
 
+    describe "Tests for exceptions" $ serialOps $ exceptionOps "serially"
+
     describe "Composed MonadThrow serially" $ composeWithMonadThrow serially
 
     it "fromCallback" $ testFromCallback `shouldReturn` (50*101)

--- a/test/Streamly/Test/Prelude/Serial.hs
+++ b/test/Streamly/Test/Prelude/Serial.hs
@@ -14,7 +14,7 @@ import Control.Monad ( when, forM_ )
 import Data.Function ( (&) )
 import Data.IORef ( newIORef, readIORef, writeIORef )
 import Data.Int (Int64)
-import Data.List (intercalate)
+import Data.List (group, intercalate)
 import Data.Maybe ( isJust, fromJust )
 import Foreign.Storable (Storable)
 #if __GLASGOW_HASKELL__ < 808
@@ -287,7 +287,14 @@ testGroupsBy =
                     (x:_) -> x == minimum ls)
                 $ S.groupsBy (>) FL.toList
                 $ S.fromList vec
-            assert $ r == True
+            assert r
+
+testGroups :: Property
+testGroups =
+    forAll (choose (0, maxStreamLen)) $ \len ->
+        forAll (vectorOf len (arbitrary :: Gen Int)) $ \vec -> monadicIO $ do
+            r <- run $ S.toList $ S.groups FL.toList $ S.fromList vec
+            assert $ r == group vec
 
 -- |
 -- If the list is empty, returns Nothing,
@@ -562,6 +569,7 @@ main = hspec
 
     describe "Tests for S.groupsBy" $ do
         prop "testGroupsBy" testGroupsBy
+        prop "S.groups = groups" testGroups
         prop "testGroupsBySep" testGroupsBySep
 
     describe "Composed MonadThrow serially" $ composeWithMonadThrow serially

--- a/test/Streamly/Test/Prelude/Serial.hs
+++ b/test/Streamly/Test/Prelude/Serial.hs
@@ -79,7 +79,7 @@ splitOnSeq = do
     where
 
     splitOnSeq' pat xs =
-        S.toList $ IS.splitOnSeq (A.fromList pat) (FL.toList) (S.fromList xs)
+        S.toList $ IS.splitOnSeq (A.fromList pat) FL.toList (S.fromList xs)
 
 splitOnSuffixSeq :: Spec
 splitOnSuffixSeq = do
@@ -105,7 +105,7 @@ splitOnSuffixSeq = do
 
     splitSuffixOn_ pat xs =
         S.toList
-             $ IS.splitOnSuffixSeq (A.fromList pat) (FL.toList) (S.fromList xs)
+             $ IS.splitOnSuffixSeq (A.fromList pat) FL.toList (S.fromList xs)
 
 seqSplitterProperties ::
        forall a. (Arbitrary a, Eq a, Show a, Storable a, Enum a)
@@ -116,7 +116,7 @@ seqSplitterProperties sep desc = do
     describe (desc <> " splitOnSeq")
         $ do
 
-            forM_ [0, 1, 2, 4] $ intercalateSplitEqId
+            forM_ [0, 1, 2, 4] intercalateSplitEqId
             forM_ [0, 1, 2, 4]
                 $ concatSplitIntercalateEqConcat
                       splitOnSeq_
@@ -129,7 +129,7 @@ seqSplitterProperties sep desc = do
     describe (desc <> " splitOnSuffixSeq")
         $ do
 
-            forM_ [0, 1, 2, 4] $ intercalateSplitEqIdNoSepEnd
+            forM_ [0, 1, 2, 4] intercalateSplitEqIdNoSepEnd
             forM_ [0, 1, 2, 4]
                 $ concatSplitIntercalateEqConcat
                       splitOnSuffixSeq_
@@ -329,7 +329,7 @@ testGroupsBySep =
                 $ S.map maybeMinimum
                 $ S.groupsBy (>) FL.toList
                 $ S.fromList vec
-            assert $ decreasing a == True
+            assert $ decreasing a
 
 groupingOps :: Spec
 groupingOps = do

--- a/test/Streamly/Test/Prelude/WAsync.hs
+++ b/test/Streamly/Test/Prelude/WAsync.hs
@@ -73,6 +73,8 @@ main = hspec
         -- stream, because the rate setting in these streams can slow down
         -- zipAsync.
      do
+        wAsyncOps $ prop "zip applicative wAsyncly" . zipAsyncApplicative S.fromFoldable (==)
+        wAsyncOps $ prop "zip applicative wAsyncly folded" . zipAsyncApplicative folded (==)
         wAsyncOps $
             prop "zip monadic wAsyncly" . zipAsyncMonadic S.fromFoldable (==)
         wAsyncOps $ prop "zip monadic wAsyncly folded" . zipAsyncMonadic folded (==)

--- a/test/Streamly/Test/Prelude/WAsync.hs
+++ b/test/Streamly/Test/Prelude/WAsync.hs
@@ -40,6 +40,10 @@ main = hspec
     describe "Construction" $ do
         wAsyncOps $ prop "wAsyncly replicateM" . constructWithReplicateM
         -- XXX add tests for fromIndices
+        wAsyncOps $ prop "wAsyncly cons" . constructWithCons S.cons
+        wAsyncOps $ prop "wAsyncly consM" . constructWithConsM S.consM sort
+        wAsyncOps $ prop "wAsyncly (.:)" . constructWithCons (S..:)
+        wAsyncOps $ prop "wAsyncly (|:)" . constructWithConsM (S.|:) sort
 
     describe "Functor operations" $ do
         wAsyncOps $ functorOps S.fromFoldable "wAsyncly" sortEq
@@ -93,7 +97,7 @@ main = hspec
         wAsyncOps $ eliminationOps folded "wAsyncly folded"
         wAsyncOps $ eliminationOpsWord8 S.fromFoldable "wAsyncly"
         wAsyncOps $ eliminationOpsWord8 folded "wAsyncly folded"
-    
+
     -- describe "WAsync interleaved (<>) ordering check" $
     --     interleaveCheck wAsyncly (<>)
     -- describe "WAsync interleaved mappend ordering check" $

--- a/test/Streamly/Test/Prelude/WAsync.hs
+++ b/test/Streamly/Test/Prelude/WAsync.hs
@@ -109,6 +109,7 @@ main = hspec
     -- describe "WAsync mappend time order check" $
     --     parallelCheck wAsyncly mappend
 
+    describe "Tests for exceptions" $ wAsyncOps $ exceptionOps "wAsyncly"
     describe "Composed MonadThrow wAsyncly" $ composeWithMonadThrow wAsyncly
 
     -- Ad-hoc tests

--- a/test/Streamly/Test/Prelude/WSerial.hs
+++ b/test/Streamly/Test/Prelude/WSerial.hs
@@ -71,6 +71,10 @@ main = hspec
 
     describe "Construction" $ do
         wSerialOps  $ prop "wSerially replicateM" . constructWithReplicateM
+        wSerialOps $ prop "wSerially cons" . constructWithCons S.cons
+        wSerialOps $ prop "wSerially consM" . constructWithConsM S.consM id
+        wSerialOps $ prop "wSerially (.:)" . constructWithCons (S..:)
+        wSerialOps $ prop "wSerially (|:)" . constructWithConsM (S.|:) id
 
     describe "Functor operations" $ do
         wSerialOps   $ functorOps S.fromFoldable "wSerially" (==)

--- a/test/Streamly/Test/Prelude/WSerial.hs
+++ b/test/Streamly/Test/Prelude/WSerial.hs
@@ -153,4 +153,5 @@ main = hspec
     describe "WSerial interleaved mappend ordering check" $
         interleaveCheck wSerially mappend
 
+    describe "Tests for exceptions" $ wSerialOps $ exceptionOps "wSerially"
     describe "Composed MonadThrow wSerially" $ composeWithMonadThrow wSerially

--- a/test/Streamly/Test/Prelude/WSerial.hs
+++ b/test/Streamly/Test/Prelude/WSerial.hs
@@ -70,6 +70,9 @@ main = hspec
 #endif
 
     describe "Construction" $ do
+        wSerialOps  $ prop "wSerially repeat" . constructWithRepeat
+        wSerialOps  $ prop "wSerially repeatM" . constructWithRepeatM
+        wSerialOps  $ prop "wSerially replicateM" . constructWithReplicate
         wSerialOps  $ prop "wSerially replicateM" . constructWithReplicateM
         wSerialOps $ prop "wSerially cons" . constructWithCons S.cons
         wSerialOps $ prop "wSerially consM" . constructWithConsM S.consM id


### PR DESCRIPTION
Added basic tests for 
- cons, consM, (.:), (|:)
- yield, yieldM, repeat, repeatM
- enumerate, enumerateTo
- unfoldr
- fromListM
- drainWhile
- findM
- eqBy, cmpBy
- mapM_, trace
- postscanl', postscanlM'
- mapMaybeM
- dropWhileM
- groups, groupsByRolling
- zipAsyncWith
- concatMapM, concatUnfold
- before, after, bracket, onException, finally, handle