### PR TITLE
Rename foldMany and foldMany1

### DIFF
--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
@@ -112,7 +112,7 @@ inspect $ hasNoTypeClasses 'readFromBytesNull
 inspect $ 'readFromBytesNull `hasNoType` ''Step
 inspect $ 'readFromBytesNull `hasNoType` ''MAS.SpliceState
 inspect $ 'readFromBytesNull `hasNoType` ''AT.ArrayUnsafe -- FH.fromBytes/S.arraysOf
-inspect $ 'readFromBytesNull `hasNoType` ''D.FoldMany1
+inspect $ 'readFromBytesNull `hasNoType` ''D.FoldMany
 #endif
 
 -- | Send the file contents ('defaultChunkSize') to /dev/null
@@ -126,7 +126,7 @@ inspect $ hasNoTypeClasses 'readWithBufferOfFromBytesNull
 inspect $ 'readWithBufferOfFromBytesNull `hasNoType` ''Step
 inspect $ 'readWithBufferOfFromBytesNull `hasNoType` ''MAS.SpliceState
 inspect $ 'readWithBufferOfFromBytesNull `hasNoType` ''AT.ArrayUnsafe -- FH.fromBytes/S.arraysOf
-inspect $ 'readWithBufferOfFromBytesNull `hasNoType` ''D.FoldMany1
+inspect $ 'readWithBufferOfFromBytesNull `hasNoType` ''D.FoldMany
 #endif
 
 -- | Send the chunk content ('defaultChunkSize') to /dev/null


### PR DESCRIPTION
foldMany1 is the default foldMany now. foldMany is renamed to
foldManyPost which is of limited use to split in an infix manner.