### PR TITLE
Implement Data.Parser.ParserD.wordBy

### DIFF
--- a/benchmark/Streamly/Benchmark/Data/Parser.hs
+++ b/benchmark/Streamly/Benchmark/Data/Parser.hs
@@ -76,6 +76,14 @@ takeWhile value = IP.parse (PR.takeWhile (<= value) FL.drain)
 groupBy :: MonadCatch m => SerialT m Int -> m ()
 groupBy = IP.parse (PR.groupBy (<=) FL.drain)
 
+{-# INLINE wordBy #-}
+wordBy :: MonadCatch m => Int -> SerialT m Int -> m ()
+wordBy value = IP.parse (PR.wordBy (>= value) FL.drain)
+
+{-# INLINE manyWordByEven #-}
+manyWordByEven :: MonadCatch m => SerialT m Int -> m ()
+manyWordByEven = IP.parse (PR.many FL.drain (PR.wordBy (Prelude.even) FL.drain))
+
 {-# INLINE many #-}
 many :: MonadCatch m => SerialT m Int -> m Int
 many = IP.parse (PR.many FL.length (PR.satisfy (> 0)))
@@ -263,11 +271,13 @@ o_1_space_serial value =
     , benchIOSink value "takeWhile" $ takeWhile value
     , benchIOSink value "drainWhile" $ drainWhile value
     , benchIOSink value "groupBy" $ groupBy
+    , benchIOSink value "wordBy" $ wordBy value
     , benchIOSink value "splitAp" $ splitAp value
     , benchIOSink value "splitApBefore" $ splitApBefore value
     , benchIOSink value "splitApAfter" $ splitApAfter value
     , benchIOSink value "splitWith" $ splitWith value
     , benchIOSink value "many" many
+    , benchIOSink value "many (wordBy even)" $ manyWordByEven
     , benchIOSink value "some" some
     , benchIOSink value "manyTill" $ manyTill value
     , benchIOSink value "tee" $ teeAllAny value

--- a/benchmark/Streamly/Benchmark/Data/Parser/ParserD.hs
+++ b/benchmark/Streamly/Benchmark/Data/Parser/ParserD.hs
@@ -71,6 +71,15 @@ takeWhile value = IP.parseD (drainWhile (<= value))
 groupBy :: MonadThrow m => SerialT m Int -> m ()
 groupBy = IP.parseD (PR.groupBy (<=) FL.drain)
 
+{-# INLINE wordBy #-}
+wordBy :: MonadThrow m => Int -> SerialT m Int -> m ()
+wordBy value = IP.parseD (PR.wordBy (>= value) FL.drain)
+
+{-# INLINE manyWordByEven #-}
+manyWordByEven :: MonadCatch m => SerialT m Int -> m ()
+manyWordByEven =
+    IP.parseD (PR.many FL.drain (PR.wordBy (Prelude.even) FL.drain))
+
 {-# INLINE many #-}
 many :: MonadCatch m => SerialT m Int -> m Int
 many = IP.parseD (PR.many FL.length (PR.satisfy (> 0)))
@@ -200,8 +209,10 @@ o_1_space_serial :: Int -> [Benchmark]
 o_1_space_serial value =
     [ benchIOSink value "takeWhile" $ takeWhile value
     , benchIOSink value "groupBy" $ groupBy
+    , benchIOSink value "wordBy" $ wordBy value
     , benchIOSink value "split (all,any)" $ splitAllAny value
     , benchIOSink value "many" many
+    , benchIOSink value "many (wordBy even)" $ manyWordByEven
     , benchIOSink value "some" some
     , benchIOSink value "manyTill" $ manyTill value
     , benchIOSink value "tee (all,any)" $ teeAllAny value

--- a/src/Streamly/Internal/Data/Parser.hs
+++ b/src/Streamly/Internal/Data/Parser.hs
@@ -548,13 +548,9 @@ escapedFrameBy _begin _end _escape _p = undefined
 -- S.wordsBy pred f = S.parseMany (PR.wordBy pred f)
 -- @
 --
--- /Unimplemented/
---
-{-# INLINABLE wordBy #-}
-wordBy ::
-    -- Monad m =>
-    (a -> Bool) -> Fold m a b -> Parser m a b
-wordBy = undefined
+{-# INLINE wordBy #-}
+wordBy :: MonadCatch m => (a -> Bool) -> Fold m a b -> Parser m a b
+wordBy f = K.toParserK . D.wordBy f
 
 -- | @groupBy cmp f $ S.fromList [a,b,c,...]@ assigns the element @a@ to the
 -- first group, then if @a \`cmp` b@ is 'True' @b@ is also assigned to the same

--- a/test/Streamly/Test/Data/Parser.hs
+++ b/test/Streamly/Test/Data/Parser.hs
@@ -317,6 +317,23 @@ groupBy =
         | null lst = []
         | otherwise = head $ List.groupBy cmp lst
 
+
+wordBy :: Property
+wordBy =
+    forAll (listOf (elements [' ', 's']))
+        $ \ls ->
+              case S.parse parser (S.fromList ls) of
+                  Right parsed -> checkListEqual parsed (words' ls)
+                  Left _ -> property False
+
+    where
+
+    predicate = (== ' ')
+    parser = P.many FL.toList (P.wordBy predicate FL.toList)
+    words' lst =
+        let wrds = words lst
+         in if wrds == [] then [""] else wrds
+
 -- splitWithPass :: Property
 -- splitWithPass =
 --     forAll (listOf (chooseInt (0, 1))) $ \ls ->
@@ -627,6 +644,7 @@ main =
         prop "P.takeWhile = Prelude.takeWhile" Main.takeWhile
         prop "P.takeWhile1 = Prelude.takeWhile if taken something, else check why failed" takeWhile1
         prop "P.groupBy = Prelude.head . Prelude.groupBy" groupBy
+        prop "many (P.wordBy ' ') = words'" wordBy
         -- prop "" splitWithPass
         -- prop "" splitWithFailLeft
         -- prop "" splitWithFailRight

--- a/test/Streamly/Test/Data/Parser/ParserD.hs
+++ b/test/Streamly/Test/Data/Parser/ParserD.hs
@@ -323,6 +323,23 @@ sliceSepByMax =
             where
                 predicate = (== 1)
 
+wordBy :: Property
+wordBy =
+    forAll (listOf (elements [' ', 's']))
+        $ \ls ->
+              case S.parseD parser (S.fromList ls) of
+                  Right parsed -> checkListEqual parsed (words' ls)
+                  Left _ -> property False
+
+    where
+
+    predicate = (== ' ')
+    parser = P.many FL.toList (P.wordBy predicate FL.toList)
+    words' lst =
+        let wrds = words lst
+         in if wrds == [] then [""] else wrds
+
+
 splitWith :: Property
 splitWith =
     forAll (listOf (chooseInt (0, 1))) $ \ls ->
@@ -657,6 +674,7 @@ main =
         prop "P.groupBy = Prelude.head . Prelude.groupBy" groupBy
         prop "P.sliceSepBy = Prelude.takeWhile (not . predicate)" sliceSepBy
         prop "P.sliceSepByMax = Prelude.take n (Prelude.takeWhile (not . predicate)" sliceSepByMax
+        prop "many (P.wordBy ' ') = words'" wordBy
         prop "parse 0, then 1, else fail" splitWith
         prop "fail due to die as left parser" splitWithFailLeft
         prop "fail due to die as right parser" splitWithFailRight


### PR DESCRIPTION
- Modify Data.Parser.wordBy accordingly
- Add tests for both
- Add benchmarks for both

This requires `fusion-plugin`

```
benchmarked Data.Parser.ParserD/o-1-space/wordBy
time                 65.46 μs   (64.92 μs .. 65.92 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 65.82 μs   (65.47 μs .. 66.22 μs)
std dev              1.856 μs   (1.475 μs .. 2.670 μs)
variance introduced by outliers: 22% (moderately inflated)

benchmarked Data.Parser/o-1-space/wordBy
time                 64.97 μs   (64.54 μs .. 65.34 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 66.02 μs   (65.67 μs .. 66.49 μs)
std dev              1.967 μs   (1.637 μs .. 2.780 μs)
variance introduced by outliers: 24% (moderately inflated)
```