### PR TITLE
Rename some modules.

### DIFF
--- a/.hlint.ignore
+++ b/.hlint.ignore
@@ -30,7 +30,7 @@ test/Streamly/Test/Common/Array.hs
 test/Streamly/Test/Data/Array.hs
 test/Streamly/Test/Data/Array/Prim.hs
 test/Streamly/Test/Data/Array/Prim/Pinned.hs
-test/Streamly/Test/Data/Array/Storable/Foreign.hs
+test/Streamly/Test/Data/Array/Foreign.hs
 test/Streamly/Test/Data/Parser.hs
 test/Streamly/Test/Data/Parser/ParserD.hs
 test/Streamly/Test/Data/SmallArray.hs

--- a/Changelog.md
+++ b/Changelog.md
@@ -52,7 +52,7 @@
 ### Deprecations
 
 * Deprecate `Streamly.Memory.Array` in favor of
-  `Streamly.Data.Array.Storable.Foreign`
+  `Streamly.Data.Array.Foreign`
 * Deprecate `Streamly.Data.Unicode.Stream` in favor of
   `Streamly.Unicode.Stream`
 * The `Streamly` module is now deprecated, its functionality is subsumed

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ documentation.
 
 ## Arrays
 
-The `Streamly.Data.Array.Storable.Foreign` module provides immutable arrays.  Arrays are the
+The `Streamly.Data.Array.Foreign` module provides immutable arrays.  Arrays are the
 computing duals of streams. Streams are good at sequential access and immutable
 transformations of in-transit data whereas arrays are good at random access and
 in-place transformations of buffered data. Unlike streams which are potentially
@@ -373,7 +373,7 @@ computing system. The design of streamly as a general purpose computing
 framework is centered around these two fundamental aspects of computing and
 storage.
 
-`Streamly.Data.Array.Storable.Foreign` uses pinned memory outside GC and therefore avoid any
+`Streamly.Data.Array.Foreign` uses pinned memory outside GC and therefore avoid any
 GC overhead for the storage in arrays. Streamly allows efficient
 transformations over arrays using streams. It uses arrays to transfer data to
 and from the operating system and to store data in memory.
@@ -416,7 +416,7 @@ module Main where
 
 import qualified Streamly.Prelude as S
 import qualified Streamly.Data.Fold as FL
-import qualified Streamly.Data.Array.Storable.Foreign as A
+import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.FileSystem.Handle as FH
 import qualified System.IO as FH
 

--- a/benchmark/NanoBenchmarks.hs
+++ b/benchmark/NanoBenchmarks.hs
@@ -9,7 +9,7 @@
 import Streamly.Prelude (SerialT)
 import Streamly.Internal.Data.SVar (MonadAsync)
 
-import qualified Streamly.Data.Array.Storable.Foreign as A
+import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.FileSystem.Handle as FH
 import qualified Streamly.Internal.FileSystem.Handle as IFH
 import qualified Streamly.Data.Fold as FL

--- a/benchmark/Streamly/Benchmark/Data/Array.hs
+++ b/benchmark/Streamly/Benchmark/Data/Array.hs
@@ -12,8 +12,8 @@ import Control.DeepSeq (NFData(..))
 import System.Random (randomRIO)
 
 import qualified Streamly.Benchmark.Data.ArrayOps as Ops
-import qualified Streamly.Data.Array.Storable.Foreign as A
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as IA
+import qualified Streamly.Data.Array.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign as IA
 import qualified Streamly.Prelude  as S
 
 import Gauge

--- a/benchmark/Streamly/Benchmark/Data/ArrayOps.hs
+++ b/benchmark/Streamly/Benchmark/Data/ArrayOps.hs
@@ -35,8 +35,8 @@ import qualified Streamly.Internal.Data.SmallArray as A
 type Stream = A.SmallArray
 #elif defined(MEMORY_ARRAY)
 import qualified GHC.Exts as GHC
-import qualified Streamly.Data.Array.Storable.Foreign as A
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
+import qualified Streamly.Data.Array.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign as A
 type Stream = A.Array
 #elif defined(DATA_ARRAY_PRIM)
 import qualified Streamly.Internal.Data.Array.Prim as A

--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/Read.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/Read.hs
@@ -33,8 +33,8 @@ import GHC.Magic (noinline)
 import System.IO (Handle)
 
 import qualified Streamly.FileSystem.Handle as FH
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as AT
+import qualified Streamly.Internal.Data.Array.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign.Types as AT
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Parser as PR
 import qualified Streamly.Internal.Data.Stream.IsStream as IP
@@ -51,7 +51,7 @@ import Streamly.Benchmark.Common.Handle
 #ifdef INSPECTION
 import Streamly.Internal.Data.Stream.StreamD.Type (Step(..), GroupState)
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types as MA
+import qualified Streamly.Internal.Data.Array.Foreign.Mut.Types as MA
 import qualified Streamly.Internal.Data.Stream.StreamD as D
 import qualified Streamly.Internal.Data.Unfold as IUF
 

--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/Read.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/Read.hs
@@ -39,7 +39,7 @@ import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Parser as PR
 import qualified Streamly.Internal.Data.Stream.IsStream as IP
 import qualified Streamly.Internal.FileSystem.Handle as IFH
-import qualified Streamly.Internal.Memory.ArrayStream as AS
+import qualified Streamly.Internal.Data.Array.Stream.Foreign as AS
 import qualified Streamly.Internal.Unicode.Stream as IUS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Unicode.Stream as SS

--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
@@ -29,7 +29,7 @@ import Streamly.Internal.Data.Array.Foreign.Types (defaultChunkSize)
 import qualified Streamly.FileSystem.Handle as FH
 import qualified Streamly.Internal.Data.Unfold as IUF
 import qualified Streamly.Internal.FileSystem.Handle as IFH
-import qualified Streamly.Internal.Memory.ArrayStream as AS
+import qualified Streamly.Internal.Data.Array.Stream.Foreign as AS
 import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.Prelude as S
 

--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
@@ -24,13 +24,13 @@ where
 
 import System.IO (Handle)
 import Prelude hiding (last, length)
-import Streamly.Internal.Data.Array.Storable.Foreign.Types (defaultChunkSize)
+import Streamly.Internal.Data.Array.Foreign.Types (defaultChunkSize)
 
 import qualified Streamly.FileSystem.Handle as FH
 import qualified Streamly.Internal.Data.Unfold as IUF
 import qualified Streamly.Internal.FileSystem.Handle as IFH
 import qualified Streamly.Internal.Memory.ArrayStream as AS
-import qualified Streamly.Data.Array.Storable.Foreign as A
+import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.Prelude as S
 
 import Gauge hiding (env)
@@ -43,8 +43,8 @@ import Streamly.Internal.Data.Stream.StreamD.Type (Step(..))
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
 import qualified Streamly.Internal.Data.Tuple.Strict as Strict
 import qualified Streamly.Internal.Data.Array.Stream.Mut.Foreign as MAS
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as AT
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types as MA
+import qualified Streamly.Internal.Data.Array.Foreign.Types as AT
+import qualified Streamly.Internal.Data.Array.Foreign.Mut.Types as MA
 
 import Test.Inspection
 #endif

--- a/benchmark/Streamly/Benchmark/Prelude/Serial/Split.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial/Split.hs
@@ -25,7 +25,7 @@ import Data.Word (Word8)
 import System.IO (Handle)
 
 import qualified Streamly.FileSystem.Handle as FH
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Parser as PR
 import qualified Streamly.Internal.Data.Stream.IsStream as IP
@@ -41,7 +41,7 @@ import Streamly.Benchmark.Common.Handle
 #ifdef INSPECTION
 import Streamly.Internal.Data.Stream.StreamD.Type (Step(..))
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types as MA
+import qualified Streamly.Internal.Data.Array.Foreign.Mut.Types as MA
 import qualified Streamly.Internal.Data.Unfold as IUF
 
 import Test.Inspection
@@ -229,4 +229,3 @@ benchmarks moduleName env =
             , o_1_space_reduce_toChunks_split env
             ]
         ]
-

--- a/benchmark/Streamly/Benchmark/Unicode/Stream.hs
+++ b/benchmark/Streamly/Benchmark/Unicode/Stream.hs
@@ -29,7 +29,7 @@ import qualified Streamly.Internal.Unicode.Stream as IUS
 import qualified Streamly.Internal.FileSystem.Handle as IFH
 import qualified Streamly.Internal.Unicode.Array.Char as IUA
 import qualified Streamly.Internal.Data.Stream.IsStream as IP
-import qualified Streamly.Data.Array.Storable.Foreign as A
+import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.Prelude as S
 
 import Gauge hiding (env)
@@ -40,8 +40,8 @@ import Streamly.Benchmark.Common.Handle
 import Foreign.Storable (Storable)
 import Streamly.Internal.Data.Stream.StreamD.Type (Step(..))
 import qualified Streamly.Internal.Data.Tuple.Strict as Strict
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as AT
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types as MA
+import qualified Streamly.Internal.Data.Array.Foreign.Types as AT
+import qualified Streamly.Internal.Data.Array.Foreign.Mut.Types as MA
 
 import Test.Inspection
 #endif

--- a/benchmark/streamly-benchmarks.cabal
+++ b/benchmark/streamly-benchmarks.cabal
@@ -162,7 +162,7 @@ common bench-options-threaded
 benchmark Prelude.Serial
   import: bench-options
   type: exitcode-stdio-1.0
-  hs-source-dirs: Streamly/Benchmark/Prelude 
+  hs-source-dirs: Streamly/Benchmark/Prelude
   main-is: Serial.hs
   other-modules:
         Serial.Generation
@@ -432,7 +432,7 @@ benchmark Data.Array.Prim.Pinned
   other-modules: Streamly.Benchmark.Data.ArrayOps
   cpp-options: -DDATA_ARRAY_PRIM_PINNED
 
-benchmark Data.Array.Storable.Foreign
+benchmark Data.Array.Foreign
   import: bench-options
   type: exitcode-stdio-1.0
   hs-source-dirs: .
@@ -461,7 +461,7 @@ benchmark Unicode.Stream
   type: exitcode-stdio-1.0
   hs-source-dirs: Streamly/Benchmark/Unicode
   main-is: Stream.hs
