### PR TITLE
Add combinators for Timeout Buffered writer stream

### DIFF
--- a/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
@@ -93,7 +93,6 @@ module Streamly.Internal.Data.Array.Foreign.Mut.Type
     , memcpy
     , memcmp
     , c_memchr
-    , writeNUnsafeMaybe
     , writeMaybesN
     , writeMaybes
     )
@@ -1186,7 +1185,7 @@ writeMaybesN n = Fold step initial extract
 {-# INLINE_NORMAL writeMaybes #-}
 writeMaybes :: forall m a. (MonadIO m, Storable a)
     => Fold m (Maybe a) (Array a)
-writeMaybes = FL.mkFoldM_ step initial extract
+writeMaybes = FL.rmapM extract $ FL.foldlM' step initial
 
     where
 

--- a/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
@@ -93,7 +93,6 @@ module Streamly.Internal.Data.Array.Foreign.Mut.Type
     , memcpy
     , memcmp
     , c_memchr
-    , bytesToElemCount
     , writeNUnsafeMaybe
     , writeMaybesN
     , writeMaybes
@@ -1162,14 +1161,6 @@ toStreamD_ size Array{..} =
                     return r
         return $ D.Yield x (p `plusPtr` size)
 #endif
-    Array a
-nil = Array nullForeignPtr (Ptr nullAddr#) (Ptr nullAddr#)
-
-instance Storable a => Monoid (Array a) where
-    {-# INLINE mempty #-}
-    mempty = nil
-    {-# INLINE mappend #-}
-    mappend = (<>)
 
 {-# INLINE_NORMAL writeMaybesN #-}
 writeMaybesN :: forall m a. (MonadIO m, Storable a)
@@ -1195,7 +1186,7 @@ writeMaybesN n = Fold step initial extract
 {-# INLINE_NORMAL writeMaybes #-}
 writeMaybes :: forall m a. (MonadIO m, Storable a)
     => Fold m (Maybe a) (Array a)
-writeMaybes = FL.mkAccumM step initial extract
+writeMaybes = FL.mkFoldM_ step initial extract
 
     where
 

--- a/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
@@ -92,7 +92,12 @@ module Streamly.Internal.Data.Array.Foreign.Mut.Type
     , bytesToElemCount
     , memcpy
     , memcmp
+<<<<<<< HEAD:src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
     , c_memchr
+=======
+    , bytesToElemCount
+    , writeNUnsafeMaybe
+>>>>>>> 7e73b7af (Add combinators for Timeout Buffered writer stream):src/Streamly/Internal/Data/Array/Storable/Foreign/Mut/Types.hs
     )
 where
 
@@ -106,6 +111,7 @@ import Data.Functor.Identity (runIdentity)
 #if __GLASGOW_HASKELL__ < 808
 import Data.Semigroup (Semigroup(..))
 #endif
+import Data.Maybe (isJust, fromJust)
 import Data.Word (Word8)
 import Foreign.C.Types (CSize(..), CInt(..))
 import Foreign.ForeignPtr (touchForeignPtr)
@@ -1157,3 +1163,35 @@ toStreamD_ size Array{..} =
                     return r
         return $ D.Yield x (p `plusPtr` size)
 #endif
+<<<<<<< HEAD:src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
+=======
+    Array a
+nil = Array nullForeignPtr (Ptr nullAddr#) (Ptr nullAddr#)
+
+instance Storable a => Monoid (Array a) where
+    {-# INLINE mempty #-}
+    mempty = nil
+    {-# INLINE mappend #-}
+    mappend = (<>)
+
+{-# INLINE_NORMAL writeNUnsafeMaybe #-}
+writeNUnsafeMaybe :: forall m a. (MonadIO m, Storable a)
+    => Int -> Fold m (Maybe a) (Array a)
+writeNUnsafeMaybe n = Fold step initial extract
+
+    where
+
+    initial = do
+        (Array start end _) <- liftIO $ newArray (max n 0)
+        return $ ArrayUnsafe start end
+
+    step (ArrayUnsafe start end) x = do            
+        if isJust x
+        then  do 
+            liftIO $ poke end (fromJust x)
+            return $ FL.Partial $ ArrayUnsafe start (end `plusPtr` sizeOf (undefined :: a))
+        else do
+            return $ FL.Done $ Array start end end    
+
+    extract (ArrayUnsafe start end) = return $ Array start end end -- liftIO . shrinkToFit 
+>>>>>>> 7e73b7af (Add combinators for Timeout Buffered writer stream):src/Streamly/Internal/Data/Array/Storable/Foreign/Mut/Types.hs

--- a/src/Streamly/Internal/Data/Array/Foreign/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Type.hs
@@ -80,7 +80,7 @@ module Streamly.Internal.Data.Array.Foreign.Type
     , MA.memcpy
     , MA.memcmp
     , MA.bytesToElemCount
-    , writeNUnsafeMaybe 
+    , writeMaybesN 
     )
 where
 
@@ -547,10 +547,11 @@ writeNUnsafe :: forall m a. (MonadIO m, Storable a)
     => Int -> Fold m a (Array a)
 writeNUnsafe n = unsafeFreeze <$> MA.writeNUnsafe n
 
-{-# INLINE_NORMAL writeNUnsafeMaybe #-}
-writeNUnsafeMaybe :: forall m a. (MonadIO m, Storable a)
+
+{-# INLINE_NORMAL writeMaybesN #-}
+writeMaybesN :: forall m a. (MonadIO m, Storable a)
     => Int -> Fold m (Maybe a) (Array a)
-writeNUnsafeMaybe n = unsafeFreeze <$> MA.writeNUnsafeMaybe n
+writeMaybesN n = unsafeFreeze <$> MA.writeMaybesN n
 
 -- XXX The realloc based implementation needs to make one extra copy if we use
 -- shrinkToFit.  On the other hand, the stream of arrays implementation may

--- a/src/Streamly/Internal/Data/Array/Foreign/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Type.hs
@@ -71,6 +71,16 @@ module Streamly.Internal.Data.Array.Foreign.Type
     , bufferChunks
     , flattenArrays
     , flattenArraysRev
+    -- * Utilities
+    , MA.defaultChunkSize
+    , MA.mkChunkSize
+    , MA.mkChunkSizeKB
+    , MA.unsafeInlineIO
+
+    , MA.memcpy
+    , MA.memcmp
+    , MA.bytesToElemCount
+    , writeNUnsafeMaybe 
     )
 where
 
@@ -536,6 +546,11 @@ writeNAlignedUnmanaged alignSize =
 writeNUnsafe :: forall m a. (MonadIO m, Storable a)
     => Int -> Fold m a (Array a)
 writeNUnsafe n = unsafeFreeze <$> MA.writeNUnsafe n
+
+{-# INLINE_NORMAL writeNUnsafeMaybe #-}
+writeNUnsafeMaybe :: forall m a. (MonadIO m, Storable a)
+    => Int -> Fold m (Maybe a) (Array a)
+writeNUnsafeMaybe n = unsafeFreeze <$> MA.writeNUnsafeMaybe n
 
 -- XXX The realloc based implementation needs to make one extra copy if we use
 -- shrinkToFit.  On the other hand, the stream of arrays implementation may

--- a/src/Streamly/Internal/Data/Array/Foreign/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Type.hs
@@ -72,10 +72,10 @@ module Streamly.Internal.Data.Array.Foreign.Type
     , flattenArrays
     , flattenArraysRev
     -- * Utilities
-    , MA.defaultChunkSize
-    , MA.mkChunkSize
-    , MA.mkChunkSizeKB
-    , MA.unsafeInlineIO
+    -- , MA.defaultChunkSize
+    -- , MA.mkChunkSize
+    -- , MA.mkChunkSizeKB
+    -- , MA.unsafeInlineIO
 
     , MA.memcpy
     , MA.memcmp

--- a/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
@@ -116,9 +116,7 @@ module Streamly.Internal.Data.Stream.IsStream.Transform
     , intersperseSuffixBySpan
     , interjectSuffix
     , justsOfTimeout
-    -- , intersperseBySpan
-    -- , intersperseByIndices -- using an index function/stream
-
+    
     -- , interspersePrefix
     -- , interspersePrefixBySpan
 

--- a/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
@@ -1675,7 +1675,7 @@ infixl 1 |&
 {-# INLINE justsOf #-}
 justsOf :: (MonadIO m, IsStream t)
     => t m a -> t m (Maybe a)
-justsOf = Serial.map Just
+justsOf = map Just
 
 -- | Transform a stream of @a@ to @(Just a)@ then intersperse a Nothing into the input
 -- stream after every n elements then interject Nothing every @t@ seconds.

--- a/src/Streamly/Internal/Network/Socket.hs
+++ b/src/Streamly/Internal/Network/Socket.hs
@@ -56,8 +56,7 @@ module Streamly.Internal.Network.Socket
     , writeChunk
     , writeChunks
     , writeChunksWithBufferOf
-    , writeStrings
-    , writeMaybesWithBufferOf
+    ,writeMaybesWithBufferOf
 
     -- reading/writing datagrams
     )
@@ -96,22 +95,63 @@ import Streamly.Internal.Data.Fold (Fold)
 import Streamly.Internal.Data.Stream.IsStream.Type
     (IsStream, mkStream, fromStreamD)
 import Streamly.Internal.Data.Stream.Serial (SerialT)
+import Streamly.Internal.Data.Unfold.Type (Unfold(..))
 -- import Streamly.String (encodeUtf8, decodeUtf8, foldLines)
+import Streamly.Internal.System.IO (defaultChunkSize)
+
+import qualified Streamly.Internal.Data.Array.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign.Type as A
+import qualified Streamly.Internal.Data.Array.Stream.Foreign as AS
+import qualified Streamly.Internal.Data.Fold as FL
+import qualified Streamly.Internal.Data.Stream.IsStream as S
+import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
+import qualified Streamly.Internal.Data.Unfold as UF
+
+-- | @'forSocketM' action socket@ runs the monadic computation @action@ passing
+-- the socket handle to it.  The handle will be closed on exit from
+-- 'forSocketM', whether by normal termination or by raising an exception.  If
+-- closing the handle raises an exception, then this exception will be raised
+-- by 'forSocketM' rather than any exception raised by 'action'.
 --
+-- @since 0.8.0
+{-# INLINE forSocketM #-}
 forSocketM :: (MonadMask m, MonadIO m) => (Socket -> m ()) -> Socket -> m ()
+forSocketM f sk = finally (f sk) (liftIO (Net.close sk))
+
 -- | Like 'forSocketM' but runs a streaming computation instead of a monadic
+-- computation.
+--
 -- /Inhibits stream fusion/
+--
+-- /Internal/
 {-# INLINE withSocket #-}
+withSocket :: (IsStream t, MonadAsync m, MonadCatch m)
+    => Socket -> (Socket -> t m a) -> t m a
+withSocket sk f = S.finally (liftIO $ Net.close sk) (f sk)
+
+-------------------------------------------------------------------------------
 -- Accept (Unfolds)
+-------------------------------------------------------------------------------
+
+-- XXX Protocol specific socket options should be separated from socket level
+-- options.
+--
 -- | Specify the socket protocol details.
 data SockSpec = SockSpec
+    {
       sockFamily :: !Family
     , sockType   :: !SocketType
+    , sockProto  :: !ProtocolNumber
     , sockOpts   :: ![(SocketOption, Int)]
     }
+
 initListener :: Int -> SockSpec -> SockAddr -> IO Socket
+initListener listenQLen SockSpec{..} addr =
+  withSocketsDo $ do
     sock <- socket sockFamily sockType sockProto
     use sock `onException` Net.close sock
+    return sock
+
     where
 
     use sock = do
@@ -459,20 +499,6 @@ writeWithBufferOf :: MonadIO m => Int -> Socket -> Fold m Word8 ()
 writeWithBufferOf n h = FL.chunksOf n (A.writeNUnsafe n) (writeChunks h)
 
 -- > write = 'writeWithBufferOf' defaultChunkSize
--- | Write a (Maybe Word8) stream to a socket. Accumulates the input in chunks of
--- specified number of bytes or till Nothing before writing.
---
--- >>> S.unfold readWithBufferOf (1024, sk)
---             & S.justsOfTimeout 1024 1
---             & S.fold (writeMaybesWithBufferOf 1024 sk)
--- /Internal/
-
-{-# INLINE writeMaybesWithBufferOf #-}
-writeMaybesWithBufferOf :: (MonadIO m )
-    => Int -> Socket -> Fold m (Maybe Word8) ()
-writeMaybesWithBufferOf n h = FL.many (writeChunks h) (A.writeMaybesN n)
-
--- > write = 'writeWithBufferOf' A.defaultChunkSize
 --
 -- | Write a byte stream to a file handle. Combines the bytes in chunks of size
 -- up to 'defaultChunkSize' before writing.  Note that the write behavior
@@ -494,6 +520,11 @@ putBytes = putBytesWithBufferOf defaultChunkSize
 {-# INLINE write #-}
 write :: MonadIO m => Socket -> Fold m Word8 ()
 write = writeWithBufferOf defaultChunkSize
+
+{-# INLINE writeMaybesWithBufferOf #-}
+writeMaybesWithBufferOf :: (MonadIO m )
+    => Int -> Socket -> Fold m (Maybe Word8) ()
+writeMaybesWithBufferOf n h = FL.many (A.writeMaybesN n) (writeChunks h)
 
 {-
 {-# INLINE write #-}

--- a/src/Streamly/Internal/Network/Socket.hs
+++ b/src/Streamly/Internal/Network/Socket.hs
@@ -56,7 +56,7 @@ module Streamly.Internal.Network.Socket
     , writeChunk
     , writeChunks
     , writeChunksWithBufferOf
-    ,writeMaybesWithBufferOf
+    , writeMaybesWithBufferOf
 
     -- reading/writing datagrams
     )


### PR DESCRIPTION
With Timeout combinators 45,000,000  Bytes written to socket and then drained out in **142.4000** seconds vs **122.0099** secs without Timeout combinators.