### PR TITLE
Implement foldIterate

### DIFF
--- a/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation2.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial/Transformation2.hs
@@ -141,13 +141,13 @@ foldMany =
     . Internal.foldMany (FL.take 2 FL.mconcat)
     . S.map Sum
 
-{-# INLINE _foldIterate #-}
-_foldIterate :: Monad m => SerialT m Int -> m ()
-_foldIterate =
-      S.drain
-    . S.map getSum
-    . Internal.foldIterate (FL.take 2 . FL.sconcat) (Sum 0)
-    . S.map Sum
+{-# INLINE foldIterateM #-}
+foldIterateM :: Monad m => SerialT m Int -> m ()
+foldIterateM =
+    S.drain
+        . S.map getSum
+        . Internal.foldIterateM (return . FL.take 2 . FL.sconcat) (Sum 0)
+        . S.map Sum
 
 o_1_space_grouping :: Int -> [Benchmark]
 o_1_space_grouping value =
@@ -159,7 +159,7 @@ o_1_space_grouping value =
         , benchIOSink value "groupsByRollingLT" groupsByRollingLT
         , benchIOSink value "groupsByRollingEq" groupsByRollingEq
         , benchIOSink value "foldMany" foldMany
-     -- , benchIOSink value "foldIterate" foldIterate
+        , benchIOSink value "foldIterateM" foldIterateM
         ]
     ]
 

--- a/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
@@ -130,7 +130,7 @@ module Streamly.Internal.Data.Stream.IsStream.Nesting
     , foldMany
     , foldManyPost
     , foldSequence
-    , foldIterate
+    , foldIterateM
 
     -- ** Parsing
     -- | Apply parsers on a stream.
@@ -1009,9 +1009,9 @@ foldSequence _f _m = undefined
 --
 -- @
 -- > import Data.Monoid (Sum(..))
--- > f x = Fold.take 2 (Fold.sconcat x)
+-- > f x = return (Fold.take 2 (Fold.sconcat x))
 -- > s = Stream.map Sum $ Stream.fromList [1..10]
--- > Stream.toList $ Stream.map getSum $ Stream.foldIterate f 0 s
+-- > Stream.toList $ Stream.map getSum $ Stream.foldIterateM f 0 s
 -- [3,10,21,36,55,55]
 --
 -- @
@@ -1021,15 +1021,10 @@ foldSequence _f _m = undefined
 --
 -- /Pre-release/
 --
-{-# INLINE foldIterate #-}
-foldIterate
-    :: -- (IsStream t, Monad m) =>
-       (b -> Fold m a b)
-    -> b
-    -> t m a
-    -> t m b
-foldIterate _f _i _m = undefined
--- D.fromStreamD $ D.foldIterate f i (D.toStreamD m)
+{-# INLINE foldIterateM #-}
+foldIterateM ::
+       (IsStream t, Monad m) => (b -> m (Fold m a b)) -> b -> t m a -> t m b
+foldIterateM f i m = D.fromStreamD $ D.foldIterateM f i (D.toStreamD m)
 
 ------------------------------------------------------------------------------
 -- Parsing

--- a/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
@@ -1922,7 +1922,7 @@ data SessionState t m k a b = SessionState
 -- Stream.mapM_ print
 --     $ Stream.classifySessionsBy 1 False (const (return False)) 3 (Fold.take 3 Fold.toList)
 --     $ Stream.timestamped
---     $ Stream.delay 1
+--     $ Stream.delay 0.1
 --     $ (,) <$> Stream.fromList [1,2,3] <*> Stream.fromList ['a','b','c']
 -- :}
 -- (1,"abc")


### PR DESCRIPTION
Benchmarks,
```
benchmarked Data.Fold/o-1-space/nesting/foldIterateM (take 1)
time                 115.4 μs   (114.6 μs .. 116.4 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 116.8 μs   (116.2 μs .. 117.3 μs)
std dev              2.446 μs   (2.150 μs .. 2.918 μs)
variance introduced by outliers: 12% (moderately inflated)

benchmarked Data.Fold/o-1-space/nesting/foldIterateM (take all)
time                 817.1 μs   (812.2 μs .. 821.7 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 816.6 μs   (813.0 μs .. 820.2 μs)
std dev              12.36 μs   (10.22 μs .. 15.09 μs)
```
These benchmarks look incorrect,
1. I expected `foldIterateM (take 1)` to be worse compared to `foldIterateM (take all)`
2. In contrast `parseIterate` is much worse. I expected them to be almost the same.
```
benchmarked Data.Parser/o-1-space/parseIterate (take 1)
time                 3.046 ms   (3.025 ms .. 3.059 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 3.035 ms   (3.026 ms .. 3.052 ms)
std dev              31.09 μs   (15.04 μs .. 48.53 μs)

benchmarked Data.Parser/o-1-space/parseIterate (take all)
time                 3.239 ms   (3.224 ms .. 3.252 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 3.242 ms   (3.232 ms .. 3.253 ms)
std dev              26.36 μs   (19.39 μs .. 35.92 μs)
```
Looks like my hunch about `take 1` being worse compared to `take all` is incorrect. Why though?