### PR TITLE
Review/update docs, combinators in Fold module

### DIFF
--- a/src/Streamly/Internal/Data/Fold/Types.hs
+++ b/src/Streamly/Internal/Data/Fold/Types.hs
@@ -139,7 +139,6 @@ module Streamly.Internal.Data.Fold.Types
     , lfilterM
     , lcatMaybes
     , ltake
-    , takeSepBy
     , takeByTime
 
     -- * Distributing
@@ -690,20 +689,6 @@ ltake n (Fold fstep finitial fextract) = Fold step initial extract
         | otherwise = Done <$> fextract r
 
     extract (Tuple' _ r) = fextract r
-
--- | Takes elements from the input as long as the predicate succeeds.
---
--- @since 0.7.0
-{-# INLINE takeSepBy #-}
-takeSepBy :: Monad m => (a -> Bool) -> Fold m a b -> Fold m a b
-takeSepBy predicate (Fold fstep finitial fextract) = Fold step finitial fextract
-
-    where
-
-    step s a =
-        if predicate a
-        then fstep s a
-        else Done <$> fextract s
 
 ------------------------------------------------------------------------------
 -- Nesting

--- a/src/Streamly/Internal/Data/Stream/StreamD.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD.hs
@@ -1522,7 +1522,7 @@ reverse' m =
 {-# INLINE_NORMAL splitSuffixWith #-}
 splitSuffixWith :: Monad m
     => (a -> Bool) -> Fold m a b -> Stream m a -> Stream m b
-splitSuffixWith predicate f = foldMany1 (FL.sliceSepWith predicate f)
+splitSuffixWith predicate f = foldMany1 (FL.sliceEndWith predicate f)
 
 {-# INLINE_NORMAL groupsBy #-}
 groupsBy :: Monad m

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -679,6 +679,7 @@ test-suite Data.Fold
   import: test-options
   type: exitcode-stdio-1.0
   main-is: Streamly/Test/Data/Fold.hs
+  other-modules: Streamly.Test.Common
 
 test-suite Data.Unfold
   import: test-options

--- a/test/Streamly/Test/Common.hs
+++ b/test/Streamly/Test/Common.hs
@@ -10,6 +10,8 @@
 module Streamly.Test.Common
     ( equals
     , listEquals
+    , checkListEqual
+    , chooseInt
     ) where
 
 import Control.Monad (when)
@@ -18,8 +20,8 @@ import Data.List ((\\))
 #if __GLASGOW_HASKELL__ < 808
 import Data.Semigroup ((<>))
 #endif
-import Test.QuickCheck (counterexample)
-import Test.QuickCheck.Monadic (PropertyM, assert, monitor)
+import Test.QuickCheck (Property, Gen, choose, counterexample)
+import Test.QuickCheck.Monadic (PropertyM, assert, monitor, monadicIO)
 
 equals
     :: (Show a, Monad m)
@@ -51,3 +53,9 @@ listEquals eq stream list = do
              <> "\nlist \\\\ stream " <> show (list \\ stream)
              )
     assert (stream `eq` list)
+
+checkListEqual :: (Show a, Eq a) => [a] -> [a] -> Property
+checkListEqual ls_1 ls_2 = monadicIO (listEquals (==) ls_1 ls_2)
+
+chooseInt :: (Int, Int) -> Gen Int
+chooseInt = choose


### PR DESCRIPTION
Data.Fold.Types:
* Remove takeSepBy:  This function does not do what the name. Also,
`takeSepBy p` is the same as (sliceSepBy (not . p)). We can just remove
this in favor of sliceSepBy.

Data.Fold:

* Reorganize exports
* Add some skeleton/unimplemented combinators.
* Add/update haddock documentation
* Add sliceSepByMax fold - It was in parsers but it can be implemented
  as a fold.
* Rename drainSepBy to drainWhile
* Rename sliceSepWith to sliceEndWith
* Remove distribute_ as it can be implemented using distribute and has
  not perf advantage.
* Remove demuxWithDefault_ and implement demuxDefaultWith instead, which
  does not discard the results. Discarding results has no perf
  advantage.
* Implement demuxWith in terms of demuxDefaultWith, it has no perf
  advantage over the latter.
* Remove demuxWith_, use demuxWith instead.
* Remove demuxDefault_, use demuxDefault instead.
* Some code/comment cleanups

Benchmarks:

* Changes corresponding to the source changes
* Some code cleanups
* Reorder benchmarks