- 
+
 -------------------------------------------------------------------------------
 -- benchmark comparison and presentation
 -------------------------------------------------------------------------------

--- a/bin/targets.sh
+++ b/bin/targets.sh
@@ -34,7 +34,7 @@ prelude_other_grp="\
 
 array_grp="\
   Data.Array \
-  Data.Array.Storable.Foreign \
+  Data.Array.Foreign \
   Data.Array.Prim \
   Data.SmallArray \
   Data.Array.Prim.Pinned"

--- a/design/module-organization.md
+++ b/design/module-organization.md
@@ -143,9 +143,9 @@ conflict with any other module on Hackage.
 We have the following module hierarchy under Streamly:
 
 * Data: This is a generic bucket for basic data structures a la the `base`
-  package's `Data` hierarchy. 
+  package's `Data` hierarchy.
     * Streamly.Data.Array
-  
+
   Streams can be classified under `Data` or `Control`.  Though they are
   mostly used for processing, they can also be used to store data in
   memory.
@@ -216,7 +216,7 @@ Similarly, the immutable Array modules would go in:
 * `Streamly.Data.Array`                  -- unpinned, native memory arrays
 * `Streamly.Data.Array.Storable`         -- unpinned, unboxed, native memory arrays
 * `Streamly.Data.Array.Storable.Pinned`  -- pinned, unboxed, native memory arrays
-* `Streamly.Data.Array.Storable.Foreign` -- pinned, unboxed, foreign capable arrays
+* `Streamly.Data.Array.Foreign` -- pinned, unboxed, foreign capable arrays
 
 Unboxed arrays, based on `Prim` type class:
 

--- a/design/optimization-guidelines.md
+++ b/design/optimization-guidelines.md
@@ -317,7 +317,7 @@ consume as arguments. This means `StreamD` combinators should not be marked
 as `INLINE` or `INLINE_EARLY`, instead they should all be marked as
 `INLINE_NORMAL` because higher order functions like `concatMap`/`map`/`mapM`
 etc are marked as `INLINE_NORMAL`. `StreamD` functions in other modules like
-`Streamly.Data.Array.Storable.Foreign` should also follow the same rules.
+`Streamly.Data.Array.Foreign` should also follow the same rules.
 
 ## Stream Fusion
 

--- a/hie.yaml
+++ b/hie.yaml
@@ -48,8 +48,8 @@ cradle:
           cabal:
             - path: "./test/Streamly/Test/Data/Array.hs"
               component: "test:Data.Array"
-            - path: "./test/Streamly/Test/Data/Array/Storable/Foreign.hs"
-              component: "Data.Array.Storable.Foreign"
+            - path: "./test/Streamly/Test/Data/Array/Foreign.hs"
+              component: "Data.Array.Foreign"
             - path: "./test/Streamly/Test/Data/Fold.hs"
               component: "test:Data.Fold"
             - path: "./test/Streamly/Test/Data/List.hs"

--- a/src/Streamly.hs
+++ b/src/Streamly.hs
@@ -244,7 +244,7 @@ import qualified Streamly.Internal.Data.Stream.Async as Async
 -- > S.length $ S.splitOnSuffix FL.drain 10 $ FH.read fh
 --
 -- The following example folds the lines to arrays of 'Word8' using the
--- 'Streamly.Data.Array.Storable.Foreign.writeF' fold and then wraps the lines in square
+-- 'Streamly.Data.Array.Foreign.writeF' fold and then wraps the lines in square
 -- brackets before writing them to standard output using
 -- 'Streamly.FileSystem.Handle.write':
 --
@@ -295,7 +295,7 @@ import qualified Streamly.Internal.Data.Stream.Async as Async
 
 -- $arrays
 --
--- Streamly arrays (See "Streamly.Data.Array.Storable.Foreign") complement streams to provide an
+-- Streamly arrays (See "Streamly.Data.Array.Foreign") complement streams to provide an
 -- efficient computing paradigm.  Streams are suitable for immutable
 -- transformations of /potentially infinite/ data using /sequential access/ and
 -- pipelined transformations whereas arrays are suitable for in-place

--- a/src/Streamly/Data/Array/Foreign.hs
+++ b/src/Streamly/Data/Array/Foreign.hs
@@ -1,7 +1,7 @@
 #include "inline.hs"
 
 -- |
--- Module      : Streamly.Data.Array.Storable.Foreign
+-- Module      : Streamly.Data.Array.Foreign
 -- Copyright   : (c) 2019 Composewell Technologies
 --
 -- License     : BSD3
@@ -32,9 +32,9 @@
 --
 -- > import qualified Streamly.Array as A
 --
--- For experimental APIs see "Streamly.Internal.Data.Array.Storable.Foreign".
+-- For experimental APIs see "Streamly.Internal.Data.Array.Foreign".
 
-module Streamly.Data.Array.Storable.Foreign
+module Streamly.Data.Array.Foreign
     (
       A.Array
 
@@ -70,4 +70,4 @@ module Streamly.Data.Array.Storable.Foreign
     )
 where
 
-import Streamly.Internal.Data.Array.Storable.Foreign as A
+import Streamly.Internal.Data.Array.Foreign as A

--- a/src/Streamly/Data/Unicode/Stream.hs
+++ b/src/Streamly/Data/Unicode/Stream.hs
@@ -12,11 +12,11 @@
 -- A 'Char' stream is the canonical representation to process Unicode strings.
 -- It can be processed efficiently using regular stream processing operations.
 -- A byte stream of Unicode text read from an IO device or from an
--- 'Streamly.Data.Array.Storable.Foreign.Array' in memory can be decoded into a 'Char' stream
+-- 'Streamly.Data.Array.Foreign.Array' in memory can be decoded into a 'Char' stream
 -- using the decoding routines in this module.  A 'String' (@[Char]@) can be
 -- converted into a 'Char' stream using 'Streamly.Prelude.fromList'.  An @Array
 -- Char@ can be 'Streamly.Prelude.unfold'ed into a stream using the array
--- 'Streamly.Data.Array.Storable.Foreign.read' unfold.
+-- 'Streamly.Data.Array.Foreign.read' unfold.
 --
 -- = Storing Unicode Strings
 --
@@ -30,7 +30,7 @@
 -- than pinned arrays for short and short lived strings.
 --
 -- For longer or long lived streams you can 'Streamly.Prelude.fold' the 'Char'
--- stream as @Array Char@ using the array 'Streamly.Data.Array.Storable.Foreign.write' fold.
+-- stream as @Array Char@ using the array 'Streamly.Data.Array.Foreign.write' fold.
 -- The 'Array' type provides a more compact representation and pinned memory
 -- reducing GC overhead. If space efficiency is a concern you can use
 -- 'encodeUtf8'' on the 'Char' stream before writing it to an 'Array' providing

--- a/src/Streamly/FileSystem/FD.hs
+++ b/src/Streamly/FileSystem/FD.hs
@@ -25,7 +25,7 @@
 --
 -- Reading and writing APIs are divided into two categories, sequential
 -- streaming APIs and random or seekable access APIs.  File IO APIs are quite
--- similar to "Streamly.Data.Array.Storable.Foreign" read write APIs. In that regard, arrays can
+-- similar to "Streamly.Data.Array.Foreign" read write APIs. In that regard, arrays can
 -- be considered as in-memory files or files can be considered as on-disk
 -- arrays.
 --
@@ -130,8 +130,8 @@ import Prelude hiding (read)
 import qualified GHC.IO.FD as FD
 import qualified GHC.IO.Device as RawIO
 
-import Streamly.Internal.Data.Array.Storable.Foreign.Types (Array(..), byteLength, defaultChunkSize, unsafeFreeze)
-import Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types (mutableArray)
+import Streamly.Internal.Data.Array.Foreign.Types (Array(..), byteLength, defaultChunkSize, unsafeFreeze)
+import Streamly.Internal.Data.Array.Foreign.Mut.Types (mutableArray)
 
 import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Stream.StreamK.Type (IsStream, mkStream)
@@ -145,7 +145,7 @@ import qualified Streamly.FileSystem.FDIO as RawIO hiding (write)
 -- import Streamly.Data.Fold (Fold)
 -- import Streamly.String (encodeUtf8, decodeUtf8, foldLines)
 
-import qualified Streamly.Data.Array.Storable.Foreign as A
+import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.Internal.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -10,7 +10,7 @@
 -- Portability : GHC
 --
 -- Read and write streams and arrays to and from file handles. File handle IO
--- APIs are quite similar to "Streamly.Data.Array.Storable.Foreign" read write APIs. In that
+-- APIs are quite similar to "Streamly.Data.Array.Foreign" read write APIs. In that
 -- regard, arrays can be considered as in-memory files or files can be
 -- considered as on-disk arrays.
 --
@@ -44,12 +44,12 @@ module Streamly.FileSystem.Handle
     -- the stream is lazy and generated on-demand as the consumer consumes it.
     -- Read IO requests to the IO device are performed in chunks limited to a
     -- maximum size of 32KiB, this is referred to as
-    -- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize' in the
+    -- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize' in the
     -- documentation. One IO request may or may not read the full
     -- chunk. If the whole stream is not consumed, it is possible that we may
     -- read slightly more from the IO device than what the consumer needed.
     -- Unless specified otherwise in the API, writes are collected into chunks
-    -- of 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize' before they
+    -- of 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize' before they
     -- are written to the IO device.
 
     -- Streaming APIs work for all kind of devices, seekable or non-seekable;

--- a/src/Streamly/Internal/Data/Array/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign.hs
@@ -22,8 +22,8 @@
 -- less efficient compared to folding via streams.  'Semigroup' and 'Monoid'
 -- instances should be used with care; concatenating arrays using binary
 -- operations can be highly inefficient.  Instead, use
--- 'Streamly.Internal.Memory.ArrayStream.toArray' to concatenate N arrays at
--- once.
+-- 'Streamly.Internal.Data.Array.Stream.Foreign.toArray' to concatenate N
+-- arrays at once.
 --
 -- Each array is one pointer visible to the GC.  Too many small arrays (e.g.
 -- single byte) are only as good as holding those elements in a Haskell list.
