### PR TITLE
Add a ghc wrapper to invoke ghc on individual files

### DIFF
--- a/bin/ghc.sh
+++ b/bin/ghc.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+ghc -Wall                            \
+    -Wcompat                         \
+    -Wunrecognised-warning-flags     \
+    -Widentities                     \
+    -Wincomplete-record-updates      \
+    -Wincomplete-uni-patterns        \
+    -Wredundant-constraints          \
+    -Wnoncanonical-monad-instances   \
+    -Rghc-timing                     \
+    -XBangPatterns                   \
+    -XCApiFFI                        \
+    -XCPP                            \
+    -XConstraintKinds                \
+    -XDeriveDataTypeable             \
+    -XDeriveGeneric                  \
+    -XDeriveTraversable              \
+    -XExistentialQuantification      \
+    -XFlexibleContexts               \
+    -XFlexibleInstances              \
+    -XGeneralizedNewtypeDeriving     \
+    -XInstanceSigs                   \
+    -XKindSignatures                 \
+    -XLambdaCase                     \
+    -XMagicHash                      \
+    -XMultiParamTypeClasses          \
+    -XPatternSynonyms                \
+    -XRankNTypes                     \
+    -XRecordWildCards                \
+    -XScopedTypeVariables            \
+    -XTupleSections                  \
+    -XTypeFamilies                   \
+    -XViewPatterns                   \
+    -XNoMonoLocalBinds               \
+    -XTypeApplications               \
+    -XQuantifiedConstraints          \
+    -O2                              \
+    -fdicts-strict                   \
+    -fspec-constr-recursive=16       \
+    -fmax-worker-args=16             \
+    -fplugin Fusion.Plugin           \
+    -ddump-to-file                   \
+    -ddump-simpl                     \
+    $*

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -123,6 +123,7 @@ extra-source-files:
     bin/bench.sh
     bin/bench-exec-one.sh
     bin/build-lib.sh
+    bin/ghc.sh
     bin/mk-hscope.sh
     bin/mk-tags.sh
     bin/targets.sh


### PR DESCRIPTION
With all the extensions used in streamly, optimization options and
ddump-simpl options.

This is useful for compiling standalone files, when inspecting core for
perf issues.  I wish cabal could invoke ghc with environment from the
cabal file. Can it?