### PR TITLE
Sampling support for folds

### DIFF
--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -401,16 +401,6 @@ _Fold1 step = mkAccum step_ Nothing' toMaybe
 -- Run Effects
 ------------------------------------------------------------------------------
 
--- | A fold that drains all its input, running the effects and discarding the
--- results.
---
--- > drain = drainBy (const (return ()))
---
--- @since 0.7.0
-{-# INLINABLE drain #-}
-drain :: Monad m => Fold m a ()
-drain = mkAccum_ (\_ _ -> ()) ()
-
 -- |
 -- > drainBy f = lmapM f drain
 -- > drainBy = FL.foldMapM (void . f)

--- a/src/Streamly/Internal/Data/Fold/Types.hs
+++ b/src/Streamly/Internal/Data/Fold/Types.hs
@@ -186,6 +186,7 @@ module Streamly.Internal.Data.Fold.Types
     , simplify
 
     -- * Basic Folds
+    , drain
     , toList
 
     -- * Generators
@@ -416,6 +417,16 @@ simplify (Fold2 step inject extract) c =
 ------------------------------------------------------------------------------
 -- Basic Folds
 ------------------------------------------------------------------------------
+
+-- | A fold that drains all its input, running the effects and discarding the
+-- results.
+--
+-- > drain = drainBy (const (return ()))
+--
+-- @since 0.7.0
+{-# INLINABLE drain #-}
+drain :: Monad m => Fold m a ()
+drain = mkAccum_ (\_ _ -> ()) ()
 
 -- | Folds the input stream to a list.
 --

--- a/src/Streamly/Internal/Data/Parser.hs
+++ b/src/Streamly/Internal/Data/Parser.hs
@@ -202,7 +202,7 @@ import Prelude
 import Streamly.Internal.Data.Fold.Types (Fold(..))
 import Streamly.Internal.Data.Parser.ParserK.Types (Parser)
 
-import qualified Streamly.Internal.Data.Fold as FL
+import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.Parser.ParserD as D
 import qualified Streamly.Internal.Data.Parser.ParserK.Types as K
 

--- a/src/Streamly/Internal/Data/Parser/ParserD/Types.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD/Types.hs
@@ -137,7 +137,7 @@ import Fusion.Plugin.Types (Fuse(..))
 import Streamly.Internal.Data.Fold.Types (Fold(..), toList)
 import Streamly.Internal.Data.Tuple.Strict (Tuple3'(..))
 
-import qualified Streamly.Internal.Data.Fold as FL
+import qualified Streamly.Internal.Data.Fold.Types as FL
 
 import Prelude hiding (concatMap)
 

--- a/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
@@ -23,7 +23,7 @@ module Streamly.Internal.Data.Stream.IsStream.Transform
     , mapM
     , smapM
 
-    -- * Mapping Side Effects
+    -- * Mapping Side Effects (Observation)
     , trace
     , trace_
     , tap
@@ -387,6 +387,8 @@ sequence m = fromStreamS $ S.sequence (toStreamS m)
 tap :: (IsStream t, Monad m) => FL.Fold m a b -> t m a -> t m a
 tap f xs = D.fromStreamD $ D.tap f (D.toStreamD xs)
 
+-- XXX Remove this. It can be expressed in terms of Fold.sampleFromThen.
+--
 -- | @tapOffsetEvery offset n@ taps every @n@th element in the stream
 -- starting at @offset@. @offset@ can be between @0@ and @n - 1@. Offset 0
 -- means start at the first element in the stream. If the offset is outside

--- a/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
@@ -162,7 +162,7 @@ import Streamly.Internal.Data.Parser (ParseError(..))
 import Streamly.Internal.Data.Unfold.Types (Unfold(..))
 
 import qualified Streamly.Internal.Data.Array.Foreign.Types as A
-import qualified Streamly.Internal.Data.Fold as FL
+import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.Parser as PR
 import qualified Streamly.Internal.Data.Parser.ParserD as PRD
 import qualified Streamly.Internal.Ring.Foreign as RB

--- a/src/Streamly/Internal/Data/Stream/StreamD/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Transform.hs
@@ -140,7 +140,7 @@ import Streamly.Internal.Data.Time.Units
        (TimeUnit64, toRelTime64, diffAbsTime64)
 
 import qualified Streamly.Internal.Data.Array.Foreign.Types as A
-import qualified Streamly.Internal.Data.Fold as FL
+import qualified Streamly.Internal.Data.Fold.Types as FL
 import qualified Streamly.Internal.Data.IORef.Prim as Prim
 import qualified Streamly.Internal.Data.Pipe.Types as Pipe
 import qualified Streamly.Internal.Data.Stream.StreamK as K


### PR DESCRIPTION
The unimplemented function `zipWithM` needs to be implemented for this to work.

Combinators like `tapOffsetEvery` can be expressed using `sampleFromThen`.