### PR TITLE
Misc tasks

### DIFF
--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -1036,11 +1036,9 @@ splitAt n fld = splitWith (,) (takeLE n fld)
 {-# INLINE sliceSepBy #-}
 sliceSepBy :: Monad m => (a -> Bool) -> Fold m a b -> Fold m a b
 sliceSepBy predicate (Fold fstep finitial fextract) =
-    Fold step initial fextract
+    Fold step finitial fextract
 
     where
-
-    initial = finitial
 
     step s a =
         if not (predicate a)
@@ -1060,11 +1058,9 @@ sliceSepBy predicate (Fold fstep finitial fextract) =
 {-# INLINE sliceEndWith #-}
 sliceEndWith :: Monad m => (a -> Bool) -> Fold m a b -> Fold m a b
 sliceEndWith predicate (Fold fstep finitial fextract) =
-    Fold step initial fextract
+    Fold step finitial fextract
 
     where
-
-    initial = finitial
 
     step s a = do
         res <- fstep s a

--- a/src/Streamly/Internal/Data/Parser/ParserD.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD.hs
@@ -161,6 +161,7 @@ where
 
 import Control.Exception (assert)
 import Control.Monad.Catch (MonadCatch, MonadThrow(..))
+import Fusion.Plugin.Types (Fuse(..))
 import Streamly.Internal.Data.Fold.Types (Fold(..))
 import Streamly.Internal.Data.Tuple.Strict (Tuple'(..))
 
@@ -626,6 +627,7 @@ wordBy predicate (Fold fstep finitial fextract) = Parser step initial extract
     extract (WBWord s) = fextract s
     extract (WBRight b) = return b
 
+{-# ANN type GroupByState Fuse #-}
 data GroupByState a s
     = GroupByInit !s
     | GroupByGrouping !a !s

--- a/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
@@ -1196,6 +1196,9 @@ groupsBy :: Monad m
     -> Fold m a b
     -> Stream m a
     -> Stream m b
+{-
+groupsBy eq fld = parseMany (PRD.groupBy eq fld)
+-}
 groupsBy cmp (Fold fstep initial done) (Stream step state) =
     Stream stepOuter (GroupingInit state)
 
@@ -1277,6 +1280,9 @@ groupsRollingBy :: Monad m
     -> Fold m a b
     -> Stream m a
     -> Stream m b
+{-
+groupsRollingBy eq fld = parseMany (PRD.groupByRolling eq fld)
+-}
 groupsRollingBy cmp (Fold fstep initial done) (Stream step state) =
     Stream stepOuter (GroupingInit state)
 


### PR DESCRIPTION
Simple fixes + additional benchmarks

 ```
benchmarked Data.Parser.ParserD/o-1-space/parseMany
time                 87.56 μs   (87.24 μs .. 87.92 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 88.19 μs   (87.60 μs .. 88.82 μs)
std dev              2.778 μs   (2.234 μs .. 3.433 μs)
variance introduced by outliers: 24% (moderately inflated)

benchmarked Data.Parser.ParserD/o-1-space/parseMany groupBy
time                 76.02 μs   (75.44 μs .. 76.73 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 76.30 μs   (76.02 μs .. 76.61 μs)
std dev              1.493 μs   (1.279 μs .. 1.735 μs)
variance introduced by outliers: 12% (moderately inflated)

benchmarked Data.Parser.ParserD/o-1-space/parseMany groupRollingBy
time                 88.39 μs   (87.98 μs .. 88.75 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 89.19 μs   (88.21 μs .. 90.84 μs)
std dev              6.094 μs   (3.660 μs .. 8.841 μs)
variance introduced by outliers: 61% (severely inflated)
```