### PR TITLE
Allow -Werror without inspection/fusion-plugin

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -48,6 +48,7 @@ jobs:
             ghc_version: 8.8.3
             build: cabal-v2
             cabal_project: cabal.project.ci
+            cabal_build_options: "--flag fusion-plugin --flag inspection"
             runner: ubuntu-latest
           - name: 8.6.5+streamk
             ghc_version: 8.6.5

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -5,12 +5,9 @@ packages:
 
 package streamly
   ghc-options: -Werror
-  flags: inspection
 
 package streamly-benchmarks
   ghc-options: -Werror
-  flags: inspection fusion-plugin
 
 package streamly-tests
   ghc-options: -Werror
-  flags: opt fusion-plugin

--- a/test/streamly-tests.cabal
+++ b/test/streamly-tests.cabal
@@ -103,7 +103,7 @@ common threading-options
                 -with-rtsopts=-N
 
 common optimization-options
-  if flag(opt)
+  if flag(opt) || flag(fusion-plugin)
     ghc-options: -O2
                  -fdicts-strict
                  -fmax-worker-args=16


### PR DESCRIPTION
We may want to use the -Werror build locally but fusion-plugin takes too
much time to build, so separate the two.