### PR TITLE
Enable inspection tests for interposeSuffix bench

### DIFF
--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
@@ -561,7 +561,7 @@ copyChunksSplitInterposeSuffix inh outh =
 
 #ifdef INSPECTION
 inspect $ hasNoTypeClassesExcept 'copyChunksSplitInterposeSuffix [''Storable]
--- inspect $ 'copyChunksSplitInterposeSuffix `hasNoType` ''Step
+inspect $ 'copyChunksSplitInterposeSuffix `hasNoType` ''Step
 #endif
 
 -- | Words and unwords
@@ -575,7 +575,7 @@ copyChunksSplitInterpose inh outh =
 
 #ifdef INSPECTION
 inspect $ hasNoTypeClassesExcept 'copyChunksSplitInterpose [''Storable]
--- inspect $ 'copyChunksSplitInterpose `hasNoType` ''Step
+inspect $ 'copyChunksSplitInterpose `hasNoType` ''Step
 #endif
 
 o_1_space_copy_toChunks_group_ungroup :: BenchEnv -> [Benchmark]


### PR DESCRIPTION
I think we should start using `fusion-plugin` flag along with `inspection` flag. We can have more inspection tests passing that way.