### PR TITLE
Fixes for GHC 9.0 support

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -44,6 +44,13 @@ jobs:
         name: [8.10.2+macOS, 8.8.3+inspection+fusion-plugin+Werror, 8.8+stack+lts-16.2, 8.6.5+fusion-plugin, 8.6.5+streamk, 8.4.4+debug, doctests]
         cabal_version: ["3.2"]
         include:
+          #- name: 9.0.1+no-bench
+          #  ghc_version: 9.0.1
+          #  build: cabal-v2
+          #  cabal_build_options: "--allow-newer=hsc2hs"
+          #  cabal_build_targets: "streamly streamly-tests"
+          #  disable_sdist_build: "y"
+          #  runner: ubuntu-latest
           - name: 8.10.2+macOS
             ghc_version: 8.10.2
             build: cabal-v2

--- a/benchmark/streamly-benchmarks.cabal
+++ b/benchmark/streamly-benchmarks.cabal
@@ -113,7 +113,7 @@ common bench-depends
     , containers          >= 0.5   && < 0.7
     , typed-process     >= 0.2.3 && < 0.3
     , directory         >= 1.2.2 && < 1.4
-    , ghc-prim          >= 0.4   && < 0.7
+    , ghc-prim          >= 0.4   && < 0.8
 
   if flag(fusion-plugin) && !impl(ghcjs) && !impl(ghc < 8.6)
     build-depends:

--- a/bin/bench-exec-one.sh
+++ b/bin/bench-exec-one.sh
@@ -53,6 +53,9 @@ bench_rts_opts_specific () {
 
     Prelude.Rate/o-1-space/*) echo -n "-K128K" ;;
 
+    -- XXX For GHC-9.0
+    Prelude.Serial/o-1-space/mixed/sum-product-fold) echo -n "-K64M" ;;
+
     # XXX These should be moved to o-n-space?
     Prelude.Serial/o-n-heap/grouping/classifySessionsOf) echo -n "-K1M -M32M" ;;
     Prelude.Serial/o-n-heap/Functor/*) echo -n "-K4M -M32M" ;;

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -5,6 +5,9 @@ For best performance use GHC 8.10 or 8.8 along with `fusion-plugin`
 (see below).  Benchmarks show that GHC 8.8 has significantly better
 performance than GHC 8.6 in many cases.
 
+Please do not use GHC 9.0 for sensitive applications, initial
+evaluations have shown severe perf regressions with GHC 9.0.
+
 GHC versions 8.6 onwards are fully supported along with `fusion-plugin`.
 `fusion-plugin` is not supported for GHC versions below 8.6.
 

--- a/src/Streamly/Internal/FileSystem/FD.hs
+++ b/src/Streamly/Internal/FileSystem/FD.hs
@@ -217,7 +217,11 @@ readArrayUpto size (Handle fd) = do
     -- ptr <- mallocPlainForeignPtrAlignedBytes size (alignment (undefined :: Word8))
     withForeignPtr ptr $ \p -> do
         -- n <- hGetBufSome h p size
+#if MIN_VERSION_base(4,15,0)
+        n <- RawIO.read fd p 0 size
+#else
         n <- RawIO.read fd p size
+#endif
         -- XXX shrink only if the diff is significant
         -- Use unsafeFreezeWithShrink
         return $
@@ -235,7 +239,11 @@ writeArray :: Storable a => Handle -> Array a -> IO ()
 writeArray _ arr | A.length arr == 0 = return ()
 writeArray (Handle fd) arr = withForeignPtr (aStart arr) $ \p ->
     -- RawIO.writeAll fd (castPtr p) aLen
+#if MIN_VERSION_base(4,15,0)
+    RawIO.write fd (castPtr p) 0 aLen
+#else
     RawIO.write fd (castPtr p) aLen
+#endif
     {-
     -- Experiment to compare "writev" based IO with "write" based IO.
     iov <- A.newArray 1

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -552,12 +552,12 @@ library
                      , deepseq           >= 1.4.1 && < 1.5
                      , directory         >= 1.2.2 && < 1.4
                      , exceptions        >= 0.8   && < 0.11
-                     , ghc-prim          >= 0.2   && < 0.7
+                     , ghc-prim          >= 0.2   && < 0.8
                      , mtl               >= 2.2   && < 3
                      , primitive         >= 0.5.4 && < 0.8
                      , transformers      >= 0.4   && < 0.6
 
-                     , heaps             >= 0.3     && < 0.4
+                     , heaps             >= 0.3     && < 0.5
 
                     -- concurrency
                      , atomic-primops    >= 0.8   && < 0.9

--- a/test/lib/Streamly/Test/Prelude/Common.hs
+++ b/test/lib/Streamly/Test/Prelude/Common.hs
@@ -1081,11 +1081,7 @@ transformCombineFromList constr eq listOp t op a b c =
 -- transformCombineOpsOrdered work only for ordered stream types i.e. excluding
 -- the Async type.
 transformCombineOpsCommon
-    :: (IsStream t, Semigroup (t IO Int)
-#if __GLASGOW_HASKELL__ < 806
-       , Functor (t IO)
-#endif
-       )
+    :: (IsStream t, Semigroup (t IO Int) , Functor (t IO))
     => ([Int] -> t IO Int)
     -> String
     -> ([Int] -> [Int] -> Bool)


### PR DESCRIPTION
* Still needs `--allow-newer`
* For benchmarks needs - `basement` to be fixed (for gauge), fusion-plugin fixes