### PR TITLE
Add support for --with-compiler

### DIFF
--- a/bin/bench.sh
+++ b/bin/bench.sh
@@ -17,6 +17,7 @@ print_help () {
   echo "       [--quick]"
   echo "       [--raw]"
   echo "       [--dev-build]"
+  echo "       [--with-compiler <compiler exe name>]"
   echo "       [--cabal-build-options <options>]"
   echo "       [--rtsopts <opts>]"
   echo "       [--compare] [--base <commit>] [--candidate <commit>]"
@@ -297,6 +298,7 @@ do
     --fields) shift; FIELDS=$1; shift ;;
     --base) shift; BASE=$1; shift ;;
     --candidate) shift; CANDIDATE=$1; shift ;;
+    --with-compiler) shift; CABAL_WITH_COMPILER=$1; shift ;;
     --cabal-build-flags) shift; CABAL_BUILD_OPTIONS+=$1; shift ;;
     --cabal-build-options) shift; CABAL_BUILD_OPTIONS+=$1; shift ;;
     --rtsopts) shift; RTS_OPTIONS=$1; shift ;;
@@ -316,6 +318,8 @@ do
   esac
 done
 GAUGE_ARGS=$*
+
+set_derived_vars
 
 #-----------------------------------------------------------------------------
 # Determine targets

--- a/bin/build-lib.sh
+++ b/bin/build-lib.sh
@@ -137,8 +137,6 @@ set_common_vars () {
   TARGET_EXE_ARGS=
   RTS_OPTIONS=
 
-  GHC_VERSION=$(ghc --numeric-version)
-
   CABAL_BUILD_OPTIONS=""
   CABAL_EXECUTABLE=cabal
 
@@ -153,6 +151,18 @@ set_common_vars () {
         BUILD_DIR=$(git-cabal show-builddir)
       fi
   fi
+}
+
+# To be called after parsing CLI arguments
+set_derived_vars () {
+  if test -n "$CABAL_WITH_COMPILER"
+  then
+    CABAL_BUILD_OPTIONS+=" --with-compiler $CABAL_WITH_COMPILER"
+  else
+    CABAL_WITH_COMPILER=ghc
+  fi
+
+  GHC_VERSION=$($CABAL_WITH_COMPILER --numeric-version)
 }
 
 # XXX cabal issue "cabal v2-exec which" cannot find benchmark/test executables

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR=$(dirname $0)
 print_help () {
   echo "Usage: $0 "
   echo "       [--targets <"target1 target2 ..." | help>]"
+  echo "       [--with-compiler <compiler exe name>]"
   echo "       [--cabal-build-options <option>]"
   echo "       [--dev-build]"
   echo "       [--coverage]"
@@ -52,6 +53,7 @@ do
     -h|--help|help) print_help ;;
     # options with arguments
     --targets) shift; TARGETS=$1; shift ;;
+    --with-compiler) shift; CABAL_WITH_COMPILER=$1; shift ;;
     --cabal-build-options) shift; CABAL_BUILD_OPTIONS=$1; shift ;;
     --hpc-report-options) shift; HPC_REPORT_OPTIONS=$1; shift ;;
     --rtsopts) shift; RTS_OPTIONS=$1; shift ;;
@@ -68,6 +70,8 @@ do
   esac
 done
 TARGET_EXE_ARGS=$*
+
+set_derived_vars
 
 #-----------------------------------------------------------------------------
 # Determine targets


### PR DESCRIPTION
We could use `--with-compiler` in `--cabal-build-options` but we need to find the benchmark/test executable under dist-newstyle based on the compiler version, so we need to know the executable in the shell script.