### PR TITLE
Implement Data.Parser.ParserD.groupBy

### DIFF
--- a/benchmark/Streamly/Benchmark/Data/Parser.hs
+++ b/benchmark/Streamly/Benchmark/Data/Parser.hs
@@ -72,6 +72,10 @@ drainWhile value = IP.parse (PR.drainWhile (<= value))
 takeWhile :: MonadCatch m => Int -> SerialT m Int -> m ()
 takeWhile value = IP.parse (PR.takeWhile (<= value) FL.drain)
 
+{-# INLINE groupBy #-}
+groupBy :: MonadCatch m => SerialT m Int -> m ()
+groupBy = IP.parse (PR.groupBy (<=) FL.drain)
+
 {-# INLINE many #-}
 many :: MonadCatch m => SerialT m Int -> m Int
 many = IP.parse (PR.many FL.length (PR.satisfy (> 0)))
@@ -258,6 +262,7 @@ o_1_space_serial value =
     [ benchIOSink value "takeEQ" $ takeEQ value
     , benchIOSink value "takeWhile" $ takeWhile value
     , benchIOSink value "drainWhile" $ drainWhile value
+    , benchIOSink value "groupBy" $ groupBy
     , benchIOSink value "splitAp" $ splitAp value
     , benchIOSink value "splitApBefore" $ splitApBefore value
     , benchIOSink value "splitApAfter" $ splitApAfter value

--- a/benchmark/Streamly/Benchmark/Data/Parser/ParserD.hs
+++ b/benchmark/Streamly/Benchmark/Data/Parser/ParserD.hs
@@ -67,6 +67,10 @@ drainWhile p = PR.takeWhile p FL.drain
 takeWhile :: MonadThrow m => Int -> SerialT m Int -> m ()
 takeWhile value = IP.parseD (drainWhile (<= value))
 
+{-# INLINE groupBy #-}
+groupBy :: MonadThrow m => SerialT m Int -> m ()
+groupBy = IP.parseD (PR.groupBy (<=) FL.drain)
+
 {-# INLINE many #-}
 many :: MonadCatch m => SerialT m Int -> m Int
 many = IP.parseD (PR.many FL.length (PR.satisfy (> 0)))
@@ -195,6 +199,7 @@ moduleName = "Data.Parser.ParserD"
 o_1_space_serial :: Int -> [Benchmark]
 o_1_space_serial value =
     [ benchIOSink value "takeWhile" $ takeWhile value
+    , benchIOSink value "groupBy" $ groupBy
     , benchIOSink value "split (all,any)" $ splitAllAny value
     , benchIOSink value "many" many
     , benchIOSink value "some" some

--- a/src/Streamly/Internal/Data/Parser.hs
+++ b/src/Streamly/Internal/Data/Parser.hs
@@ -573,10 +573,8 @@ wordBy = undefined
 -- /Unimplemented/
 --
 {-# INLINABLE groupBy #-}
-groupBy ::
-    -- Monad m =>
-    (a -> a -> Bool) -> Fold m a b -> Parser m a b
-groupBy = undefined
+groupBy :: MonadCatch m => (a -> a -> Bool) -> Fold m a b -> Parser m a b
+groupBy cmp = K.toParserK . D.groupBy cmp
 
 -- | Match the given sequence of elements using the given comparison function.
 --

--- a/test/Streamly/Test/Data/Parser.hs
+++ b/test/Streamly/Test/Data/Parser.hs
@@ -625,7 +625,7 @@ main =
         -- prop "Fail when stream length exceeded" lookAheadFail
         -- prop "lookAhead . take n >> lookAhead . take n = lookAhead . take n, else fail" lookAhead
         prop "P.takeWhile = Prelude.takeWhile" Main.takeWhile
-        prop "P.takeWhile = Prelude.takeWhile if taken something, else check why failed" takeWhile1
+        prop "P.takeWhile1 = Prelude.takeWhile if taken something, else check why failed" takeWhile1
         prop "P.groupBy = Prelude.head . Prelude.groupBy" groupBy
         -- prop "" splitWithPass
         -- prop "" splitWithFailLeft


### PR DESCRIPTION
Regressions:
```
Prelude.Serial/o-1-space/grouping/groupsByEq                                          65.92                   +2516.15
Prelude.Serial/o-1-space/grouping/groups                                           34683.66                    +140.63
```
This benchmark is weird. `groupsByEq` and `groups` is the same I believe. `groups = groupsBy (==)`

## TODO:
- [x] Add tests and benchmarks