### PR TITLE
Remove the prefix *l* in a few functions of Fold

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -21,6 +21,7 @@
 - ignore: {name: "Use <$>"}
 - ignore: {name: "Use uncurry"}
 - ignore: {name: "Redundant $!"}
+- ignore: {name: "Use fmap"}
 
 
 # Specify additional command line arguments

--- a/benchmark/Streamly/Benchmark/Data/Fold.hs
+++ b/benchmark/Streamly/Benchmark/Data/Fold.hs
@@ -64,9 +64,9 @@ any value = IP.fold (FL.any (> value))
 all :: (Monad m, Ord a) => a -> SerialT m a -> m Bool
 all value = IP.fold (FL.all (<= value))
 
-{-# INLINE take #-}
-take :: Monad m => Int -> SerialT m a -> m ()
-take value = IP.fold (FL.ltake value FL.drain)
+{-# INLINE takeLE #-}
+takeLE :: Monad m => Int -> SerialT m a -> m ()
+takeLE value = IP.fold (FL.takeLE value FL.drain)
 
 -------------------------------------------------------------------------------
 -- Splitting by serial application
@@ -78,7 +78,7 @@ sliceSepBy value = IP.fold (FL.sliceSepBy (>= value) FL.drain)
 
 {-# INLINE many #-}
 many :: Monad m => SerialT m Int -> m ()
-many = IP.fold (FL.many FL.drain (FL.ltake 1 FL.drain))
+many = IP.fold (FL.many FL.drain (FL.takeLE 1 FL.drain))
 
 {-# INLINE splitAllAny #-}
 splitAllAny :: Monad m => Int -> SerialT m Int -> m (Bool, Bool)
@@ -229,7 +229,7 @@ o_1_space_serial_elimination value =
         , benchIOSink value "notElem" (S.fold (FL.notElem (value + 1)))
         , benchIOSink value "all" $ all value
         , benchIOSink value "any" $ any value
-        , benchIOSink value "take" $ take value
+        , benchIOSink value "takeLE" $ takeLE value
         , benchIOSink value "sliceSepBy" $ sliceSepBy value
         , benchIOSink value "and" (S.fold FL.and . S.map (<= (value + 1)))
         , benchIOSink value "or" (S.fold FL.or . S.map (> (value + 1)))
@@ -265,7 +265,7 @@ o_1_space_serial_composition value =
             [ benchIOSink value "splitWith (all, any)" $ splitAllAny value
             , benchIOSink value "teeApplicative (all, any)"
                 $ teeApplicative value
-            , benchIOSink value "many drain (take 1)" many
+            , benchIOSink value "many drain (takeLE 1)" many
             , benchIOSink value "tee (sum, length)" teeSumLength
             , benchIOSink value "distribute [sum, length]" distribute
             , benchIOSink value "partition (sum, length)" partition

--- a/benchmark/Streamly/Benchmark/Data/Fold.hs
+++ b/benchmark/Streamly/Benchmark/Data/Fold.hs
@@ -129,7 +129,7 @@ partition =
             if odd a
             then Left a
             else Right a
-     in IP.fold $ FL.lmap f (FL.partition FL.sum FL.length)
+     in IP.fold $ FL.map f (FL.partition FL.sum FL.length)
 
 {-# INLINE demuxWith  #-}
 demuxWith ::
@@ -147,7 +147,7 @@ demuxDefaultWith ::
     -> Map k (Fold m b b)
     -> SerialT m a
     -> m (Map k b, b)
-demuxDefaultWith f mp = S.fold (FL.demuxDefaultWith f mp (FL.lmap snd FL.sum))
+demuxDefaultWith f mp = S.fold (FL.demuxDefaultWith f mp (FL.map snd FL.sum))
 
 {-# INLINE classifyWith #-}
 classifyWith ::
@@ -160,7 +160,7 @@ classifyWith f = S.fold (FL.classifyWith f FL.sum)
 
 {-# INLINE unzip #-}
 unzip :: Monad m => SerialT m Int -> m (Int, Int)
-unzip = IP.fold $ FL.lmap (\a -> (a, a)) (FL.unzip FL.sum FL.length)
+unzip = IP.fold $ FL.map (\a -> (a, a)) (FL.unzip FL.sum FL.length)
 
 -------------------------------------------------------------------------------
 -- Benchmarks
@@ -215,7 +215,7 @@ o_1_space_serial_elimination value =
         , benchIOSink
               value
               "lookup"
-              (S.fold (FL.lmap (\a -> (a, a)) (FL.lookup (value + 1))))
+              (S.fold (FL.map (\a -> (a, a)) (FL.lookup (value + 1))))
         , benchIOSink
               value
               "findIndex"
@@ -239,7 +239,7 @@ o_1_space_serial_elimination value =
 o_1_space_serial_transformation :: Int -> [Benchmark]
 o_1_space_serial_transformation value =
     [ bgroup "transformation"
-        [ benchIOSink value "lmap" (S.fold (FL.lmap (+ 1) FL.drain))
+        [ benchIOSink value "map" (S.fold (FL.map (+ 1) FL.drain))
         , let f x = if even x then Just x else Nothing
               fld = FL.mapMaybe f FL.drain
            in benchIOSink value "mapMaybe" (S.fold fld)

--- a/benchmark/Streamly/Benchmark/Data/Parser.hs
+++ b/benchmark/Streamly/Benchmark/Data/Parser.hs
@@ -256,7 +256,7 @@ parseMany :: MonadCatch m => SerialT m Int -> m ()
 parseMany =
       S.drain
     . S.map getSum
-    . IP.parseMany (PR.fromFold $ FL.ltake 2 FL.mconcat)
+    . IP.parseMany (PR.fromFold $ FL.takeLE 2 FL.mconcat)
     . S.map Sum
 
 {-# INLINE parseIterate #-}
@@ -264,7 +264,7 @@ parseIterate :: MonadCatch m => SerialT m Int -> m ()
 parseIterate =
       S.drain
     . S.map getSum
-    . IP.parseIterate (PR.fromFold . FL.ltake 2 . FL.sconcat) (Sum 0)
+    . IP.parseIterate (PR.fromFold . FL.takeLE 2 . FL.sconcat) (Sum 0)
     . S.map Sum
 
 -------------------------------------------------------------------------------

--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/Read.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/Read.hs
@@ -311,12 +311,12 @@ chunksOfSum n inh = S.length $ S.chunksOf n FL.sum (S.unfold FH.read inh)
 
 foldManyChunksOfSum :: Int -> Handle -> IO Int
 foldManyChunksOfSum n inh =
-    S.length $ IP.foldMany (FL.ltake n FL.sum) (S.unfold FH.read inh)
+    S.length $ IP.foldMany (FL.takeLE n FL.sum) (S.unfold FH.read inh)
 
 parseManyChunksOfSum :: Int -> Handle -> IO Int
 parseManyChunksOfSum n inh =
     S.length
-        $ IP.parseMany (PR.fromFold $ FL.ltake n FL.sum) (S.unfold FH.read inh)
+        $ IP.parseMany (PR.fromFold $ FL.takeLE n FL.sum) (S.unfold FH.read inh)
 
 -- XXX investigate why we need an INLINE in this case (GHC)
 -- Even though allocations remain the same in both cases inlining improves time

--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
@@ -85,7 +85,7 @@ inspect $ 'copyStream `hasNoType` ''Step -- S.unfold
 inspect $ 'copyStream `hasNoType` ''IUF.ConcatState -- FH.read/UF.concat
 inspect $ 'copyStream `hasNoType` ''A.ReadUState  -- FH.read/A.read
 inspect $ 'copyStream `hasNoType` ''AT.ArrayUnsafe -- FH.write/writeNUnsafe
-inspect $ 'copyStream `hasNoType` ''Strict.Tuple3' -- FH.write/lchunksOf
+inspect $ 'copyStream `hasNoType` ''Strict.Tuple3' -- FH.write/chunksOf
 #endif
 
 o_1_space_copy_read :: BenchEnv -> [Benchmark]

--- a/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation2.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation2.hs
@@ -137,7 +137,7 @@ foldMany :: Monad m => SerialT m Int -> m ()
 foldMany =
       S.drain
     . S.map getSum
-    . Internal.foldMany (FL.ltake 2 FL.mconcat)
+    . Internal.foldMany (FL.takeLE 2 FL.mconcat)
     . S.map Sum
 
 {-# INLINE _foldIterate #-}
@@ -145,7 +145,7 @@ _foldIterate :: Monad m => SerialT m Int -> m ()
 _foldIterate =
       S.drain
     . S.map getSum
-    . Internal.foldIterate (FL.ltake 2 . FL.sconcat) (Sum 0)
+    . Internal.foldIterate (FL.takeLE 2 . FL.sconcat) (Sum 0)
     . S.map Sum
 
 o_1_space_grouping :: Int -> [Benchmark]

--- a/benchmark/Streamly/Benchmark/Unicode/Stream.hs
+++ b/benchmark/Streamly/Benchmark/Unicode/Stream.hs
@@ -203,7 +203,7 @@ inspect $ 'copyStreamLatin1' `hasNoType` ''Step
 inspect $ 'copyStreamLatin1' `hasNoType` ''IUF.ConcatState -- FH.read/UF.concat
 inspect $ 'copyStreamLatin1' `hasNoType` ''A.ReadUState  -- FH.read/A.read
 inspect $ 'copyStreamLatin1' `hasNoType` ''AT.ArrayUnsafe -- FH.write/writeNUnsafe
-inspect $ 'copyStreamLatin1' `hasNoType` ''Strict.Tuple3' -- FH.write/lchunksOf
+inspect $ 'copyStreamLatin1' `hasNoType` ''Strict.Tuple3' -- FH.write/chunksOf
 #endif
 
 -- | Copy file (encodeLatin1)
@@ -220,7 +220,7 @@ inspect $ 'copyStreamLatin1 `hasNoType` ''Step
 inspect $ 'copyStreamLatin1 `hasNoType` ''IUF.ConcatState -- FH.read/UF.concat
 inspect $ 'copyStreamLatin1 `hasNoType` ''A.ReadUState  -- FH.read/A.read
 inspect $ 'copyStreamLatin1 `hasNoType` ''AT.ArrayUnsafe -- FH.write/writeNUnsafe
-inspect $ 'copyStreamLatin1 `hasNoType` ''Strict.Tuple3' -- FH.write/lchunksOf
+inspect $ 'copyStreamLatin1 `hasNoType` ''Strict.Tuple3' -- FH.write/chunksOf
 #endif
 
 -- | Copy file

--- a/benchmark/Streamly/Benchmark/Unicode/Stream.hs
+++ b/benchmark/Streamly/Benchmark/Unicode/Stream.hs
@@ -116,7 +116,7 @@ linesUnlinesArrayUtf8Copy inh outh =
     S.fold (FH.write outh)
       $ SS.encodeLatin1'
       $ IP.intercalate (A.fromList [10]) (pipe SS.decodeUtf8P A.read)
-      $ S.splitOnSuffix (== '\n') (IFL.lmap SS.encodeUtf8' A.write)
+      $ S.splitOnSuffix (== '\n') (IFL.map SS.encodeUtf8' A.write)
       $ SS.decodeLatin1
       $ S.unfold FH.read inh
 -}

--- a/src/Streamly/Data/Fold.hs
+++ b/src/Streamly/Data/Fold.hs
@@ -148,8 +148,8 @@ module Streamly.Data.Fold
     -- , lmapM
 
     -- -- ** Filtering
-    -- , lfilter
-    -- , lfilterM
+    -- , filter
+    -- , filterM
     -- , ldeleteBy
     -- , luniq
 

--- a/src/Streamly/Data/Fold.hs
+++ b/src/Streamly/Data/Fold.hs
@@ -173,7 +173,7 @@ module Streamly.Data.Fold
 
     {-
     -- ** Trimming
-    , ltake
+    , takeLE
     -- takeByTime
     , ldrop
     , ldropWhile

--- a/src/Streamly/Internal/Data/Array/Storable/Foreign/Types.hs
+++ b/src/Streamly/Internal/Data/Array/Storable/Foreign/Types.hs
@@ -97,7 +97,7 @@ import GHC.ForeignPtr (touchForeignPtr, unsafeForeignPtrToPtr)
 #endif
 import GHC.IO (unsafePerformIO)
 import GHC.Ptr (Ptr(..))
-import Streamly.Internal.Data.Fold.Types (Fold(..), lmap)
+import Streamly.Internal.Data.Fold.Types (Fold(..))
 import Text.Read (readPrec, readListPrec, readListPrecDefault)
 
 import Prelude hiding (length, foldr, read, unlines, splitAt)
@@ -105,6 +105,7 @@ import Prelude hiding (length, foldr, read, unlines, splitAt)
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
 import qualified Streamly.Internal.Data.Stream.StreamK as K
 import qualified Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types as MA
+import qualified Streamly.Internal.Data.Fold.Types as Fold
 import qualified GHC.Exts as Exts
 
 #if __GLASGOW_HASKELL__ < 808
@@ -377,7 +378,7 @@ packArraysChunksOf n str =
 lpackArraysChunksOf :: (MonadIO m, Storable a)
     => Int -> Fold m (Array a) () -> Fold m (Array a) ()
 lpackArraysChunksOf n fld =
-    lmap unsafeThaw $ MA.lpackArraysChunksOf n (lmap unsafeFreeze fld)
+    Fold.map unsafeThaw $ MA.lpackArraysChunksOf n (Fold.map unsafeFreeze fld)
 
 #if !defined(mingw32_HOST_OS)
 

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -214,7 +214,7 @@ module Streamly.Internal.Data.Fold
     -- * Nesting
     , many
     , lsessionsOf
-    , lchunksOf
+    , chunksOf
     , chunksBetween
 
     , concatSequence

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -137,7 +137,7 @@ module Streamly.Internal.Data.Fold
     -}
 
     -- ** Trimming
-    , ltake
+    , takeLE
     , takeByTime
     -- By elements
     , sliceSepBy
@@ -715,10 +715,10 @@ rollingHash = rollingHashWithSalt defaultSalt
 -- | Compute an 'Int' sized polynomial rolling hash of the first n elements of
 -- a stream.
 --
--- > rollingHashFirstN = ltake n rollingHash
+-- > rollingHashFirstN = takeLE n rollingHash
 {-# INLINABLE rollingHashFirstN #-}
 rollingHashFirstN :: (Monad m, Enum a) => Int -> Fold m a Int64
-rollingHashFirstN n = ltake n rollingHash
+rollingHashFirstN n = takeLE n rollingHash
 
 ------------------------------------------------------------------------------
 -- Monoidal left folds
@@ -826,7 +826,7 @@ toListRevF = mkAccum_ (flip (:)) []
 -- and discarding the results.
 {-# INLINABLE drainN #-}
 drainN :: Monad m => Int -> Fold m a ()
-drainN n = ltake n drain
+drainN n = takeLE n drain
 
 ------------------------------------------------------------------------------
 -- To Elements
@@ -1056,7 +1056,7 @@ or = any (== True)
 -- >>> splitAt_ 4 [1,2,3]
 -- > ([1,2,3],[])
 --
--- > splitAt n f1 f2 = splitWith (,) (ltake n f1) f2
+-- > splitAt n f1 f2 = splitWith (,) (takeLE n f1) f2
 --
 -- /Internal/
 
@@ -1067,7 +1067,7 @@ splitAt
     -> Fold m a b
     -> Fold m a c
     -> Fold m a (b, c)
-splitAt n fld = splitWith (,) (ltake n fld)
+splitAt n fld = splitWith (,) (takeLE n fld)
 
 ------------------------------------------------------------------------------
 -- Element Aware APIs
@@ -1176,7 +1176,7 @@ sliceSepBy predicate (Fold fstep finitial fextract) =
 {-# INLINABLE sliceSepByMax #-}
 sliceSepByMax :: Monad m
     => (a -> Bool) -> Int -> Fold m a b -> Fold m a b
-sliceSepByMax p n = sliceSepBy p . ltake n
+sliceSepByMax p n = sliceSepBy p . takeLE n
 
 -- | Collect stream elements until an element succeeds the predicate. Also take
 -- the element on which the predicate succeeded. The succeeding element is

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -107,7 +107,7 @@ module Streamly.Internal.Data.Fold
 
     -- ** Mapping
     , transform
-    , lmap
+    , map
     --, lsequence
     , lmapM
     -- ** Filtering
@@ -403,7 +403,7 @@ mapM f = sequence . fmap f
 -- /Internal/
 {-# INLINE mapMaybe #-}
 mapMaybe :: (Monad m) => (a -> Maybe b) -> Fold m b r -> Fold m a r
-mapMaybe f = lmap f . filter isJust . lmap fromJust
+mapMaybe f = map f . filter isJust . map fromJust
 
 ------------------------------------------------------------------------------
 -- Transformations on fold inputs
@@ -750,7 +750,7 @@ mconcat ::
 mconcat = sconcat mempty
 
 -- |
--- > foldMap f = lmap f mconcat
+-- > foldMap f = map f mconcat
 --
 -- Make a fold from a pure function that folds the output of the function
 -- using 'mappend' and 'mempty'.
@@ -764,7 +764,7 @@ foldMap :: (Monad m, Monoid b
     , Semigroup b
 #endif
     ) => (a -> b) -> Fold m a b
-foldMap f = lmap f mconcat
+foldMap f = map f mconcat
 
 -- |
 -- > foldMapM f = lmapM f mconcat
@@ -935,7 +935,7 @@ null :: Monad m => Fold m a Bool
 null = mkFold (\() _ -> Done False) (Partial ()) (const True)
 
 --
--- > any p = lmap p or
+-- > any p = map p or
 -- > any p = fmap getAny . FL.foldMap (Any . p)
 --
 -- | Returns 'True' if any of the elements of a stream satisfies a predicate.
@@ -967,7 +967,7 @@ elem :: (Eq a, Monad m) => a -> Fold m a Bool
 elem a = any (a ==)
 
 --
--- > all p = lmap p and
+-- > all p = map p and
 -- > all p = fmap getAll . FL.foldMap (All . p)
 --
 -- | Returns 'True' if all elements of a stream satisfy a predicate.
@@ -1992,11 +1992,11 @@ classifyWith f (Fold step1 initial1 extract1) = mkAccumM step initial extract
 
 -- Same as:
 --
--- > classify fld = classifyWith fst (lmap snd fld)
+-- > classify fld = classifyWith fst (map snd fld)
 --
 {-# INLINE classify #-}
 classify :: (Monad m, Ord k) => Fold m a b -> Fold m (k, a) (Map k b)
-classify fld = classifyWith fst (lmap snd fld)
+classify fld = classifyWith fst (map snd fld)
 
 ------------------------------------------------------------------------------
 -- Unzipping
@@ -2086,7 +2086,7 @@ unzipWithMinM = undefined
 -- | Split elements in the input stream into two parts using a pure splitter
 -- function, direct each part to a different fold and zip the results.
 --
--- @unzipWith f fld1 fld2 = lmap f (unzip fld1 fld2)@
+-- @unzipWith f fld1 fld2 = map f (unzip fld1 fld2)@
 --
 -- This fold terminates when both the input folds terminate.
 --

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -111,8 +111,8 @@ module Streamly.Internal.Data.Fold
     --, lsequence
     , lmapM
     -- ** Filtering
-    , lfilter
-    , lfilterM
+    , filter
+    , filterM
     -- , ldeleteBy
     -- , luniq
     , lcatMaybes
@@ -403,7 +403,7 @@ mapM f = sequence . fmap f
 -- /Internal/
 {-# INLINE mapMaybe #-}
 mapMaybe :: (Monad m) => (a -> Maybe b) -> Fold m b r -> Fold m a r
-mapMaybe f = lmap f . lfilter isJust . lmap fromJust
+mapMaybe f = lmap f . filter isJust . lmap fromJust
 
 ------------------------------------------------------------------------------
 -- Transformations on fold inputs

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -213,7 +213,7 @@ module Streamly.Internal.Data.Fold
 
     -- * Nesting
     , many
-    , lsessionsOf
+    , intervalsOf
     , chunksOf
     , chunksBetween
 

--- a/src/Streamly/Internal/Data/Fold/Types.hs
+++ b/src/Streamly/Internal/Data/Fold/Types.hs
@@ -184,7 +184,7 @@ module Streamly.Internal.Data.Fold.Types
     , lfilter
     , lfilterM
     , lcatMaybes
-    , ltake
+    , takeLE
     , takeByTime
 
     -- * Distributing
@@ -704,18 +704,18 @@ lcatMaybes = lfilter isJust . lmap fromJust
 
 -- | Take at most @n@ input elements and fold them using the supplied fold.
 --
--- >>> Stream.fold (Fold.ltake 1 Fold.toList) $ Stream.fromList [1]
+-- >>> Stream.fold (Fold.takeLE 1 Fold.toList) $ Stream.fromList [1]
 -- [1]
 --
--- >>> Stream.fold (Fold.ltake (-1) Fold.toList) $ Stream.fromList [1]
+-- >>> Stream.fold (Fold.takeLE (-1) Fold.toList) $ Stream.fromList [1]
 -- []
 --
 -- /Internal/
 --
 -- @since 0.7.0
-{-# INLINE ltake #-}
-ltake :: Monad m => Int -> Fold m a b -> Fold m a b
-ltake n (Fold fstep finitial fextract) = Fold step initial extract
+{-# INLINE takeLE #-}
+takeLE :: Monad m => Int -> Fold m a b -> Fold m a b
+takeLE n (Fold fstep finitial fextract) = Fold step initial extract
 
     where
 
@@ -862,7 +862,7 @@ many (Fold cstep cinitial cextract) (Fold sstep sinitial sextract) =
 -- of @n@ items in the input stream and supplies the result to the @collect@
 -- fold.
 --
--- > lchunksOf n split collect = many collect (ltake n split)
+-- > lchunksOf n split collect = many collect (takeLE n split)
 --
 -- Stops when @collect@ stops.
 --
@@ -870,7 +870,7 @@ many (Fold cstep cinitial cextract) (Fold sstep sinitial sextract) =
 --
 {-# INLINE lchunksOf #-}
 lchunksOf :: Monad m => Int -> Fold m a b -> Fold m b c -> Fold m a c
-lchunksOf n split collect = many collect (ltake n split)
+lchunksOf n split collect = many collect (takeLE n split)
 
 {-# INLINE lchunksOf2 #-}
 lchunksOf2 :: Monad m => Int -> Fold m a b -> Fold2 m x b c -> Fold2 m x a c

--- a/src/Streamly/Internal/Data/Fold/Types.hs
+++ b/src/Streamly/Internal/Data/Fold/Types.hs
@@ -202,7 +202,7 @@ module Streamly.Internal.Data.Fold.Types
     , concatMap
     , many
     , lsessionsOf
-    , lchunksOf
+    , chunksOf
     , chunksOf2
 
     , duplicate
@@ -861,19 +861,19 @@ many (Fold cstep cinitial cextract) (Fold sstep sinitial sextract) =
             Partial s -> cextract s
             Done b -> return b
 
--- | @lchunksOf n split collect@ repeatedly applies the @split@ fold to chunks
+-- | @chunksOf n split collect@ repeatedly applies the @split@ fold to chunks
 -- of @n@ items in the input stream and supplies the result to the @collect@
 -- fold.
 --
--- > lchunksOf n split collect = many collect (takeLE n split)
+-- > chunksOf n split collect = many collect (takeLE n split)
 --
 -- Stops when @collect@ stops.
 --
 -- /Internal/
 --
-{-# INLINE lchunksOf #-}
-lchunksOf :: Monad m => Int -> Fold m a b -> Fold m b c -> Fold m a c
-lchunksOf n split collect = many collect (takeLE n split)
+{-# INLINE chunksOf #-}
+chunksOf :: Monad m => Int -> Fold m a b -> Fold m b c -> Fold m a c
+chunksOf n split collect = many collect (takeLE n split)
 
 {-# INLINE chunksOf2 #-}
 chunksOf2 :: Monad m => Int -> Fold m a b -> Fold2 m x b c -> Fold2 m x a c

--- a/src/Streamly/Internal/Data/Fold/Types.hs
+++ b/src/Streamly/Internal/Data/Fold/Types.hs
@@ -179,7 +179,7 @@ module Streamly.Internal.Data.Fold.Types
     , yieldM
 
     -- * Transformations
-    , lmap
+    , map
     , lmapM
     , filter
     , filterM
@@ -230,7 +230,7 @@ import Fusion.Plugin.Types (Fuse(..))
 import Streamly.Internal.Data.Tuple.Strict (Tuple'(..), Tuple3'(..))
 import Streamly.Internal.Data.SVar (MonadAsync)
 
-import Prelude hiding (concatMap, filter)
+import Prelude hiding (concatMap, filter, map)
 
 ------------------------------------------------------------------------------
 -- Monadic left folds
@@ -644,15 +644,18 @@ instance (Monad m, Floating b) => Floating (Fold m a b) where
 -- Internal APIs
 ------------------------------------------------------------------------------
 
--- | @(lmap f fold)@ maps the function @f@ on the input of the fold.
+-- | @(map f fold)@ maps the function @f@ on the input of the fold.
 --
--- >>> S.fold (FL.lmap (\x -> x * x) FL.sum) (S.enumerateFromTo 1 100)
+-- >>> S.fold (FL.map (\x -> x * x) FL.sum) (S.enumerateFromTo 1 100)
 -- 338350
 --
+-- __Note__: This is not the same as 'fmap'. @map@ is contravariant where as
+-- @fmap@ is covariant.
+--
 -- @since 0.7.0
-{-# INLINABLE lmap #-}
-lmap :: (a -> b) -> Fold m b r -> Fold m a r
-lmap f (Fold step begin done) = Fold step' begin done
+{-# INLINABLE map #-}
+map :: (a -> b) -> Fold m b r -> Fold m a r
+map f (Fold step begin done) = Fold step' begin done
     where
     step' x a = step x (f a)
 
@@ -696,7 +699,7 @@ filterM f (Fold step begin done) = Fold step' begin done
 -- 'Just' values.
 {-# INLINE lcatMaybes #-}
 lcatMaybes :: Monad m => Fold m a b -> Fold m (Maybe a) b
-lcatMaybes = filter isJust . lmap fromJust
+lcatMaybes = filter isJust . map fromJust
 
 ------------------------------------------------------------------------------
 -- Parsing

--- a/src/Streamly/Internal/Data/Fold/Types.hs
+++ b/src/Streamly/Internal/Data/Fold/Types.hs
@@ -181,8 +181,8 @@ module Streamly.Internal.Data.Fold.Types
     -- * Transformations
     , lmap
     , lmapM
-    , lfilter
-    , lfilterM
+    , filter
+    , filterM
     , lcatMaybes
     , takeLE
     , takeByTime
@@ -230,7 +230,7 @@ import Fusion.Plugin.Types (Fuse(..))
 import Streamly.Internal.Data.Tuple.Strict (Tuple'(..), Tuple3'(..))
 import Streamly.Internal.Data.SVar (MonadAsync)
 
-import Prelude hiding (concatMap)
+import Prelude hiding (concatMap, filter)
 
 ------------------------------------------------------------------------------
 -- Monadic left folds
@@ -671,22 +671,22 @@ lmapM f (Fold step begin done) = Fold step' begin done
 
 -- | Include only those elements that pass a predicate.
 --
--- >>> S.fold (lfilter (> 5) FL.sum) [1..10]
+-- >>> S.fold (filter (> 5) FL.sum) [1..10]
 -- 40
 --
 -- @since 0.7.0
-{-# INLINABLE lfilter #-}
-lfilter :: Monad m => (a -> Bool) -> Fold m a r -> Fold m a r
-lfilter f (Fold step begin done) = Fold step' begin done
+{-# INLINABLE filter #-}
+filter :: Monad m => (a -> Bool) -> Fold m a r -> Fold m a r
+filter f (Fold step begin done) = Fold step' begin done
     where
     step' x a = if f a then step x a else return $ Partial x
 
--- | Like 'lfilter' but with a monadic predicate.
+-- | Like 'filter' but with a monadic predicate.
 --
 -- @since 0.7.0
-{-# INLINABLE lfilterM #-}
-lfilterM :: Monad m => (a -> m Bool) -> Fold m a r -> Fold m a r
-lfilterM f (Fold step begin done) = Fold step' begin done
+{-# INLINABLE filterM #-}
+filterM :: Monad m => (a -> m Bool) -> Fold m a r -> Fold m a r
+filterM f (Fold step begin done) = Fold step' begin done
     where
     step' x a = do
       use <- f a
@@ -696,7 +696,7 @@ lfilterM f (Fold step begin done) = Fold step' begin done
 -- 'Just' values.
 {-# INLINE lcatMaybes #-}
 lcatMaybes :: Monad m => Fold m a b -> Fold m (Maybe a) b
-lcatMaybes = lfilter isJust . lmap fromJust
+lcatMaybes = filter isJust . lmap fromJust
 
 ------------------------------------------------------------------------------
 -- Parsing

--- a/src/Streamly/Internal/Data/Fold/Types.hs
+++ b/src/Streamly/Internal/Data/Fold/Types.hs
@@ -203,7 +203,7 @@ module Streamly.Internal.Data.Fold.Types
     , many
     , lsessionsOf
     , lchunksOf
-    , lchunksOf2
+    , chunksOf2
 
     , duplicate
     , initialize
@@ -875,9 +875,9 @@ many (Fold cstep cinitial cextract) (Fold sstep sinitial sextract) =
 lchunksOf :: Monad m => Int -> Fold m a b -> Fold m b c -> Fold m a c
 lchunksOf n split collect = many collect (takeLE n split)
 
-{-# INLINE lchunksOf2 #-}
-lchunksOf2 :: Monad m => Int -> Fold m a b -> Fold2 m x b c -> Fold2 m x a c
-lchunksOf2 n (Fold step1 initial1 extract1) (Fold2 step2 inject2 extract2) =
+{-# INLINE chunksOf2 #-}
+chunksOf2 :: Monad m => Int -> Fold m a b -> Fold2 m x b c -> Fold2 m x a c
+chunksOf2 n (Fold step1 initial1 extract1) (Fold2 step2 inject2 extract2) =
     Fold2 step' inject' extract'
 
     where

--- a/src/Streamly/Internal/Data/Fold/Types.hs
+++ b/src/Streamly/Internal/Data/Fold/Types.hs
@@ -201,7 +201,7 @@ module Streamly.Internal.Data.Fold.Types
     -- * Nested Application
     , concatMap
     , many
-    , lsessionsOf
+    , intervalsOf
     , chunksOf
     , chunksOf2
 
@@ -968,10 +968,10 @@ takeByTime n (Fold step initial done) = Fold step' initial' done'
 --
 -- @
 --
--- > lsessionsOf n split collect = many collect (takeByTime n split)
+-- > intervalsOf n split collect = many collect (takeByTime n split)
 --
 -- /Internal/
 --
-{-# INLINE lsessionsOf #-}
-lsessionsOf :: MonadAsync m => Double -> Fold m a b -> Fold m b c -> Fold m a c
-lsessionsOf n split collect = many collect (takeByTime n split)
+{-# INLINE intervalsOf #-}
+intervalsOf :: MonadAsync m => Double -> Fold m a b -> Fold m b c -> Fold m a c
+intervalsOf n split collect = many collect (takeByTime n split)

--- a/src/Streamly/Internal/Data/Stream/IsStream/Eliminate.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Eliminate.hs
@@ -382,7 +382,7 @@ drain = P.drain
 
 -- |
 -- > drainN n = drain . take n
--- > drainN n = fold (Fold.ltake n Fold.drain)
+-- > drainN n = fold (Fold.takeLE n Fold.drain)
 --
 -- Run maximum up to @n@ iterations of a stream.
 --

--- a/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
@@ -877,7 +877,7 @@ iterateMapLeftsWith combine f = iterateMapWith combine (either f (const K.nil))
 -- This is the streaming dual of the 'Streamly.Internal.Data.Fold.many'
 -- parse combinator.
 --
--- >>> f = Fold.ltake 2 Fold.sum
+-- >>> f = Fold.takeLE 2 Fold.sum
 -- >>> Stream.toList $ Stream.foldMany f $ Stream.fromList [1..10]
 -- > [3,7,11,15,19]
 --
@@ -912,7 +912,7 @@ foldSequence _f _m = undefined
 -- generate the first fold, the fold is applied on the stream and the result of
 -- the fold is used to generate the next fold and so on.
 --
--- >>> f x = Fold.ltake 2 (Fold.mconcatTo x)
+-- >>> f x = Fold.takeLE 2 (Fold.mconcatTo x)
 -- >>> s = Stream.map Sum $ Stream.fromList [1..10]
 -- >>> Stream.toList $ Stream.map getSum $ Stream.foldIterate f 0 s
 -- > [3,10,21,36,55,55]
@@ -1535,15 +1535,15 @@ splitOnSuffixSeqAny subseq f m = undefined
 -- >> S.toList $ S.chunksOf 2 FL.sum (S.enumerateFromTo 1 10)
 -- > [3,7,11,15,19]
 --
--- This can be considered as an n-fold version of 'ltake' where we apply
--- 'ltake' repeatedly on the leftover stream until the stream exhausts.
+-- This can be considered as an n-fold version of 'takeLE' where we apply
+-- 'takeLE' repeatedly on the leftover stream until the stream exhausts.
 --
 -- @since 0.7.0
 {-# INLINE chunksOf #-}
 chunksOf
     :: (IsStream t, Monad m)
     => Int -> Fold m a b -> t m a -> t m b
-chunksOf n f = foldMany (FL.ltake n f)
+chunksOf n f = foldMany (FL.takeLE n f)
 
 -- |
 --

--- a/src/Streamly/Internal/FileSystem/Dir.hs
+++ b/src/Streamly/Internal/FileSystem/Dir.hs
@@ -388,7 +388,7 @@ writeChunksWithBufferOf n h = lpackArraysChunksOf n (writeChunks h)
 -- @since 0.7.0
 {-# INLINE writeWithBufferOf #-}
 writeWithBufferOf :: MonadIO m => Int -> Handle -> Fold m Word8 ()
-writeWithBufferOf n h = FL.lchunksOf n (writeNUnsafe n) (writeChunks h)
+writeWithBufferOf n h = FL.chunksOf n (writeNUnsafe n) (writeChunks h)
 
 -- > write = 'writeWithBufferOf' A.defaultChunkSize
 --

--- a/src/Streamly/Internal/FileSystem/File.hs
+++ b/src/Streamly/Internal/FileSystem/File.hs
@@ -377,7 +377,7 @@ writeChunks path = Fold step initial extract
 writeWithBufferOf :: (MonadIO m, MonadCatch m)
     => Int -> FilePath -> Fold m Word8 ()
 writeWithBufferOf n path =
-    FL.lchunksOf n (writeNUnsafe n) (writeChunks path)
+    FL.chunksOf n (writeNUnsafe n) (writeChunks path)
 
 -- > write = 'writeWithBufferOf' A.defaultChunkSize
 --

--- a/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/src/Streamly/Internal/FileSystem/Handle.hs
@@ -464,7 +464,7 @@ writeWithBufferOf n h = FL.lchunksOf n (writeNUnsafe n) (writeChunks h)
 
 {-# INLINE writeWithBufferOf2 #-}
 writeWithBufferOf2 :: MonadIO m => Int -> Fold2 m Handle Word8 ()
-writeWithBufferOf2 n = FL.lchunksOf2 n (writeNUnsafe n) writeChunks2
+writeWithBufferOf2 n = FL.chunksOf2 n (writeNUnsafe n) writeChunks2
 
 -- > write = 'writeWithBufferOf' A.defaultChunkSize
 --

--- a/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/src/Streamly/Internal/FileSystem/Handle.hs
@@ -460,7 +460,7 @@ writeChunksWithBufferOf n h = lpackArraysChunksOf n (writeChunks h)
 -- @since 0.7.0
 {-# INLINE writeWithBufferOf #-}
 writeWithBufferOf :: MonadIO m => Int -> Handle -> Fold m Word8 ()
-writeWithBufferOf n h = FL.lchunksOf n (writeNUnsafe n) (writeChunks h)
+writeWithBufferOf n h = FL.chunksOf n (writeNUnsafe n) (writeChunks h)
 
 {-# INLINE writeWithBufferOf2 #-}
 writeWithBufferOf2 :: MonadIO m => Int -> Fold2 m Handle Word8 ()

--- a/src/Streamly/Internal/Memory/ArrayStream.hs
+++ b/src/Streamly/Internal/Memory/ArrayStream.hs
@@ -232,5 +232,5 @@ toArraysInRange low high (Fold step initial extract) =
 {-# INLINE _toArraysOf #-}
 _toArraysOf :: (MonadIO m, Storable a)
     => Int -> Fold m a (SerialT Identity (Array a))
-_toArraysOf n = FL.lchunksOf n (A.writeNF n) FL.toStream
+_toArraysOf n = FL.chunksOf n (A.writeNF n) FL.toStream
 -}

--- a/src/Streamly/Internal/Network/Inet/TCP.hs
+++ b/src/Streamly/Internal/Network/Inet/TCP.hs
@@ -396,7 +396,7 @@ writeWithBufferOf
     -> PortNumber
     -> Fold m Word8 ()
 writeWithBufferOf n addr port =
-    FL.lchunksOf n (writeNUnsafe n) (writeChunks addr port)
+    FL.chunksOf n (writeNUnsafe n) (writeChunks addr port)
 
 -- | Write a stream to the supplied IPv4 host address and port number.
 --

--- a/src/Streamly/Internal/Network/Socket.hs
+++ b/src/Streamly/Internal/Network/Socket.hs
@@ -503,7 +503,7 @@ fromBytesWithBufferOf n h m = fromChunks h $ AS.arraysOf n m
 -- @since 0.7.0
 {-# INLINE writeWithBufferOf #-}
 writeWithBufferOf :: MonadIO m => Int -> Socket -> Fold m Word8 ()
-writeWithBufferOf n h = FL.lchunksOf n (A.writeNUnsafe n) (writeChunks h)
+writeWithBufferOf n h = FL.chunksOf n (A.writeNUnsafe n) (writeChunks h)
 
 -- > write = 'writeWithBufferOf' A.defaultChunkSize
 --

--- a/test/Streamly/Test/Data/Fold.hs
+++ b/test/Streamly/Test/Data/Fold.hs
@@ -215,10 +215,10 @@ and ls = S.fold FL.and (S.fromList ls) `shouldReturn` Prelude.and ls
 or :: [Bool] -> Expectation
 or ls = S.fold FL.or (S.fromList ls) `shouldReturn` Prelude.or ls
 
-ltake :: [Int] -> Property
-ltake ls =
+takeLE :: [Int] -> Property
+takeLE ls =
     forAll (chooseInt (-1, Prelude.length ls + 2)) $ \n ->
-            S.fold (F.ltake n FL.toList) (S.fromList ls)
+            S.fold (F.takeLE n FL.toList) (S.fromList ls)
                 `shouldReturn` Prelude.take n ls
 
 sliceSepBy :: Property
@@ -443,7 +443,7 @@ main = hspec $
         prop "And" Main.and
         prop "Or" Main.or
         prop "mapMaybe" mapMaybe
-        prop "ltake" ltake
+        prop "takeLE" takeLE
         prop "sliceSepBy" sliceSepBy
         prop "sliceSepByMax" sliceSepByMax
         prop "drain" Main.drain

--- a/test/Streamly/Test/Data/Parser.hs
+++ b/test/Streamly/Test/Data/Parser.hs
@@ -535,8 +535,8 @@ applicative =
         forAll (listOf (chooseAny :: Gen Int)) $ \ list2 ->
             let parser =
                     (,)
-                        <$> P.fromFold (FL.ltake (length list1) FL.toList)
-                        <*> P.fromFold (FL.ltake (length list2) FL.toList)
+                        <$> P.fromFold (FL.takeLE (length list1) FL.toList)
+                        <*> P.fromFold (FL.takeLE (length list2) FL.toList)
              in monadicIO $ do
                     (olist1, olist2) <-
                         run $ S.parse parser (S.fromList $ list1 ++ list2)
@@ -546,7 +546,7 @@ applicative =
 sequence :: Property
 sequence =
     forAll (vectorOf 11 (listOf (chooseAny :: Gen Int))) $ \ ins ->
-        let p xs = P.fromFold (FL.ltake (length xs) FL.toList)
+        let p xs = P.fromFold (FL.takeLE (length xs) FL.toList)
          in monadicIO $ do
                 outs <- run $
                         S.parse
@@ -559,8 +559,8 @@ monad =
     forAll (listOf (chooseAny :: Gen Int)) $ \ list1 ->
         forAll (listOf (chooseAny :: Gen Int)) $ \ list2 ->
             let parser = do
-                    olist1 <- P.fromFold (FL.ltake (length list1) FL.toList)
-                    olist2 <- P.fromFold (FL.ltake (length list2) FL.toList)
+                    olist1 <- P.fromFold (FL.takeLE (length list1) FL.toList)
+                    olist2 <- P.fromFold (FL.takeLE (length list2) FL.toList)
                     return (olist1, olist2)
              in monadicIO $ do
                     (olist1, olist2) <-
@@ -578,7 +578,7 @@ parseMany =
         forAll (listOf (vectorOf len (chooseAny :: Gen Int))) $ \ ins ->
             monadicIO $ do
                 outs <- do
-                    let p = P.fromFold $ FL.ltake len FL.toList
+                    let p = P.fromFold $ FL.takeLE len FL.toList
                     run
                         $ S.toList
                         $ S.parseMany p (S.fromList $ concat ins)

--- a/test/Streamly/Test/Data/Parser/ParserD.hs
+++ b/test/Streamly/Test/Data/Parser/ParserD.hs
@@ -182,7 +182,7 @@ take :: Property
 take =
     forAll (chooseInt (min_value, max_value)) $ \n ->
         forAll (listOf (chooseInt (min_value, max_value))) $ \ls ->
-            case S.parseD (P.fromFold $ FL.ltake n FL.toList) (S.fromList ls) of
+            case S.parseD (P.fromFold $ FL.takeLE n FL.toList) (S.fromList ls) of
                 Right parsed_list -> checkListEqual parsed_list (Prelude.take n ls)
                 Left _ -> property False
 
@@ -263,7 +263,7 @@ lookAheadPass :: Property
 lookAheadPass =
     forAll (chooseInt (min_value, max_value)) $ \n ->
         let
-            takeWithoutConsume = P.lookAhead $ P.fromFold $ FL.ltake n FL.toList
+            takeWithoutConsume = P.lookAhead $ P.fromFold $ FL.takeLE n FL.toList
             parseTwice = do
                 parsed_list_1 <- takeWithoutConsume
                 parsed_list_2 <- takeWithoutConsume
@@ -279,7 +279,7 @@ lookAhead :: Property
 lookAhead =
     forAll (chooseInt (min_value, max_value)) $ \n ->
         let
-            takeWithoutConsume = P.lookAhead $ P.fromFold $ FL.ltake n FL.toList
+            takeWithoutConsume = P.lookAhead $ P.fromFold $ FL.takeLE n FL.toList
             parseTwice = do
                 parsed_list_1 <- takeWithoutConsume
                 parsed_list_2 <- takeWithoutConsume
@@ -396,7 +396,7 @@ teeWithPass =
     forAll (chooseInt (min_value, max_value)) $ \n ->
         forAll (listOf (chooseInt (0, 1))) $ \ls ->
             let
-                prsr = P.fromFold $ FL.ltake n FL.toList
+                prsr = P.fromFold $ FL.takeLE n FL.toList
             in
                 case S.parseD (P.teeWith (,) prsr prsr) (S.fromList ls) of
                     Right (ls_1, ls_2) -> checkListEqual (Prelude.take n ls) ls_1 .&&. checkListEqual ls_1 ls_2
@@ -536,8 +536,8 @@ applicative =
         forAll (listOf (chooseAny :: Gen Int)) $ \ list2 ->
             let parser =
                         (,)
-                            <$> P.fromFold (FL.ltake (length list1) FL.toList)
-                            <*> P.fromFold (FL.ltake (length list2) FL.toList)
+                            <$> P.fromFold (FL.takeLE (length list1) FL.toList)
+                            <*> P.fromFold (FL.takeLE (length list2) FL.toList)
              in monadicIO $ do
                     (olist1, olist2) <-
                         run $ S.parseD parser (S.fromList $ list1 ++ list2)
@@ -547,7 +547,7 @@ applicative =
 sequence :: Property
 sequence =
     forAll (vectorOf 11 (listOf (chooseAny :: Gen Int))) $ \ ins ->
-        let parsers = fmap (\xs -> P.fromFold $ FL.ltake (length xs) FL.toList) ins
+        let parsers = fmap (\xs -> P.fromFold $ FL.takeLE (length xs) FL.toList) ins
          in monadicIO $ do
                 outs <- run $
                         S.parseD
@@ -560,8 +560,8 @@ monad =
     forAll (listOf (chooseAny :: Gen Int)) $ \ list1 ->
         forAll (listOf (chooseAny :: Gen Int)) $ \ list2 ->
             let parser = do
-                            olist1 <- P.fromFold (FL.ltake (length list1) FL.toList)
-                            olist2 <- P.fromFold (FL.ltake (length list2) FL.toList)
+                            olist1 <- P.fromFold (FL.takeLE (length list1) FL.toList)
+                            olist2 <- P.fromFold (FL.takeLE (length list2) FL.toList)
                             return (olist1, olist2)
              in monadicIO $ do
                     (olist1, olist2) <-
@@ -582,7 +582,7 @@ parseMany =
                     ( run
                     $ S.toList
                     $ S.parseManyD
-                        (P.fromFold $ FL.ltake len FL.toList) (S.fromList $ concat ins)
+                        (P.fromFold $ FL.takeLE len FL.toList) (S.fromList $ concat ins)
                     )
                 listEquals (==) outs ins
 


### PR DESCRIPTION
Fold.ltake -> Fold.takeLE
Fold.lfilter -> Fold.filter
Fold.lfilterM -> Fold.filterM
Fold.lmap -> Fold.map
Fold.lchunksOf2 -> Fold.chunksOf2
Fold.lchunksOf -> Fold.chunksOf
Fold.lsessionsOf -> Fold.intervalsOf