### PR TITLE
Implement concatPairswith/sortBy

### DIFF
--- a/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation2.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation2.hs
@@ -20,6 +20,7 @@ import Control.Monad.IO.Class (MonadIO(..))
 import Data.Monoid (Sum(..))
 import GHC.Generics (Generic)
 
+import qualified Data.List as List
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Stream.IsStream as Internal
 import qualified Streamly.Prelude  as S
@@ -174,6 +175,10 @@ reverse n = composeN n S.reverse
 reverse' :: MonadIO m => Int -> SerialT m Int -> m ()
 reverse' n = composeN n Internal.reverse'
 
+{-# INLINE sortBy #-}
+sortBy :: MonadIO m => Int -> SerialT m Int -> m ()
+sortBy n = composeN n (Internal.sortBy compare)
+
 o_n_heap_buffering :: Int -> [Benchmark]
 o_n_heap_buffering value =
     [ bgroup "buffered"
@@ -181,6 +186,8 @@ o_n_heap_buffering value =
         -- Reversing/sorting a stream
           benchIOSink value "reverse" (reverse 1)
         , benchIOSink value "reverse'" (reverse' 1)
+        , benchIOSink value "sortBy" (sortBy 1)
+        , bench "sort Lists" $ nf (\x -> List.sort [1..x]) value
 
         , benchIOSink value "mkAsync" (mkAsync serially)
         ]

--- a/src/Streamly/Internal/Data/Stream/IsStream/Common.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Common.hs
@@ -8,6 +8,8 @@
 -- Stability   : experimental
 -- Portability : GHC
 --
+-- Bottom level IsStream module that can be used by all other upper level
+-- IsStream modules.
 
 module Streamly.Internal.Data.Stream.IsStream.Common
     (

--- a/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
@@ -84,7 +84,8 @@ module Streamly.Internal.Data.Stream.IsStream.Nesting
     , concatMapM
     , concatMapWith
     , concatSmapMWith
-    -- , bindWith
+    , K.bindWith
+    , concatPairsWith
 
     -- *** ConcatUnfold
     -- | Unfold and flatten streams.
@@ -440,7 +441,7 @@ roundrobin ::(IsStream t, Monad m) => t m b -> t m b -> t m b
 roundrobin m1 m2 = fromStreamD $ D.roundRobin (toStreamD m1) (toStreamD m2)
 
 ------------------------------------------------------------------------------
--- Merging
+-- Merging (sorted streams)
 ------------------------------------------------------------------------------
 
 -- | Merge two streams using a comparison function. The head elements of both
@@ -638,6 +639,29 @@ concatMapEitherWith
     -> t m b
 concatMapEitherWith = undefined
 -}
+
+-- XXX Implement a StreamD version for fusion.
+--
+-- | Combine streams in pairs using a binary stream combinator, then combine
+-- the resulting streams in pairs recursively until we get to a single combined
+-- stream.
+--
+-- For example, you can sort a stream using merge sort like this:
+--
+-- >>> Stream.toList $ Stream.concatPairsWith (Stream.mergeBy compare) Stream.yield $ Stream.fromList [5,1,7,9,2]
+-- [1,2,5,7,9]
+--
+-- /Caution: the stream of streams must be finite/
+--
+-- /Internal/
+--
+{-# INLINE concatPairsWith #-}
+concatPairsWith :: IsStream t =>
+       (t m b -> t m b -> t m b)
+    -> (a -> t m b)
+    -> t m a
+    -> t m b
+concatPairsWith = K.concatPairsWith
 
 ------------------------------------------------------------------------------
 -- Combine N Streams - concatUnfold

--- a/src/Streamly/Internal/Data/Stream/StreamK.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamK.hs
@@ -163,6 +163,7 @@ module Streamly.Internal.Data.Stream.StreamK
     , concatMapBy
     , concatMap
     , bindWith
+    , concatPairsWith
     , apWith
     , apSerial
     , apSerialDiscardFst


### PR DESCRIPTION
sortBy is 10x slower than lists, but it could be concurrent. It would be interesting to see how the StreamD implementation of this performs.