### PR TITLE
Improving time-ish stream combinators

### DIFF
--- a/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation1.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation1.hs
@@ -334,8 +334,8 @@ _intervalsOfSum :: MonadAsync m => Double -> Int -> SerialT m Int -> m ()
 _intervalsOfSum i n = composeN n (S.intervalsOf i FL.sum)
 
 {-# INLINE dropInterval #-}
-dropInterval :: NanoSecond64 -> Int -> SerialT IO Int -> IO ()
-dropInterval i n = composeN n (Internal.dropInterval i)
+dropInterval :: Double -> NanoSecond64 -> Int -> SerialT IO Int -> IO ()
+dropInterval g i n = composeN n (Internal.dropInterval g i)
 
 #ifdef INSPECTION
 inspect $ hasNoTypeClasses 'dropInterval
@@ -403,7 +403,7 @@ o_1_space_filtering value =
         , benchIOSink
               value
               "dropInterval-all"
-              (dropInterval (NanoSecond64 maxBound) 1)
+              (dropInterval 1 (NanoSecond64 maxBound) 1)
         , benchIOSink value "dropWhile-true" (dropWhileTrue value 1)
      -- , benchIOSink value "dropWhileM-true" (_dropWhileMTrue value 1)
         , benchIOSink

--- a/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation1.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation1.hs
@@ -308,12 +308,6 @@ takeWhileMTrue value n = composeN n $ S.takeWhileM (return . (<= (value + 1)))
 takeInterval :: NanoSecond64 -> Int -> SerialT IO Int -> IO ()
 takeInterval i n = composeN n (Internal.takeInterval i)
 
-#ifdef INSPECTION
--- inspect $ hasNoType 'takeInterval ''SPEC
-inspect $ hasNoTypeClasses 'takeInterval
--- inspect $ 'takeInterval `hasNoType` ''D.Step
-#endif
-
 {-# INLINE dropOne #-}
 dropOne :: MonadIO m => Int -> SerialT m Int -> m ()
 dropOne n = composeN n $ S.drop 1

--- a/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation1.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation1.hs
@@ -305,8 +305,8 @@ takeWhileMTrue :: MonadIO m => Int -> Int -> SerialT m Int -> m ()
 takeWhileMTrue value n = composeN n $ S.takeWhileM (return . (<= (value + 1)))
 
 {-# INLINE takeInterval #-}
-takeInterval :: NanoSecond64 -> Int -> SerialT IO Int -> IO ()
-takeInterval i n = composeN n (Internal.takeInterval i)
+takeInterval :: Double -> NanoSecond64 -> Int -> SerialT IO Int -> IO ()
+takeInterval g i n = composeN n (Internal.takeInterval g i)
 
 {-# INLINE dropOne #-}
 dropOne :: MonadIO m => Int -> SerialT m Int -> m ()
@@ -395,7 +395,7 @@ o_1_space_filtering value =
         , benchIOSink
               value
               "takeInterval-all"
-              (takeInterval (NanoSecond64 maxBound) 1)
+              (takeInterval 1 (NanoSecond64 maxBound) 1)
         , benchIOSink value "takeWhile-true" (takeWhileTrue value 1)
      -- , benchIOSink value "takeWhileM-true" (_takeWhileMTrue value 1)
         , benchIOSink value "drop-one" (dropOne 1)

--- a/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
@@ -1072,7 +1072,7 @@ dropWhileM p m = fromStreamD $ D.dropWhileM p $ toStreamD m
 -- /Pre-release/
 --
 {-# INLINE dropInterval #-}
-dropInterval ::(MonadIO m, IsStream t, TimeUnit64 d) => d -> t m a -> t m a
+dropInterval ::(MonadAsync m, IsStream t, TimeUnit64 d) => d -> t m a -> t m a
 dropInterval d = fromStreamD . D.dropByTime d . toStreamD
 
 -- | Drop @n@ elements at the end of the stream.

--- a/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
@@ -1082,8 +1082,9 @@ dropWhileM p m = fromStreamD $ D.dropWhileM p $ toStreamD m
 -- /Pre-release/
 --
 {-# INLINE dropInterval #-}
-dropInterval ::(MonadAsync m, IsStream t, TimeUnit64 d) => d -> t m a -> t m a
-dropInterval d = fromStreamD . D.dropByTime d . toStreamD
+dropInterval ::
+       (MonadAsync m, IsStream t, TimeUnit64 d) => Double -> d -> t m a -> t m a
+dropInterval g d = fromStreamD . D.dropByTime g d . toStreamD
 
 -- | Drop @n@ elements at the end of the stream.
 --

--- a/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
@@ -235,6 +235,7 @@ import Streamly.Internal.Data.Stream.IsStream.Common
     , takeWhile
     , interjectSuffix
     , intersperseM
+    , relTimesWith
     )
 import Streamly.Internal.Data.Stream.Prelude (fromStreamS, toStreamS)
 import Streamly.Internal.Data.Stream.Serial (SerialT)
@@ -245,7 +246,6 @@ import Streamly.Internal.Data.Time.Units
     (TimeUnit64, AbsTime, RelTime64, toRelTime64)
 
 import qualified Streamly.Internal.Data.Fold as FL
-import qualified Streamly.Internal.Data.Stream.IsStream.Generate as Generate
 import qualified Streamly.Internal.Data.Stream.Parallel as Par
 import qualified Streamly.Internal.Data.Stream.Prelude as P
 import qualified Streamly.Internal.Data.Stream.Serial as Serial
@@ -1024,11 +1024,11 @@ takeWhileAround :: -- (IsStream t, Monad m) =>
     (a -> Bool) -> t m a -> t m a
 takeWhileAround = undefined -- fromStreamD $ D.takeWhileAround n $ toStreamD m
 
--- | @takeInterval duration@ yields stream elements upto specified time
--- @duration@. The duration starts when the stream is evaluated for the first
--- time, before the first element is yielded. The time duration is checked
--- before generating each element, if the duration has expired the stream
--- stops.
+-- | @takeInterval granularity duration@ yields stream elements upto specified
+-- time @duration@ measured on a clock with granularity @granularity@. The
+-- duration starts when the stream is evaluated for the first time, before the
+-- first element is yielded. The time duration is checked before generating each
+-- element, if the duration has expired the stream stops.
 --
 -- The total time taken in executing the stream is guaranteed to be /at least/
 -- @duration@, however, because the duration is checked before generating an
@@ -1043,14 +1043,14 @@ takeWhileAround = undefined -- fromStreamD $ D.takeWhileAround n $ toStreamD m
 {-# INLINE takeInterval #-}
 takeInterval ::
        (MonadAsync m, IsStream t, TimeUnit64 d, Functor (t m))
-    => d -> t m a -> t m a
-takeInterval duration = catMaybes . Par.parallelMin timeStream . fmap Just
+    => Double -> d -> t m a -> t m a
+takeInterval g duration = catMaybes . Par.parallelMin timeStream . fmap Just
 
     where
 
     duration64 = toRelTime64 duration
     timeStream =
-        fmap (const Nothing) $ takeWhile (< duration64) Generate.relTimes
+        fmap (const Nothing) $ takeWhile (< duration64) (relTimesWith g)
 
 -- | Drop elements in the stream as long as the predicate succeeds and then
 -- take the rest of the stream.

--- a/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
@@ -1084,7 +1084,7 @@ dropWhileM p m = fromStreamD $ D.dropWhileM p $ toStreamD m
 {-# INLINE dropInterval #-}
 dropInterval ::
        (MonadAsync m, IsStream t, TimeUnit64 d) => Double -> d -> t m a -> t m a
-dropInterval g d = fromStreamD . D.dropByTime g d . toStreamD
+dropInterval g d = fromStreamD . D.dropInterval g d . toStreamD
 
 -- | Drop @n@ elements at the end of the stream.
 --

--- a/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
@@ -241,9 +241,11 @@ import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Stream.StreamD (fromStreamD, toStreamD)
 import Streamly.Internal.Data.Stream.StreamK (IsStream)
 import Streamly.Internal.Data.SVar (MonadAsync, Rate(..))
-import Streamly.Internal.Data.Time.Units (TimeUnit64, AbsTime, RelTime64)
+import Streamly.Internal.Data.Time.Units
+    (TimeUnit64, AbsTime, RelTime64, toRelTime64)
 
 import qualified Streamly.Internal.Data.Fold as FL
+import qualified Streamly.Internal.Data.Stream.IsStream.Generate as Generate
 import qualified Streamly.Internal.Data.Stream.Parallel as Par
 import qualified Streamly.Internal.Data.Stream.Prelude as P
 import qualified Streamly.Internal.Data.Stream.Serial as Serial
@@ -1039,8 +1041,16 @@ takeWhileAround = undefined -- fromStreamD $ D.takeWhileAround n $ toStreamD m
 -- /Pre-release/
 --
 {-# INLINE takeInterval #-}
-takeInterval ::(MonadIO m, IsStream t, TimeUnit64 d) => d -> t m a -> t m a
-takeInterval d = fromStreamD . D.takeByTime d . toStreamD
+takeInterval ::
+       (MonadAsync m, IsStream t, TimeUnit64 d, Functor (t m))
+    => d -> t m a -> t m a
+takeInterval duration = catMaybes . Par.parallelMin timeStream . fmap Just
+
+    where
+
+    duration64 = toRelTime64 duration
+    timeStream =
+        fmap (const Nothing) $ takeWhile (< duration64) Generate.relTimes
 
 -- | Drop elements in the stream as long as the predicate succeeds and then
 -- take the rest of the stream.

--- a/src/Streamly/Internal/Data/Stream/StreamD/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Transform.hs
@@ -79,7 +79,7 @@ module Streamly.Internal.Data.Stream.StreamD.Transform
     , takeWhile
     , takeWhileM
     , drop
-    , dropByTime
+    , dropInterval
     , dropWhile
     , dropWhileM
 
@@ -794,10 +794,10 @@ deleteBy eq x (Stream step state) = Stream step' (state, False)
 -- Trimming
 ------------------------------------------------------------------------------
 
-{-# INLINE_NORMAL dropByTime #-}
-dropByTime ::
+{-# INLINE_NORMAL dropInterval #-}
+dropInterval ::
        (MonadAsync m, TimeUnit64 t) => Double -> t -> Stream m a -> Stream m a
-dropByTime g duration =
+dropInterval g duration =
     map snd
         . dropWhile (\(t, _) -> t <= duration64)
         . Nesting.zipWith (,) (relTimesWith g)

--- a/src/Streamly/Internal/Data/Stream/StreamD/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Transform.hs
@@ -815,6 +815,8 @@ data TakeByTime st s
     | TakeByTimeCheck st s
     | TakeByTimeYield st s
 
+-- This is INCORRECT. A requirement of this combinator is to end the stream
+-- after the given duration. This combinator should ideally act as a supervisor.
 {-# INLINE_NORMAL takeByTime #-}
 takeByTime :: (MonadIO m, TimeUnit64 t) => t -> Stream m a -> Stream m a
 takeByTime duration (Stream step1 state1) = Stream step (TakeByTimeInit state1)

--- a/src/Streamly/Internal/Data/Stream/StreamD/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Transform.hs
@@ -795,15 +795,16 @@ deleteBy eq x (Stream step state) = Stream step' (state, False)
 ------------------------------------------------------------------------------
 
 {-# INLINE_NORMAL dropByTime #-}
-dropByTime :: (MonadAsync m, TimeUnit64 t) => t -> Stream m a -> Stream m a
-dropByTime duration =
+dropByTime ::
+       (MonadAsync m, TimeUnit64 t) => Double -> t -> Stream m a -> Stream m a
+dropByTime g duration =
     map snd
         . dropWhile (\(t, _) -> t <= duration64)
-        . Nesting.zipWith (,) relTimes
+        . Nesting.zipWith (,) (relTimesWith g)
 
     where
 
-    relTimes = map snd (Generate.times 0.01)
+    relTimesWith g_ = map snd (Generate.times g_)
     duration64 = toRelTime64 duration
 
 -- Adapted from the vector package

--- a/test/Streamly/Test/Prelude/Serial.hs
+++ b/test/Streamly/Test/Prelude/Serial.hs
@@ -431,7 +431,7 @@ testTakeInterval :: IO Bool
 testTakeInterval = do
     r <-
           S.fold (FL.tee FL.head FL.last)
-        $ IS.takeInterval takeDropTime
+        $ IS.takeInterval 1 takeDropTime
         $ S.repeatM (threadDelay 1000 >> getTime Monotonic)
     checkTakeDropTime r
 
@@ -440,7 +440,7 @@ testDropInterval = do
     t0 <- getTime Monotonic
     mt1 <-
           S.head
-        $ IS.dropInterval takeDropTime
+        $ IS.dropInterval 1 takeDropTime
         $ S.repeatM (threadDelay 1000 >> getTime Monotonic)
     checkTakeDropTime (Just t0, mt1)
 #endif


### PR DESCRIPTION
- [x] Improve dropByTime
- [x] Fix takeByTime

`dropByTime` improved from `63.02 ms` to `609.8 μs`