### PR TITLE
Add a hack to find "chart" executable

### DIFF
--- a/bin/bench.sh
+++ b/bin/bench.sh
@@ -70,7 +70,19 @@ cabal_which_report() {
   local path=$(cabal_which streamly-benchmarks x $1)
   if test -z "$path"
   then
-    cabal_which_builddir dist-newstyle streamly-benchmarks x $1
+    echo "Cannot find $1 executable, trying in dist-newstyle" 1>&2
+    local path1=$(cabal_which_builddir dist-newstyle streamly-benchmarks x $1)
+    if test -z "$path1"
+    then
+      local path2="./bin/$1"
+      echo "Cannot find $1 executable, trying $path2" 1>&2
+      if test -e "$path2"
+      then
+        echo $path2
+      fi
+    else
+        echo $path1
+    fi
   else
     echo $path
   fi

--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,13 @@
 # To build the chart executable for running bench.sh use:
 # nix-shell --argstr c2nix "--flag dev" --run "cabal build chart --flag dev"
 #
+# You can permanently copy the "chart" executable to "./bin" to pick
+# it up irrespective of the compiler/build. Its path is printed by the
+# above build command. You can also print its path using the following
+# command and then use "cp <path> ./bin" to copy it to "./bin", the bench.sh
+# script will pick it up from there:
+# nix-shell --argstr c2nix "--flag dev" --run "cabal exec --flag dev -- which chart"
+#
 # To use ghc-8.6.5
 # nix-shell --argstr compiler "ghc865"
 


### PR DESCRIPTION
We can always use the chart executable built by any compiler version.
Sometimes the chart executable is not buildable by newer compiler
versions, in that case we can build it using another compiler and use
that.