@@ -169,7 +169,7 @@ import qualified Streamly.Internal.Data.Stream.Prelude as P
 import qualified Streamly.Internal.Data.Stream.Serial as Serial
 import qualified Streamly.Internal.Data.Stream.StreamD as D
 import qualified Streamly.Internal.Data.Unfold as Unfold
-import qualified Streamly.Memory.Ring as RB
+import qualified Streamly.Internal.Ring.Foreign as RB
 
 -------------------------------------------------------------------------------
 -- Construction

--- a/src/Streamly/Internal/Data/Array/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign.hs
@@ -3,7 +3,7 @@
 #include "inline.hs"
 
 -- |
--- Module      : Streamly.Internal.Data.Array.Storable.Foreign
+-- Module      : Streamly.Internal.Data.Array.Foreign
 -- Copyright   : (c) 2019 Composewell Technologies
 --
 -- License     : BSD3
@@ -32,7 +32,7 @@
 -- if we use one array for each chunk. This is still significant to add
 -- pressure to GC.
 
-module Streamly.Internal.Data.Array.Storable.Foreign
+module Streamly.Internal.Data.Array.Foreign
     (
       Array
 
@@ -156,14 +156,14 @@ import GHC.Ptr (Ptr(..))
 import GHC.Prim (touch#)
 import GHC.IO (IO(..))
 
-import Streamly.Internal.Data.Array.Storable.Foreign.Types (Array(..), length)
+import Streamly.Internal.Data.Array.Foreign.Types (Array(..), length)
 import Streamly.Internal.Data.Fold.Types (Fold(..))
 import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Tuple.Strict (Tuple3'(..))
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types as MA
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as A
+import qualified Streamly.Internal.Data.Array.Foreign.Mut.Types as MA
+import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Stream.Prelude as P
 import qualified Streamly.Internal.Data.Stream.Serial as Serial

--- a/src/Streamly/Internal/Data/Array/Foreign/Mut/Types.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Mut/Types.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE UnboxedTuples #-}
 
 -- |
--- Module      : Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types
+-- Module      : Streamly.Internal.Data.Array.Foreign.Mut.Types
 -- Copyright   : (c) 2020 Composewell Technologies
 -- License     : BSD3-3-Clause
 -- Maintainer  : streamly@composewell.com
@@ -22,7 +22,7 @@
 -- Stream and Fold APIs allow easy, efficient and convenient operations on
 -- arrays.
 
-module Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types
+module Streamly.Internal.Data.Array.Foreign.Mut.Types
     (
     -- * Type
     -- $arrayNotes
@@ -459,7 +459,7 @@ arraysOf n (D.Stream step state) =
     step' _ (GroupStart st) = do
         when (n <= 0) $
             -- XXX we can pass the module string from the higher level API
-            error $ "Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types.fromStreamDArraysOf: the size of "
+            error $ "Streamly.Internal.Data.Array.Foreign.Mut.Types.fromStreamDArraysOf: the size of "
                  ++ "arrays [" ++ show n ++ "] must be a natural number"
         Array start end bound <- liftIO $ newArray n
         return $ D.Skip (GroupBuffer st start end bound)

--- a/src/Streamly/Internal/Data/Array/Foreign/Types.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Types.hs
@@ -1,7 +1,7 @@
 #include "inline.hs"
 
 -- |
--- Module      : Streamly.Internal.Data.Array.Storable.Foreign.Types
+-- Module      : Streamly.Internal.Data.Array.Foreign.Types
 -- Copyright   : (c) 2020 Composewell Technologies
 --
 -- License     : BSD3-3-Clause
@@ -9,9 +9,9 @@
 -- Stability   : experimental
 -- Portability : GHC
 --
--- See notes in "Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types"
+-- See notes in "Streamly.Internal.Data.Array.Foreign.Mut.Types"
 --
-module Streamly.Internal.Data.Array.Storable.Foreign.Types
+module Streamly.Internal.Data.Array.Foreign.Types
     (
     -- $arrayNotes
       Array (..)
@@ -101,7 +101,7 @@ import Text.Read (readPrec, readListPrec, readListPrecDefault)
 
 import Prelude hiding (length, foldr, read, unlines, splitAt)
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types as MA
+import qualified Streamly.Internal.Data.Array.Foreign.Mut.Types as MA
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
 import qualified Streamly.Internal.Data.Stream.StreamK.Type as K
 import qualified GHC.Exts as Exts

--- a/src/Streamly/Internal/Data/Array/Prim/MutTypesInclude.hs
+++ b/src/Streamly/Internal/Data/Array/Prim/MutTypesInclude.hs
@@ -266,7 +266,7 @@ fromStreamDArraysOf n (D.Stream step state) = D.Stream step' (GroupStart state)
         when (n <= 0) $
             -- XXX we can pass the module string from the higher level API
             error $
-            "Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types.fromStreamDArraysOf: the size of " ++
+            "Streamly.Internal.Data.Array.Foreign.Mut.Types.fromStreamDArraysOf: the size of " ++
             "arrays [" ++ show n ++ "] must be a natural number"
         arr <- newArray n
         return $ D.Skip (GroupBuffer st arr 0)
@@ -319,7 +319,7 @@ packArraysChunksOf n (D.Stream step state) =
     step' gst (SpliceInitial st) = do
         when (n <= 0) $
             -- XXX we can pass the module string from the higher level API
-            error $ "Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types.packArraysChunksOf: the size of "
+            error $ "Streamly.Internal.Data.Array.Foreign.Mut.Types.packArraysChunksOf: the size of "
                  ++ "arrays [" ++ show n ++ "] must be a natural number"
         r <- step gst st
         case r of
@@ -364,7 +364,7 @@ lpackArraysChunksOf n (Fold step1 initial1 extract1) =
         when (n <= 0)
             -- XXX we can pass the module string from the higher level API
           $ error
-          $ "Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types."
+          $ "Streamly.Internal.Data.Array.Foreign.Mut.Types."
               ++ "packArraysChunksOf: the size of arrays ["
               ++ show n
               ++ "] must be a natural number"

--- a/src/Streamly/Internal/Data/Array/Prim/TypesInclude.hs
+++ b/src/Streamly/Internal/Data/Array/Prim/TypesInclude.hs
@@ -552,7 +552,7 @@ packArraysChunksOf n (D.Stream step state) =
     step' gst (SpliceInitial st) = do
         when (n <= 0) $
             -- XXX we can pass the module string from the higher level API
-            error $ "Streamly.Internal.Data.Array.Storable.Foreign.Types.packArraysChunksOf: the size of "
+            error $ "Streamly.Internal.Data.Array.Foreign.Types.packArraysChunksOf: the size of "
                  ++ "arrays [" ++ show n ++ "] must be a natural number"
         r <- step gst st
         case r of
@@ -602,7 +602,7 @@ lpackArraysChunksOf n (Fold step1 initial1 extract1) =
     initial = do
         when (n <= 0) $
             -- XXX we can pass the module string from the higher level API
-            error $ "Streamly.Internal.Data.Array.Storable.Foreign.Types.packArraysChunksOf: the size of "
+            error $ "Streamly.Internal.Data.Array.Foreign.Types.packArraysChunksOf: the size of "
                  ++ "arrays [" ++ show n ++ "] must be a natural number"
         res <- initial1
         return $ first (Tuple3' Nothing' 0) res

--- a/src/Streamly/Internal/Data/Array/Stream/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Stream/Foreign.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      : Streamly.Internal.Memory.ArrayStream
+-- Module      : Streamly.Internal.Data.Array.Stream.Foreign
 -- Copyright   : (c) 2019 Composewell Technologies
 -- License     : BSD3-3-Clause
 -- Maintainer  : streamly@composewell.com
@@ -8,7 +8,7 @@
 --
 -- Combinators to efficiently manipulate streams of immutable arrays.
 --
-module Streamly.Internal.Memory.ArrayStream
+module Streamly.Internal.Data.Array.Stream.Foreign
     (
     -- * Creation
       arraysOf
@@ -50,7 +50,7 @@ import GHC.Ptr (Ptr(..))
 import Prelude hiding (length, null, last, map, (!!), read, concat, unlines)
 
 #if !defined(mingw32_HOST_OS)
-import Streamly.FileSystem.FDIO (IOVec(..))
+import Streamly.Internal.FileSystem.FDIO (IOVec(..))
 #endif
 import Streamly.Internal.Data.Array.Foreign.Types (Array(..), length)
 import Streamly.Internal.Data.Fold.Types (Fold(..))

--- a/src/Streamly/Internal/Data/Array/Stream/Mut/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Stream/Mut/Foreign.hs
@@ -36,7 +36,7 @@ import Foreign.Storable (Storable(..))
 #if !defined(mingw32_HOST_OS)
 import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import Foreign.Ptr (castPtr)
-import Streamly.FileSystem.FDIO (IOVec(..))
+import Streamly.Internal.FileSystem.FDIO (IOVec(..))
 import Streamly.Internal.Data.Array.Foreign.Mut.Types (length)
 import Streamly.Internal.Data.SVar (adaptState)
 #endif

--- a/src/Streamly/Internal/Data/Array/Stream/Mut/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Stream/Mut/Foreign.hs
@@ -37,16 +37,16 @@ import Foreign.Storable (Storable(..))
 import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import Foreign.Ptr (castPtr)
 import Streamly.FileSystem.FDIO (IOVec(..))
-import Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types (length)
+import Streamly.Internal.Data.Array.Foreign.Mut.Types (length)
 import Streamly.Internal.Data.SVar (adaptState)
 #endif
-import Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types (Array(..))
+import Streamly.Internal.Data.Array.Foreign.Mut.Types (Array(..))
 import Streamly.Internal.Data.Fold.Types (Fold(..))
 import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Stream.StreamK.Type (IsStream)
 import Streamly.Internal.Data.Tuple.Strict (Tuple'(..))
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types as MArray
+import qualified Streamly.Internal.Data.Array.Foreign.Mut.Types as MArray
 import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.Stream.StreamD as D
 
@@ -99,7 +99,7 @@ packArraysChunksOf n (D.Stream step state) =
     step' gst (SpliceInitial st) = do
         when (n <= 0) $
             -- XXX we can pass the module string from the higher level API
-            error $ "Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types.packArraysChunksOf: the size of "
+            error $ "Streamly.Internal.Data.Array.Foreign.Mut.Types.packArraysChunksOf: the size of "
                  ++ "arrays [" ++ show n ++ "] must be a natural number"
         r <- step gst st
         case r of
@@ -143,7 +143,7 @@ lpackArraysChunksOf n (Fold step1 initial1 extract1) =
     initial = do
         when (n <= 0) $
             -- XXX we can pass the module string from the higher level API
-            error $ "Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types.packArraysChunksOf: the size of "
+            error $ "Streamly.Internal.Data.Array.Foreign.Mut.Types.packArraysChunksOf: the size of "
                  ++ "arrays [" ++ show n ++ "] must be a natural number"
 
         r <- initial1
@@ -264,11 +264,11 @@ groupIOVecsOf n maxIOVLen (D.Stream step state) =
     step' gst (GatherInitial st) = do
         when (n <= 0) $
             -- XXX we can pass the module string from the higher level API
-            error $ "Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types.groupIOVecsOf: the size of "
+            error $ "Streamly.Internal.Data.Array.Foreign.Mut.Types.groupIOVecsOf: the size of "
                  ++ "groups [" ++ show n ++ "] must be a natural number"
         when (maxIOVLen <= 0) $
             -- XXX we can pass the module string from the higher level API
-            error $ "Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types.groupIOVecsOf: the number of "
+            error $ "Streamly.Internal.Data.Array.Foreign.Mut.Types.groupIOVecsOf: the number of "
                  ++ "IOVec entries [" ++ show n ++ "] must be a natural number"
         r <- step (adaptState gst) st
         case r of

--- a/src/Streamly/Internal/Data/Binary/Decode.hs
+++ b/src/Streamly/Internal/Data/Binary/Decode.hs
@@ -32,7 +32,7 @@ import Streamly.Internal.Data.Parser (Parser)
 import Streamly.Internal.Data.Maybe.Strict (Maybe'(..))
 import Streamly.Internal.Data.Tuple.Strict (Tuple' (..))
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign as A
 import qualified Streamly.Internal.Data.Parser as PR
 import qualified Streamly.Internal.Data.Parser.ParserD as PRD
 import qualified Streamly.Internal.Data.Parser.ParserK.Types as PRK

--- a/src/Streamly/Internal/Data/Fold/Types.hs
+++ b/src/Streamly/Internal/Data/Fold/Types.hs
@@ -420,7 +420,7 @@ simplify (Fold2 step inject extract) c =
 -- | Folds the input stream to a list.
 --
 -- /Warning!/ working on large lists accumulated as buffers in memory could be
--- very inefficient, consider using "Streamly.Data.Array.Storable.Foreign"
+-- very inefficient, consider using "Streamly.Data.Array.Foreign"
 -- instead.
 --
 -- @since 0.7.0

--- a/src/Streamly/Internal/Data/Pipe.hs
+++ b/src/Streamly/Internal/Data/Pipe.hs
@@ -247,7 +247,7 @@ import Prelude
 import Streamly.Internal.Data.Pipe.Types
        (Pipe(..), PipeState(..), Step(..), zipWith, tee, map, compose)
 -- import Streamly.Internal.Data.Array.Foreign.Types (Array)
--- import Streamly.Memory.Ring (Ring)
+-- import Streamly.Internal.Ring.Foreign (Ring)
 -- import Streamly.Internal.Data.Stream.Serial (SerialT)
 -- import Streamly.Internal.Data.Stream.StreamK (IsStream())
 -- import Streamly.Internal.Data.Time.Units

--- a/src/Streamly/Internal/Data/Pipe.hs
+++ b/src/Streamly/Internal/Data/Pipe.hs
@@ -246,7 +246,7 @@ import Prelude
 -- import Streamly.Data.Fold.Types (Fold(..))
 import Streamly.Internal.Data.Pipe.Types
        (Pipe(..), PipeState(..), Step(..), zipWith, tee, map, compose)
--- import Streamly.Internal.Data.Array.Storable.Foreign.Types (Array)
+-- import Streamly.Internal.Data.Array.Foreign.Types (Array)
 -- import Streamly.Memory.Ring (Ring)
 -- import Streamly.Internal.Data.Stream.Serial (SerialT)
 -- import Streamly.Internal.Data.Stream.StreamK (IsStream())
@@ -256,7 +256,7 @@ import Streamly.Internal.Data.Pipe.Types
 
 -- import Streamly.Internal.Data.Strict
 
--- import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as A
+-- import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 -- import qualified Streamly.Prelude as S
 -- import qualified Streamly.Internal.Data.Stream.StreamD as D
 -- import qualified Streamly.Internal.Data.Stream.StreamK as K

--- a/src/Streamly/Internal/Data/SmallArray.hs
+++ b/src/Streamly/Internal/Data/SmallArray.hs
@@ -103,7 +103,7 @@ foldr f z arr = runIdentity $ D.foldr f z $ toStreamD arr
 -- 'SmallArray'.
 --
 -- Since we are folding to a 'SmallArray' @n@ should be <= 128, for larger number
--- of elements use an 'Array' from either "Streamly.Data.Array" or "Streamly.Data.Array.Storable.Foreign".
+-- of elements use an 'Array' from either "Streamly.Data.Array" or "Streamly.Data.Array.Foreign".
 {-# INLINE_NORMAL writeN #-}
 writeN :: MonadIO m => Int -> Fold m a (SmallArray a)
 writeN limit = Fold step initial extract
@@ -139,7 +139,7 @@ fromStreamDN limit str = do
 --
 -- It is recommended to use a value of @n@ <= 128. For larger sized
 -- arrays, use an 'Array' from "Streamly.Data.Array" or
--- "Streamly.Data.Array.Storable.Foreign"
+-- "Streamly.Data.Array.Foreign"
 {-# INLINABLE fromListN #-}
 fromListN :: Int -> [a] -> SmallArray a
 fromListN n xs = unsafePerformIO $ fromStreamDN n $ D.fromList xs

--- a/src/Streamly/Internal/Data/Stream/IsStream/Common.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Common.hs
@@ -48,7 +48,7 @@ where
 import Control.Concurrent (threadDelay)
 import Control.Monad.IO.Class (MonadIO(..))
 import Foreign.Storable (Storable)
-import Streamly.Internal.Data.Array.Storable.Foreign.Types (Array)
+import Streamly.Internal.Data.Array.Foreign.Types (Array)
 import Streamly.Internal.Data.Fold.Types (Fold (..))
 import Streamly.Internal.Data.Stream.IsStream.Combinators (maxYields)
 import Streamly.Internal.Data.Stream.Prelude (fromStreamS, toStreamS)

--- a/src/Streamly/Internal/Data/Stream/IsStream/Eliminate.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Eliminate.hs
@@ -162,7 +162,7 @@ import Streamly.Internal.Data.Stream.StreamD (fromStreamD, toStreamD)
 import Streamly.Internal.Data.Stream.StreamK (IsStream)
 import Streamly.Internal.Data.Stream.Serial (SerialT)
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as A
+import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Stream.Parallel as Par
 import qualified Streamly.Internal.Data.Stream.Prelude as P

--- a/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
@@ -254,7 +254,7 @@ import Foreign.Storable (Storable)
 import Streamly.Internal.Data.Fold.Types (Fold (..), Fold2 (..))
 import Streamly.Internal.Data.Parser (Parser (..))
 import Streamly.Internal.Data.Unfold.Types (Unfold)
-import Streamly.Internal.Data.Array.Storable.Foreign.Types (Array)
+import Streamly.Internal.Data.Array.Foreign.Types (Array)
 import Streamly.Internal.Data.SVar (MonadAsync)
 import Streamly.Internal.Data.Stream.Ahead (ahead)
 import Streamly.Internal.Data.Stream.Async (async, wAsync)
@@ -284,7 +284,7 @@ import Streamly.Internal.Data.Tuple.Strict (Tuple'(..))
 
 import qualified Data.Heap as H
 import qualified Data.Map.Strict as Map
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as A
+import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Parser.ParserK.Types as PRK
 import qualified Streamly.Internal.Data.Parser.ParserD as PRD

--- a/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
@@ -156,12 +156,12 @@ import Foreign.Storable (Storable(..))
 import Fusion.Plugin.Types (Fuse(..))
 import GHC.Types (SPEC(..))
 
-import Streamly.Internal.Data.Array.Storable.Foreign.Types (Array(..))
+import Streamly.Internal.Data.Array.Foreign.Types (Array(..))
 import Streamly.Internal.Data.Fold.Types (Fold(..))
 import Streamly.Internal.Data.Parser (ParseError(..))
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as A
+import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Parser as PR
 import qualified Streamly.Internal.Data.Parser.ParserD as PRD

--- a/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
@@ -165,7 +165,7 @@ import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Parser as PR
 import qualified Streamly.Internal.Data.Parser.ParserD as PRD
-import qualified Streamly.Memory.Ring as RB
+import qualified Streamly.Internal.Ring.Foreign as RB
 
 import Streamly.Internal.Data.Stream.StreamD.Type
 import Streamly.Internal.Data.SVar

--- a/src/Streamly/Internal/Data/Stream/StreamD/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Transform.hs
@@ -139,7 +139,7 @@ import Streamly.Internal.Data.Time.Clock (Clock(Monotonic), getTime)
 import Streamly.Internal.Data.Time.Units
        (TimeUnit64, toRelTime64, diffAbsTime64)
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as A
+import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.IORef.Prim as Prim
 import qualified Streamly.Internal.Data.Pipe.Types as Pipe

--- a/src/Streamly/Internal/FileSystem/Dir.hs
+++ b/src/Streamly/Internal/FileSystem/Dir.hs
@@ -64,7 +64,7 @@ import Prelude hiding (read)
 -- import Streamly.Data.Fold (Fold)
 import Streamly.Internal.BaseCompat (fromLeft, fromRight)
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
--- import Streamly.Internal.Data.Array.Storable.Foreign.Types
+-- import Streamly.Internal.Data.Array.Foreign.Types
 --        (Array(..), writeNUnsafe, defaultChunkSize, shrinkToFit,
 --         lpackArraysChunksOf)
 -- import Streamly.Internal.Data.Stream.Serial (SerialT)
@@ -76,7 +76,7 @@ import Streamly.Internal.Data.Stream.StreamK.Type (IsStream)
 import qualified Streamly.Internal.Data.Unfold as UF
 -- import qualified Streamly.Internal.Memory.ArrayStream as AS
 import qualified Streamly.Internal.Data.Stream.IsStream as S
--- import qualified Streamly.Data.Array.Storable.Foreign as A
+-- import qualified Streamly.Data.Array.Foreign as A
 -- import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
 import qualified System.Directory as Dir
 
@@ -166,9 +166,9 @@ toChunks = toChunksWithBufferOf defaultChunkSize
 
 -- | Unfolds a handle into a stream of 'Word8' arrays. Requests to the IO
 -- device are performed using a buffer of size
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'. The
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'. The
 -- size of arrays in the resulting stream are therefore less than or equal to
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'.
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'.
 --
 -- @since 0.7.0
 {-# INLINE readChunks #-}
@@ -343,7 +343,7 @@ fromStreamWithBufferOf n h m = fromChunks h $ S.arraysOf n m
 -- > write = 'writeWithBufferOf' A.defaultChunkSize
 --
 -- | Write a byte stream to a file handle. Accumulates the input in chunks of
--- up to 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize' before writing.
+-- up to 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize' before writing.
 --
 -- NOTE: This may perform better than the 'write' fold, you can try this if you
 -- need some extra perf boost.
@@ -393,7 +393,7 @@ writeWithBufferOf n h = FL.chunksOf n (writeNUnsafe n) (writeChunks h)
 -- > write = 'writeWithBufferOf' A.defaultChunkSize
 --
 -- | Write a byte stream to a file handle. Accumulates the input in chunks of
--- up to 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize' before writing
+-- up to 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize' before writing
 -- to the IO device.
 --
 -- @since 0.7.0

--- a/src/Streamly/Internal/FileSystem/Dir.hs
+++ b/src/Streamly/Internal/FileSystem/Dir.hs
@@ -74,7 +74,7 @@ import Streamly.Internal.Data.Stream.StreamK.Type (IsStream)
 -- import qualified Streamly.Data.Fold as FL
 -- import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.Unfold as UF
--- import qualified Streamly.Internal.Memory.ArrayStream as AS
+-- import qualified Streamly.Internal.Data.Array.Stream.Foreign as AS
 import qualified Streamly.Internal.Data.Stream.IsStream as S
 -- import qualified Streamly.Data.Array.Foreign as A
 -- import qualified Streamly.Internal.Data.Stream.StreamD.Type as D

--- a/src/Streamly/Internal/FileSystem/Event/Darwin.hs
+++ b/src/Streamly/Internal/FileSystem/Event/Darwin.hs
@@ -165,7 +165,7 @@ import GHC.IO.Handle.FD (fdToHandle)
 import Streamly.Prelude (SerialT)
 import Streamly.Internal.Data.Cont (contListMap)
 import Streamly.Internal.Data.Parser (Parser)
-import Streamly.Internal.Data.Array.Storable.Foreign.Types (Array(..))
+import Streamly.Internal.Data.Array.Foreign.Types (Array(..))
 import System.IO (Handle, hClose)
 
 import qualified Data.List.NonEmpty as NonEmpty
@@ -173,7 +173,7 @@ import qualified Streamly.Internal.Data.Parser as PR
 import qualified Streamly.Internal.Data.Stream.IsStream as S
 import qualified Streamly.Internal.Unicode.Stream as U
 import qualified Streamly.Internal.FileSystem.Handle as FH
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign as A
 
 -------------------------------------------------------------------------------
 -- Subscription to events

--- a/src/Streamly/Internal/FileSystem/Event/Linux.hs
+++ b/src/Streamly/Internal/FileSystem/Event/Linux.hs
@@ -171,7 +171,7 @@ import GHC.IO.FD (fdFD, mkFD)
 import GHC.IO.Handle.FD (mkHandleFromFD)
 import Streamly.Prelude (SerialT)
 import Streamly.Internal.Data.Parser (Parser)
-import Streamly.Internal.Data.Array.Storable.Foreign.Types (Array(..))
+import Streamly.Internal.Data.Array.Foreign.Types (Array(..))
 import System.IO (Handle, hClose, IOMode(ReadMode))
 #if !MIN_VERSION_base(4,10,0)
 import Control.Concurrent.MVar (readMVar)
@@ -185,7 +185,7 @@ import GHC.IO.Handle.FD (handleToFd)
 
 import qualified Data.IntMap.Lazy as Map
 import qualified Data.List.NonEmpty as NonEmpty
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Parser as PR
 import qualified Streamly.Internal.Data.Stream.IsStream as S

--- a/src/Streamly/Internal/FileSystem/Event/Windows.hs
+++ b/src/Streamly/Internal/FileSystem/Event/Windows.hs
@@ -124,8 +124,8 @@ import System.Win32.Types (BOOL, DWORD, HANDLE, LPVOID, LPDWORD, failIfFalse_)
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Streamly.Internal.Data.Stream.IsStream as S
 import qualified Streamly.Internal.Unicode.Stream as U
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
-import Streamly.Internal.Data.Array.Storable.Foreign (Array)
+import qualified Streamly.Internal.Data.Array.Foreign as A
+import Streamly.Internal.Data.Array.Foreign (Array)
 
 -- | Watch configuration, used to specify the events of interest and the
 -- behavior of the watch.

--- a/src/Streamly/Internal/FileSystem/FD.hs
+++ b/src/Streamly/Internal/FileSystem/FD.hs
@@ -1,7 +1,7 @@
 #include "inline.hs"
 
 -- |
--- Module      : Streamly.FileSystem.FD
+-- Module      : Streamly.Internal.FileSystem.FD
 -- Copyright   : (c) 2019 Composewell Technologies
 --
 -- License     : BSD3
@@ -29,10 +29,10 @@
 -- be considered as in-memory files or files can be considered as on-disk
 -- arrays.
 --
--- > import qualified Streamly.FileSystem.FD as FD
+-- > import qualified Streamly.Internal.FileSystem.FD as FD
 --
 
-module Streamly.FileSystem.FD
+module Streamly.Internal.FileSystem.FD
     (
     -- * File Handles
       Handle
@@ -137,16 +137,16 @@ import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Stream.StreamK.Type (IsStream, mkStream)
 
 #if !defined(mingw32_HOST_OS)
-import Streamly.Internal.Memory.ArrayStream (groupIOVecsOf)
+import Streamly.Internal.Data.Array.Stream.Foreign (groupIOVecsOf)
 import Streamly.Internal.Data.Stream.StreamD (toStreamD)
 import Streamly.Internal.Data.Stream.StreamD.Type (fromStreamD)
-import qualified Streamly.FileSystem.FDIO as RawIO hiding (write)
+import qualified Streamly.Internal.FileSystem.FDIO as RawIO hiding (write)
 #endif
 -- import Streamly.Data.Fold (Fold)
 -- import Streamly.String (encodeUtf8, decodeUtf8, foldLines)
 
 import qualified Streamly.Data.Array.Foreign as A
-import qualified Streamly.Internal.Memory.ArrayStream as AS
+import qualified Streamly.Internal.Data.Array.Stream.Foreign as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
 

--- a/src/Streamly/Internal/FileSystem/FDIO.hs
+++ b/src/Streamly/Internal/FileSystem/FDIO.hs
@@ -1,7 +1,7 @@
 #include "inline.hs"
 
 -- |
--- Module      : Streamly.FileSystem.FDIO
+-- Module      : Streamly.Internal.FileSystem.FDIO
 -- Copyright   : (c) 2019 Composewell Technologies
 -- Copyright   : (c) 1994-2008 The University of Glasgow
 --
@@ -13,7 +13,7 @@
 -- Low level IO routines interfacing the operating system.
 --
 
-module Streamly.FileSystem.FDIO
+module Streamly.Internal.FileSystem.FDIO
     ( write
     , writeAll
     , IOVec (..)
@@ -31,7 +31,7 @@ import Foreign.C.Error (throwErrnoIfMinus1RetryMayBlock)
 import Foreign.C.Types (CBool(..))
 #endif
 import System.Posix.Internals (c_write, c_safe_write)
-import Streamly.FileSystem.IOVec (c_writev, c_safe_writev)
+import Streamly.Internal.FileSystem.IOVec (c_writev, c_safe_writev)
 #endif
 
 import Foreign.C.Types (CSize(..), CInt(..))
@@ -40,7 +40,7 @@ import Foreign.Ptr (plusPtr, Ptr)
 
 import GHC.IO.FD (FD(..))
 
-import Streamly.FileSystem.IOVec (IOVec(..))
+import Streamly.Internal.FileSystem.IOVec (IOVec(..))
 
 -------------------------------------------------------------------------------
 -- IO Routines
@@ -181,7 +181,7 @@ writeNonBlocking loc !fd !buf !off !len
 -- suspend the Haskell thread until write can proceed.  Returns the actual
 -- amount of data written.
 write :: FD -> Ptr Word8 -> Int -> CSize -> IO CInt
-write = writeNonBlocking "Streamly.FileSystem.FDIO"
+write = writeNonBlocking "Streamly.Internal.FileSystem.FDIO"
 
 -- XXX sendAll for sockets has a similar code, we can deduplicate the two.
 -- XXX we need to check the errno to determine if the loop should continue. For
@@ -205,7 +205,7 @@ writeAll fd ptr bytes = do
 -- write will not block the OS thread, it may suspend the Haskell thread until
 -- write can proceed.  Returns the actual amount of data written.
 writev :: FD -> Ptr IOVec -> Int -> IO CInt
-writev = writevNonBlocking "Streamly.FileSystem.FDIO"
+writev = writevNonBlocking "Streamly.Internal.FileSystem.FDIO"
 
 -- XXX incomplete
 -- | Keep writing an iovec in a loop until all the iovec entries are written.

--- a/src/Streamly/Internal/FileSystem/File.hs
+++ b/src/Streamly/Internal/FileSystem/File.hs
@@ -107,7 +107,7 @@ import Streamly.Internal.Data.SVar (MonadAsync)
 import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.Unfold as UF
 import qualified Streamly.Internal.FileSystem.Handle as FH
-import qualified Streamly.Internal.Memory.ArrayStream as AS
+import qualified Streamly.Internal.Data.Array.Stream.Foreign as AS
 import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.Prelude as S
 

--- a/src/Streamly/Internal/FileSystem/File.hs
+++ b/src/Streamly/Internal/FileSystem/File.hs
@@ -96,7 +96,7 @@ import qualified System.IO as SIO
 
 import Streamly.Internal.Data.Fold.Types (Fold(..))
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
-import Streamly.Internal.Data.Array.Storable.Foreign.Types
+import Streamly.Internal.Data.Array.Foreign.Types
        (Array(..), defaultChunkSize, writeNUnsafe)
 import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Stream.StreamK.Type (IsStream)
@@ -108,7 +108,7 @@ import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.Unfold as UF
 import qualified Streamly.Internal.FileSystem.Handle as FH
 import qualified Streamly.Internal.Memory.ArrayStream as AS
-import qualified Streamly.Data.Array.Storable.Foreign as A
+import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.Prelude as S
 
 -------------------------------------------------------------------------------
@@ -243,9 +243,9 @@ readChunksWithBufferOf = usingFile2 FH.readChunksWithBufferOf
 
 -- | Unfolds a 'FilePath' into a stream of 'Word8' arrays. Requests to the IO
 -- device are performed using a buffer of size
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'. The
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'. The
 -- size of arrays in the resulting stream are therefore less than or equal to
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'.
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'.
 --
 -- /Internal/
 {-# INLINE readChunks #-}
@@ -262,7 +262,7 @@ readWithBufferOf = usingFile2 FH.readWithBufferOf
 
 -- | Unfolds a file path into a byte stream. IO requests to the device are
 -- performed in sizes of
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'.
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'.
 --
 -- @since 0.7.0
 {-# INLINE read #-}
@@ -382,7 +382,7 @@ writeWithBufferOf n path =
 -- > write = 'writeWithBufferOf' A.defaultChunkSize
 --
 -- | Write a byte stream to a file. Accumulates the input in chunks of up to
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize' before writing to
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize' before writing to
 -- the IO device.
 --
 -- /Internal/

--- a/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/src/Streamly/Internal/FileSystem/Handle.hs
@@ -113,9 +113,9 @@ import Streamly.Prelude (MonadAsync)
 import Streamly.Data.Fold (Fold)
 import Streamly.Internal.Data.Fold.Types (Fold2(..))
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
-import Streamly.Internal.Data.Array.Storable.Foreign.Types
+import Streamly.Internal.Data.Array.Foreign.Types
        (Array(..), writeNUnsafe, defaultChunkSize , unsafeFreezeWithShrink)
-import Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types (mutableArray)
+import Streamly.Internal.Data.Array.Foreign.Mut.Types (mutableArray)
 import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Stream.StreamK.Type (IsStream, mkStream)
 import Streamly.Internal.Memory.ArrayStream (lpackArraysChunksOf)
@@ -124,10 +124,10 @@ import Streamly.Internal.Memory.ArrayStream (lpackArraysChunksOf)
 import qualified Streamly.Data.Fold as FL
 import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.Unfold as UF
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as IA
+import qualified Streamly.Internal.Data.Array.Foreign as IA
 import qualified Streamly.Internal.Memory.ArrayStream as AS
 import qualified Streamly.Internal.Data.Stream.IsStream as S
-import qualified Streamly.Data.Array.Storable.Foreign as A
+import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
 
 -------------------------------------------------------------------------------
@@ -255,9 +255,9 @@ getBytes = toBytes stdin
 
 -- | Unfolds a handle into a stream of 'Word8' arrays. Requests to the IO
 -- device are performed using a buffer of size
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'. The
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'. The
 -- size of arrays in the resulting stream are therefore less than or equal to
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'.
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'.
 --
 -- @since 0.7.0
 {-# INLINE readChunks #-}
@@ -294,7 +294,7 @@ toBytesWithBufferOf chunkSize h = AS.concat $ toChunksWithBufferOf chunkSize h
 --
 -- | Unfolds a file handle into a byte stream. IO requests to the device are
 -- performed in sizes of
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'.
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'.
 --
 -- @since 0.7.0
 {-# INLINE read #-}
@@ -411,7 +411,7 @@ fromBytesWithBufferOf n h m = fromChunks h $ S.arraysOf n m
 -- > write = 'writeWithBufferOf' A.defaultChunkSize
 --
 -- | Write a byte stream to a file handle. Accumulates the input in chunks of
--- up to 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize' before writing.
+-- up to 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize' before writing.
 --
 -- NOTE: This may perform better than the 'write' fold, you can try this if you
 -- need some extra perf boost.
@@ -469,7 +469,7 @@ writeWithBufferOf2 n = FL.chunksOf2 n (writeNUnsafe n) writeChunks2
 -- > write = 'writeWithBufferOf' A.defaultChunkSize
 --
 -- | Write a byte stream to a file handle. Accumulates the input in chunks of
--- up to 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize' before writing
+-- up to 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize' before writing
 -- to the IO device.
 --
 -- @since 0.7.0

--- a/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/src/Streamly/Internal/FileSystem/Handle.hs
@@ -118,14 +118,14 @@ import Streamly.Internal.Data.Array.Foreign.Types
 import Streamly.Internal.Data.Array.Foreign.Mut.Types (mutableArray)
 import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Stream.StreamK.Type (IsStream, mkStream)
-import Streamly.Internal.Memory.ArrayStream (lpackArraysChunksOf)
+import Streamly.Internal.Data.Array.Stream.Foreign (lpackArraysChunksOf)
 -- import Streamly.String (encodeUtf8, decodeUtf8, foldLines)
 
 import qualified Streamly.Data.Fold as FL
 import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.Unfold as UF
 import qualified Streamly.Internal.Data.Array.Foreign as IA
-import qualified Streamly.Internal.Memory.ArrayStream as AS
+import qualified Streamly.Internal.Data.Array.Stream.Foreign as AS
 import qualified Streamly.Internal.Data.Stream.IsStream as S
 import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D

--- a/src/Streamly/Internal/FileSystem/IOVec.hsc
+++ b/src/Streamly/Internal/FileSystem/IOVec.hsc
@@ -1,5 +1,5 @@
 -- |
--- Module      : Streamly.FileSystem.IOVec
+-- Module      : Streamly.Internal.FileSystem.IOVec
 -- Copyright   : (c) 2019 Composewell Technologies
 --
 -- License     : BSD3
@@ -10,7 +10,7 @@
 -- Low level IO routines interfacing the operating system.
 --
 
-module Streamly.FileSystem.IOVec
+module Streamly.Internal.FileSystem.IOVec
     ( IOVec(..)
     , c_writev
     , c_safe_writev

--- a/src/Streamly/Internal/Memory/ArrayStream.hs
+++ b/src/Streamly/Internal/Memory/ArrayStream.hs
@@ -52,15 +52,15 @@ import Prelude hiding (length, null, last, map, (!!), read, concat, unlines)
 #if !defined(mingw32_HOST_OS)
 import Streamly.FileSystem.FDIO (IOVec(..))
 #endif
-import Streamly.Internal.Data.Array.Storable.Foreign.Types (Array(..), length)
+import Streamly.Internal.Data.Array.Foreign.Types (Array(..), length)
 import Streamly.Internal.Data.Fold.Types (Fold(..))
 import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Stream.StreamK.Type (IsStream)
 import Streamly.Internal.Data.SVar (adaptState)
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as A
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types as MA
+import qualified Streamly.Internal.Data.Array.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign.Types as A
+import qualified Streamly.Internal.Data.Array.Foreign.Mut.Types as MA
 import qualified Streamly.Internal.Data.Array.Stream.Mut.Foreign as AS
 import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.Stream.IsStream as S

--- a/src/Streamly/Internal/Network/Inet/TCP.hs
+++ b/src/Streamly/Internal/Network/Inet/TCP.hs
@@ -118,7 +118,7 @@ import qualified Network.Socket as Net
 
 import qualified Streamly.Internal.Data.Unfold as UF
 import qualified Streamly.Internal.Data.Array.Foreign as A
-import qualified Streamly.Internal.Memory.ArrayStream as AS
+import qualified Streamly.Internal.Data.Array.Stream.Foreign as AS
 import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Prelude as S
 import qualified Streamly.Network.Socket as SK

--- a/src/Streamly/Internal/Network/Inet/TCP.hs
+++ b/src/Streamly/Internal/Network/Inet/TCP.hs
@@ -103,7 +103,7 @@ import Network.Socket
         socket)
 import Prelude hiding (read)
 
-import Streamly.Internal.Data.Array.Storable.Foreign.Types (Array(..), defaultChunkSize, writeNUnsafe)
+import Streamly.Internal.Data.Array.Foreign.Types (Array(..), defaultChunkSize, writeNUnsafe)
 import Streamly.Internal.Data.Fold.Types (Fold(..))
 import Streamly.Internal.Data.SVar (fork)
 import Streamly.Internal.Data.Stream.Serial (SerialT)
@@ -117,7 +117,7 @@ import qualified Control.Monad.Catch as MC
 import qualified Network.Socket as Net
 
 import qualified Streamly.Internal.Data.Unfold as UF
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign as A
 import qualified Streamly.Internal.Memory.ArrayStream as AS
 import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Prelude as S

--- a/src/Streamly/Internal/Network/Socket.hs
+++ b/src/Streamly/Internal/Network/Socket.hs
@@ -90,8 +90,8 @@ import qualified Network.Socket as Net
 import Streamly.Prelude (MonadAsync)
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
 import Streamly.Internal.Memory.ArrayStream (lpackArraysChunksOf)
-import Streamly.Internal.Data.Array.Storable.Foreign.Types (Array(..))
-import Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types (mutableArray)
+import Streamly.Internal.Data.Array.Foreign.Types (Array(..))
+import Streamly.Internal.Data.Array.Foreign.Mut.Types (mutableArray)
 import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Stream.StreamK.Type (IsStream, mkStream)
 import Streamly.Data.Fold (Fold)
@@ -100,10 +100,10 @@ import Streamly.Data.Fold (Fold)
 import qualified Streamly.Data.Fold as FL
 import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.Unfold as UF
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as IA
-import qualified Streamly.Data.Array.Storable.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign as IA
+import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.Internal.Memory.ArrayStream as AS
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as A
+import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 import qualified Streamly.Prelude as S
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
 
@@ -381,9 +381,9 @@ readChunksWithBufferOf = Unfold step return
 
 -- | Unfolds a socket into a stream of 'Word8' arrays. Requests to the socket
 -- are performed using a buffer of size
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'. The
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'. The
 -- size of arrays in the resulting stream are therefore less than or equal to
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'.
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'.
 --
 -- @since 0.7.0
 {-# INLINE readChunks #-}
@@ -430,7 +430,7 @@ readWithBufferOf = UF.concat readChunksWithBufferOf A.read
 
 -- | Unfolds a 'Socket' into a byte stream.  IO requests to the socket are
 -- performed in sizes of
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'.
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'.
 --
 -- @since 0.7.0
 {-# INLINE read #-}

--- a/src/Streamly/Internal/Network/Socket.hs
+++ b/src/Streamly/Internal/Network/Socket.hs
@@ -89,7 +89,7 @@ import qualified Network.Socket as Net
 
 import Streamly.Prelude (MonadAsync)
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
-import Streamly.Internal.Memory.ArrayStream (lpackArraysChunksOf)
+import Streamly.Internal.Data.Array.Stream.Foreign (lpackArraysChunksOf)
 import Streamly.Internal.Data.Array.Foreign.Types (Array(..))
 import Streamly.Internal.Data.Array.Foreign.Mut.Types (mutableArray)
 import Streamly.Internal.Data.Stream.Serial (SerialT)
@@ -102,7 +102,7 @@ import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.Unfold as UF
 import qualified Streamly.Internal.Data.Array.Foreign as IA
 import qualified Streamly.Data.Array.Foreign as A
-import qualified Streamly.Internal.Memory.ArrayStream as AS
+import qualified Streamly.Internal.Data.Array.Stream.Foreign as AS
 import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 import qualified Streamly.Prelude as S
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D

--- a/src/Streamly/Internal/Ring/Foreign.hs
+++ b/src/Streamly/Internal/Ring/Foreign.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      : Streamly.Memory.Ring
+-- Module      : Streamly.Internal.Ring.Foreign
 -- Copyright   : (c) 2019 Composewell Technologies
 -- License     : BSD3
 -- Maintainer  : streamly@composewell.com
@@ -7,7 +7,7 @@
 -- Portability : GHC
 --
 
-module Streamly.Memory.Ring
+module Streamly.Internal.Ring.Foreign
     ( Ring(..)
 
     -- * Construction

--- a/src/Streamly/Internal/Unicode/Array/Char.hs
+++ b/src/Streamly/Internal/Unicode/Array/Char.hs
@@ -20,11 +20,11 @@ where
 import Control.Monad.IO.Class (MonadIO)
 import Streamly.Prelude (MonadAsync)
 import Prelude hiding (String, lines, words, unlines, unwords)
-import Streamly.Data.Array.Storable.Foreign (Array)
+import Streamly.Data.Array.Foreign (Array)
 import Streamly.Internal.Data.Stream.IsStream (IsStream)
 
 import qualified Streamly.Internal.Unicode.Stream as S
-import qualified Streamly.Data.Array.Storable.Foreign as A
+import qualified Streamly.Data.Array.Foreign as A
 
 -- | Break a string up into a stream of strings at newline characters.
 -- The resulting strings do not contain newlines.

--- a/src/Streamly/Internal/Unicode/Stream.hs
+++ b/src/Streamly/Internal/Unicode/Stream.hs
@@ -81,14 +81,14 @@ import GHC.IO.Encoding.Failure (isSurrogate)
 import GHC.Ptr (Ptr (..), plusPtr)
 import System.IO.Unsafe (unsafePerformIO)
 import Streamly.Data.Fold (Fold)
-import Streamly.Data.Array.Storable.Foreign (Array)
+import Streamly.Data.Array.Foreign (Array)
 import Streamly.Internal.Data.Unfold (Unfold)
 import Streamly.Internal.Data.SVar (adaptState)
 import Streamly.Internal.Data.Stream.IsStream (IsStream)
 import Streamly.Internal.Data.Stream.StreamD (Stream(..), Step (..))
 import Streamly.Internal.Data.Tuple.Strict (Tuple'(..))
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as A
+import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 import qualified Streamly.Internal.Data.Stream.IsStream as S
 import qualified Streamly.Internal.Data.Stream.StreamD as D
 

--- a/src/Streamly/Memory/Array.hs
+++ b/src/Streamly/Memory/Array.hs
@@ -32,10 +32,10 @@
 --
 -- > import qualified Streamly.Array as A
 --
--- For experimental APIs see "Streamly.Internal.Data.Array.Storable.Foreign".
+-- For experimental APIs see "Streamly.Internal.Data.Array.Foreign".
 
 module Streamly.Memory.Array
-    {-# DEPRECATED "Use Streamly.Data.Array.Storable.Foreign instead" #-}
+    {-# DEPRECATED "Use Streamly.Data.Array.Foreign instead" #-}
     (
       A.Array
 
@@ -71,4 +71,4 @@ module Streamly.Memory.Array
     )
 where
 
-import Streamly.Internal.Data.Array.Storable.Foreign as A
+import Streamly.Internal.Data.Array.Foreign as A

--- a/src/Streamly/Memory/Ring.hs
+++ b/src/Streamly/Memory/Ring.hs
@@ -41,7 +41,7 @@ import Prelude hiding (length, concat)
 
 import Control.Monad.IO.Class (MonadIO(..))
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as A
+import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 
 -- | A ring buffer is a mutable array of fixed size. Initially the array is
 -- empty, with ringStart pointing at the start of allocated memory. We call the

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -64,9 +64,9 @@
 -- = Programmer Notes
 --
 -- Read IO requests to connected stream sockets are performed in chunks of
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize'.  Unless specified
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize'.  Unless specified
 -- otherwise in the API, writes are collected into chunks of
--- 'Streamly.Internal.Data.Array.Storable.Foreign.Types.defaultChunkSize' before they are
+-- 'Streamly.Internal.Data.Array.Foreign.Types.defaultChunkSize' before they are
 -- written to the socket. APIs are provided to control the chunking behavior.
 --
 -- > import qualified Streamly.Network.Socket as SK
@@ -89,7 +89,7 @@
 -- APIs for unconnected sockets need to explicitly specify the remote endpoint.
 --
 -- By design, connected socket IO APIs are similar to
--- "Streamly.Data.Array.Storable.Foreign" read write APIs. They are almost identical to the
+-- "Streamly.Data.Array.Foreign" read write APIs. They are almost identical to the
 -- sequential streaming APIs in "Streamly.Internal.FileSystem.File".
 --
 module Streamly.Network.Socket

--- a/src/Streamly/Unicode/Stream.hs
+++ b/src/Streamly/Unicode/Stream.hs
@@ -12,11 +12,11 @@
 -- A 'Char' stream is the canonical representation to process Unicode strings.
 -- It can be processed efficiently using regular stream processing operations.
 -- A byte stream of Unicode text read from an IO device or from an
--- 'Streamly.Data.Array.Storable.Foreign.Array' in memory can be decoded into a 'Char' stream
+-- 'Streamly.Data.Array.Foreign.Array' in memory can be decoded into a 'Char' stream
 -- using the decoding routines in this module.  A 'String' (@[Char]@) can be
 -- converted into a 'Char' stream using 'Streamly.Prelude.fromList'.  An @Array
 -- Char@ can be 'Streamly.Prelude.unfold'ed into a stream using the array
--- 'Streamly.Data.Array.Storable.Foreign.read' unfold.
+-- 'Streamly.Data.Array.Foreign.read' unfold.
 --
 -- = Storing Unicode Strings
 --
@@ -30,7 +30,7 @@
 -- than pinned arrays for short and short lived strings.
 --
 -- For longer or long lived streams you can 'Streamly.Prelude.fold' the 'Char'
--- stream as @Array Char@ using the array 'Streamly.Data.Array.Storable.Foreign.write' fold.
+-- stream as @Array Char@ using the array 'Streamly.Data.Array.Foreign.write' fold.
 -- The 'Array' type provides a more compact representation and pinned memory
 -- reducing GC overhead. If space efficiency is a concern you can use
 -- 'encodeUtf8'' on the 'Char' stream before writing it to an 'Array' providing

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -166,7 +166,7 @@ extra-source-files:
     test/Streamly/Test/Data/*.hs
     test/Streamly/Test/Data/Array/Prim.hs
     test/Streamly/Test/Data/Array/Prim/Pinned.hs
-    test/Streamly/Test/Data/Array/Storable/Foreign.hs
+    test/Streamly/Test/Data/Array/Foreign.hs
     test/Streamly/Test/Data/Parser/ParserD.hs
     test/Streamly/Test/FileSystem/Event.hs
     test/Streamly/Test/FileSystem/Handle.hs
@@ -388,7 +388,7 @@ library
                        Streamly.Prelude
                      , Streamly.Data.Unfold
                      , Streamly.Data.Fold
-                     , Streamly.Data.Array.Storable.Foreign
+                     , Streamly.Data.Array.Foreign
 
                      -- Text Processing
                      , Streamly.Unicode.Stream
@@ -444,8 +444,8 @@ library
 
                      -- streamly-core-array
                      -- May depend on streamly-core-stream
-                     , Streamly.Internal.Data.Array.Storable.Foreign.Mut.Types
-                     , Streamly.Internal.Data.Array.Storable.Foreign.Types
+                     , Streamly.Internal.Data.Array.Foreign.Mut.Types
+                     , Streamly.Internal.Data.Array.Foreign.Types
                      , Streamly.Internal.Data.Array.Prim.Mut.Types
                      , Streamly.Internal.Data.Array.Prim.Types
                      , Streamly.Internal.Data.Array.Prim.Pinned.Mut.Types
@@ -498,7 +498,7 @@ library
                      -- streamly-arrays
                      -- May depend on streamly-core
                      , Streamly.Internal.Data.Array
-                     , Streamly.Internal.Data.Array.Storable.Foreign
+                     , Streamly.Internal.Data.Array.Foreign
                      , Streamly.Internal.Data.Array.Prim
                      , Streamly.Internal.Data.Array.Prim.Pinned
                      , Streamly.Internal.Data.SmallArray

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -377,13 +377,6 @@ library
                      , Streamly.Data.Prim.Array
                      , Streamly.Data.SmallArray
 
-                    -- Memory storage
-                     , Streamly.Memory.Ring
-
-                     , Streamly.FileSystem.IOVec
-                     , Streamly.FileSystem.FDIO
-                     , Streamly.FileSystem.FD
-
     exposed-modules:
                        Streamly.Prelude
                      , Streamly.Data.Unfold
@@ -503,7 +496,10 @@ library
                      , Streamly.Internal.Data.Array.Prim.Pinned
                      , Streamly.Internal.Data.SmallArray
                      , Streamly.Internal.Data.Array.Stream.Mut.Foreign
-                     , Streamly.Internal.Memory.ArrayStream
+                     , Streamly.Internal.Data.Array.Stream.Foreign
+
+                    -- Memory storage
+                     , Streamly.Internal.Ring.Foreign
 
                      -- streamly-unicode
                      , Streamly.Internal.Unicode.Stream
@@ -518,6 +514,9 @@ library
                      , Streamly.Internal.FileSystem.Handle
                      , Streamly.Internal.FileSystem.Dir
                      , Streamly.Internal.FileSystem.File
+                     , Streamly.Internal.FileSystem.IOVec
+                     , Streamly.Internal.FileSystem.FDIO
+                     , Streamly.Internal.FileSystem.FD
 
                      -- streamly-network
                      , Streamly.Internal.Network.Socket

--- a/test/Streamly/Test/Common/Array.hs
+++ b/test/Streamly/Test/Common/Array.hs
@@ -31,7 +31,7 @@ import Data.Word(Word8)
 import qualified Streamly.Internal.Data.Array.Foreign as A
 import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 import qualified Streamly.Internal.Data.Stream.IsStream as IP
-import qualified Streamly.Internal.Memory.ArrayStream as AS
+import qualified Streamly.Internal.Data.Array.Stream.Foreign as AS
 type Array = A.Array
 #elif defined(DATA_ARRAY_PRIM_PINNED)
 import qualified Streamly.Internal.Data.Array.Prim.Pinned as A

--- a/test/Streamly/Test/Common/Array.hs
+++ b/test/Streamly/Test/Common/Array.hs
@@ -28,8 +28,8 @@ type Array = A.SmallArray
 #elif defined(TEST_ARRAY)
 import Data.Word(Word8)
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as A
+import qualified Streamly.Internal.Data.Array.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign.Types as A
 import qualified Streamly.Internal.Data.Stream.IsStream as IP
 import qualified Streamly.Internal.Memory.ArrayStream as AS
 type Array = A.Array

--- a/test/Streamly/Test/Data/Array/Foreign.hs
+++ b/test/Streamly/Test/Data/Array/Foreign.hs
@@ -1,12 +1,12 @@
 -- |
--- Module      : Streamly.Test.Data.Array.Storable.Foreign
+-- Module      : Streamly.Test.Data.Array.Foreign
 -- Copyright   : (c) 2019 Composewell technologies
 -- License     : BSD-3-Clause
 -- Maintainer  : streamly@composewell.com
 -- Stability   : experimental
 -- Portability : GHC
 
-module Streamly.Test.Data.Array.Storable.Foreign (main) where
+module Streamly.Test.Data.Array.Foreign (main) where
 
 #define TEST_ARRAY
 #include "Streamly/Test/Common/Array.hs"

--- a/test/Streamly/Test/Data/Parser.hs
+++ b/test/Streamly/Test/Data/Parser.hs
@@ -14,7 +14,7 @@ import Prelude hiding (sequence)
 
 import qualified Data.List as List
 import qualified Prelude
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Parser as P
 import qualified Streamly.Internal.Data.Stream.IsStream as S

--- a/test/Streamly/Test/Data/Parser/ParserD.hs
+++ b/test/Streamly/Test/Data/Parser/ParserD.hs
@@ -12,7 +12,7 @@ import Test.QuickCheck.Monadic (monadicIO, assert, run)
 
 import qualified Data.List as List
 import qualified Prelude
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as A
+import qualified Streamly.Internal.Data.Array.Foreign as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Parser.ParserD as P
 import qualified Streamly.Internal.Data.Stream.IsStream as S

--- a/test/Streamly/Test/FileSystem/Event.hs
+++ b/test/Streamly/Test/FileSystem/Event.hs
@@ -29,12 +29,12 @@ import System.IO.Temp (withSystemTempDirectory)
 #if !defined(CABAL_OS_WINDOWS)
 import System.IO.Unsafe (unsafePerformIO)
 #endif
-import Streamly.Internal.Data.Array.Storable.Foreign (Array)
+import Streamly.Internal.Data.Array.Foreign (Array)
 
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Set as Set
 import qualified Streamly.Unicode.Stream as Unicode
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as Array
+import qualified Streamly.Internal.Data.Array.Foreign as Array
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Parser as PR
 import qualified Streamly.Internal.Data.Stream.IsStream as S

--- a/test/Streamly/Test/FileSystem/Handle.hs
+++ b/test/Streamly/Test/FileSystem/Handle.hs
@@ -29,7 +29,7 @@ import Test.QuickCheck.Monadic (monadicIO, assert, run)
 import qualified Streamly.Data.Fold as Fold
 import qualified Streamly.FileSystem.Handle as Handle
 import qualified Streamly.Internal.Data.Stream.IsStream as Stream
-import qualified Streamly.Internal.Data.Array.Storable.Foreign as Array
+import qualified Streamly.Internal.Data.Array.Foreign as Array
 import qualified Streamly.Internal.Unicode.Stream as Unicode
 
 import Test.Hspec as H

--- a/test/Streamly/Test/Network/Inet/TCP.hs
+++ b/test/Streamly/Test/Network/Inet/TCP.hs
@@ -19,7 +19,7 @@ import Streamly.Prelude (SerialT)
 import Test.QuickCheck (Property)
 import Test.QuickCheck.Monadic (monadicIO, assert, run)
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as Array
+import qualified Streamly.Internal.Data.Array.Foreign.Types as Array
 import qualified Streamly.Internal.Data.Unfold as Unfold
 import qualified Streamly.Internal.Network.Inet.TCP as TCP
 import qualified Streamly.Internal.Network.Socket as Socket

--- a/test/Streamly/Test/Network/Socket.hs
+++ b/test/Streamly/Test/Network/Socket.hs
@@ -19,7 +19,7 @@ import Streamly.Prelude (SerialT)
 import Test.QuickCheck (Property)
 import Test.QuickCheck.Monadic (monadicIO, assert, run)
 
-import qualified Streamly.Internal.Data.Array.Storable.Foreign.Types as Array
+import qualified Streamly.Internal.Data.Array.Foreign.Types as Array
 import qualified Streamly.Internal.Network.Inet.TCP as TCP
 import qualified Streamly.Internal.Network.Socket as Socket
 import qualified Streamly.Internal.Unicode.Stream as Unicode

--- a/test/Streamly/Test/Prelude/Serial.hs
+++ b/test/Streamly/Test/Prelude/Serial.hs
@@ -46,7 +46,7 @@ import qualified Streamly.Prelude as S
 import qualified Streamly.Data.Fold as FL
 import qualified Streamly.Internal.Data.Unfold as UF
 import qualified Streamly.Internal.Data.Stream.IsStream as IS
-import qualified Streamly.Data.Array.Storable.Foreign as A
+import qualified Streamly.Data.Array.Foreign as A
 
 import Streamly.Internal.Data.Time.Units
        (AbsTime, NanoSecond64(..), toRelTime64, diffAbsTime64)

--- a/test/Streamly/Test/Unicode/Stream.hs
+++ b/test/Streamly/Test/Unicode/Stream.hs
@@ -16,7 +16,7 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Monadic (run, monadicIO, assert)
 
-import qualified Streamly.Data.Array.Storable.Foreign as A
+import qualified Streamly.Data.Array.Foreign as A
 import qualified Streamly.Internal.Memory.ArrayStream as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Unicode.Stream as SS

--- a/test/Streamly/Test/Unicode/Stream.hs
+++ b/test/Streamly/Test/Unicode/Stream.hs
@@ -17,7 +17,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Monadic (run, monadicIO, assert)
 
 import qualified Streamly.Data.Array.Foreign as A
-import qualified Streamly.Internal.Memory.ArrayStream as AS
+import qualified Streamly.Internal.Data.Array.Stream.Foreign as AS
 import qualified Streamly.Prelude as S
 import qualified Streamly.Unicode.Stream as SS
 import qualified Streamly.Internal.Unicode.Stream as IUS

--- a/test/streamly-tests.cabal
+++ b/test/streamly-tests.cabal
@@ -207,11 +207,11 @@ test-suite Data.Array.Prim.Pinned
   main-is: Streamly/Test/Data/Array/Prim/Pinned.hs
   ghc-options: -main-is Streamly.Test.Data.Array.Prim.Pinned.main
 
-test-suite Data.Array.Storable.Foreign
+test-suite Data.Array.Foreign
   import: test-options
   type: exitcode-stdio-1.0
-  main-is: Streamly/Test/Data/Array/Storable/Foreign.hs
-  ghc-options: -main-is Streamly.Test.Data.Array.Storable.Foreign.main
+  main-is: Streamly/Test/Data/Array/Foreign.hs
+  ghc-options: -main-is Streamly.Test.Data.Array.Foreign.main
 
 test-suite Data.Fold
   import: test-options


### PR DESCRIPTION
- Streamly.Internal.Memory.ArrayStream =>
  Streamly.Internal.Data.Array.Stream.Foreign
- Streamly.Memory.Ring =>
  Streamly.Internal.Ring.Foreign
- Streamly.FileSystem.IOVec =>
  Streamly.Internal.FileSystem.IOVec
- Streamly.FileSystem.FDIO =>
  Streamly.Internal.FileSystem.FDIO
- Streamly.FileSystem.FD =>
  Streamly.Internal.FileSystem.FD

Closes #873.