### PR TITLE
Rename some fold combinators

### DIFF
--- a/benchmark/Streamly/Benchmark/Data/Fold.hs
+++ b/benchmark/Streamly/Benchmark/Data/Fold.hs
@@ -82,9 +82,9 @@ sequence_ value =
 -- Splitting by serial application
 -------------------------------------------------------------------------------
 
-{-# INLINE sliceSepBy #-}
-sliceSepBy :: Monad m => Int -> SerialT m Int -> m ()
-sliceSepBy value = IP.fold (FL.sliceSepBy (>= value) FL.drain)
+{-# INLINE takeEndBy_ #-}
+takeEndBy_ :: Monad m => Int -> SerialT m Int -> m ()
+takeEndBy_ value = IP.fold (FL.takeEndBy_ (>= value) FL.drain)
 
 {-# INLINE many #-}
 many :: Monad m => SerialT m Int -> m ()
@@ -244,7 +244,7 @@ o_1_space_serial_elimination value =
         , benchIOSink value "all" $ all value
         , benchIOSink value "any" $ any value
         , benchIOSink value "take" $ take value
-        , benchIOSink value "sliceSepBy" $ sliceSepBy value
+        , benchIOSink value "takeEndBy_" $ takeEndBy_ value
         , benchIOSink value "and" (S.fold FL.and . S.map (<= (value + 1)))
         , benchIOSink value "or" (S.fold FL.or . S.map (> (value + 1)))
         ]

--- a/benchmark/Streamly/Benchmark/Prelude/Serial/Split.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial/Split.hs
@@ -101,7 +101,7 @@ foldManySepBy :: Handle -> IO Int
 foldManySepBy inh =
     (S.length
         $ IP.foldMany
-            (FL.sliceSepBy (== lf) FL.drain)
+            (FL.takeEndBy_ (== lf) FL.drain)
             (S.unfold FH.read inh)
     ) -- >>= print
 
@@ -110,7 +110,7 @@ parseManySepBy :: Handle -> IO Int
 parseManySepBy inh =
     (S.length
         $ IP.parseMany
-            (PR.fromFold $ FL.sliceSepBy (== lf) FL.drain)
+            (PR.fromFold $ FL.takeEndBy_ (== lf) FL.drain)
             (S.unfold FH.read inh)
     ) -- >>= print
 
@@ -159,9 +159,9 @@ splitOnSuffixSeq str inh =
 o_1_space_reduce_read_split :: BenchEnv -> [Benchmark]
 o_1_space_reduce_read_split env =
     [ bgroup "split"
-        [ mkBench "S.foldMany (FL.sliceSepBy (== lf) FL.drain)" env
+        [ mkBench "S.foldMany (FL.takeEndBy_ (== lf) FL.drain)" env
             $ \inh _ -> foldManySepBy inh
-        , mkBench "S.parseMany (FL.sliceSepBy (== lf) FL.drain)" env
+        , mkBench "S.parseMany (FL.takeEndBy_ (== lf) FL.drain)" env
             $ \inh _ -> parseManySepBy inh
         , mkBench "S.wordsBy isSpace FL.drain" env $ \inh _ ->
             wordsBy inh

--- a/benchmark/streamly-benchmarks.cabal
+++ b/benchmark/streamly-benchmarks.cabal
@@ -276,6 +276,7 @@ benchmark Data.Parser.ParserD
   type: exitcode-stdio-1.0
   hs-source-dirs: Streamly/Benchmark/Data/Parser
   main-is: ParserD.hs
+  ghc-options: +RTS -M750M -RTS
   if impl(ghcjs)
     buildable: False
   else
@@ -313,7 +314,7 @@ benchmark Data.Parser
   import: bench-options
   type: exitcode-stdio-1.0
   hs-source-dirs: Streamly/Benchmark/Data
-  ghc-options: +RTS -M750M -RTS
+  ghc-options: +RTS -M1000M -RTS
   main-is: Parser.hs
   if impl(ghcjs)
     buildable: False

--- a/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Nesting.hs
@@ -1336,7 +1336,7 @@ splitOn predicate f =
     --
     -- Since a suffix split fold can be easily expressed using a
     -- non-backtracking fold, we use that.
-    foldManyPost (FL.sliceSepBy predicate f)
+    foldManyPost (FL.takeEndBy_ predicate f)
 
 -- | Split on a suffixed separator element, dropping the separator.  The
 -- supplied 'Fold' is applied on the split segments.
@@ -1389,7 +1389,7 @@ splitOn predicate f =
 splitOnSuffix
     :: (IsStream t, Monad m)
     => (a -> Bool) -> Fold m a b -> t m a -> t m b
-splitOnSuffix predicate f = foldMany (FL.sliceSepBy predicate f)
+splitOnSuffix predicate f = foldMany (FL.takeEndBy_ predicate f)
 
 -- | Split on a prefixed separator element, dropping the separator.  The
 -- supplied 'Fold' is applied on the split segments.
@@ -1511,7 +1511,7 @@ wordsBy predicate f m =
 splitWithSuffix
     :: (IsStream t, Monad m)
     => (a -> Bool) -> Fold m a b -> t m a -> t m b
-splitWithSuffix predicate f = foldMany (FL.sliceEndWith predicate f)
+splitWithSuffix predicate f = foldMany (FL.takeEndBy predicate f)
 
 ------------------------------------------------------------------------------
 -- Splitting - on a delimiter sequence
@@ -1763,7 +1763,7 @@ intervalsOf
     :: (IsStream t, MonadAsync m)
     => Double -> Fold m a b -> t m a -> t m b
 intervalsOf n f xs =
-    splitWithSuffix isNothing (FL.lcatMaybes f)
+    splitWithSuffix isNothing (FL.catMaybes f)
         (interjectSuffix n (return Nothing) (Serial.map Just xs))
 
 ------------------------------------------------------------------------------

--- a/src/Streamly/Internal/FileSystem/Event/Linux.hs
+++ b/src/Streamly/Internal/FileSystem/Event/Linux.hs
@@ -781,12 +781,12 @@ readOneEvent cfg  wt@(Watch _ wdMap) = do
     path <-
         if pathLen /= 0
         then do
-            -- XXX sliceSepBy drops the separator so assumes a null
+            -- XXX takeEndBy_ drops the separator so assumes a null
             -- terminated path, we should use a takeWhile nested inside a
             -- takeP
             pth <-
                 PR.fromFold
-                    $ FL.sliceSepBy (== 0)
+                    $ FL.takeEndBy_ (== 0)
                     $ FL.take pathLen (A.writeN pathLen)
             let remaining = pathLen - A.length pth - 1
             when (remaining /= 0) $ PR.takeEQ remaining FL.drain

--- a/test/Streamly/Test/Data/Fold.hs
+++ b/test/Streamly/Test/Data/Fold.hs
@@ -221,22 +221,22 @@ take ls =
             S.fold (F.take n FL.toList) (S.fromList ls)
                 `shouldReturn` Prelude.take n ls
 
-sliceSepBy :: Property
-sliceSepBy =
+takeEndBy_ :: Property
+takeEndBy_ =
     forAll (listOf (chooseInt (0, 1))) $ \ls ->
         let p = (== 1)
-            f = F.sliceSepBy p FL.toList
+            f = F.takeEndBy_ p FL.toList
             ys = Prelude.takeWhile (not . p) ls
          in case S.fold f (S.fromList ls) of
             Right xs -> checkListEqual xs ys
             Left _ -> property False
 
-sliceSepByMax :: Property
-sliceSepByMax =
+takeEndByOrMax :: Property
+takeEndByOrMax =
     forAll (chooseInt (min_value, max_value)) $ \n ->
         forAll (listOf (chooseInt (0, 1))) $ \ls ->
             let p = (== 1)
-                f = F.sliceSepBy p (F.take n FL.toList)
+                f = F.takeEndBy_ p (F.take n FL.toList)
                 ys = Prelude.take n (Prelude.takeWhile (not . p) ls)
              in case S.fold f (S.fromList ls) of
                     Right xs -> checkListEqual xs ys
@@ -444,8 +444,8 @@ main = hspec $
         prop "Or" Main.or
         prop "mapMaybe" mapMaybe
         prop "take" take
-        prop "sliceSepBy" sliceSepBy
-        prop "sliceSepByMax" sliceSepByMax
+        prop "takeEndBy_" takeEndBy_
+        prop "takeEndByOrMax" takeEndByOrMax
         prop "drain" Main.drain
         prop "drainBy" Main.drainBy
         prop "mean" Main.mean

--- a/test/Streamly/Test/Data/Parser.hs
+++ b/test/Streamly/Test/Data/Parser.hs
@@ -511,7 +511,7 @@ many =
         let fldstp conL currL = return $ FL.Partial $ conL ++ currL
             concatFold = FL.Fold fldstp (return (FL.Partial [])) return
             prsr =
-                P.many concatFold $ P.fromFold $ FL.sliceSepBy (== 1) FL.toList
+                P.many concatFold $ P.fromFold $ FL.takeEndBy_ (== 1) FL.toList
         in
             case S.parse prsr (S.fromList ls) of
                 Right res_list -> checkListEqual res_list
@@ -532,7 +532,7 @@ some =
             fldstp conL currL = return $ FL.Partial $ conL ++ currL
             concatFold = FL.Fold fldstp (return (FL.Partial [])) return
             prsr =
-                P.some concatFold $ P.fromFold $ FL.sliceSepBy (== 1) FL.toList
+                P.some concatFold $ P.fromFold $ FL.takeEndBy_ (== 1) FL.toList
         in
             case S.parse prsr (S.fromList ls) of
                 Right res_list -> res_list == Prelude.filter (== 0) ls
@@ -735,10 +735,10 @@ main =
         -- prop "" shortestFailLeft
         -- prop "" shortestFailRight
         -- prop "" shortestFailBoth
-        prop ("P.many concatFold $ P.sliceSepBy (== 1) FL.toList ="
+        prop ("P.many concatFold $ P.takeEndBy_ (== 1) FL.toList ="
                 ++ "Prelude.filter (== 0)") many
         -- prop "[] due to parser being die" many_empty
-        prop ("P.some concatFold $ P.sliceSepBy (== 1) FL.toList ="
+        prop ("P.some concatFold $ P.takeEndBy_ (== 1) FL.toList ="
                 ++ "Prelude.filter (== 0)") some
         -- prop "fail due to parser being die" someFail
     takeProperties

--- a/test/Streamly/Test/Data/Parser/ParserD.hs
+++ b/test/Streamly/Test/Data/Parser/ParserD.hs
@@ -356,11 +356,11 @@ groupByRolling =
         then x : groupByLF (Just x) xs
         else []
 
-sliceSepByMax :: Property
-sliceSepByMax =
+takeEndByOrMax :: Property
+takeEndByOrMax =
     forAll (chooseInt (min_value, max_value)) $ \n ->
         forAll (listOf (chooseInt (0, 1))) $ \ls ->
-            case S.parseD (P.fromFold $ FL.sliceSepBy predicate (FL.take n FL.toList)) (S.fromList ls) of
+            case S.parseD (P.fromFold $ FL.takeEndBy_ predicate (FL.take n FL.toList)) (S.fromList ls) of
                 Right parsed_list -> checkListEqual parsed_list (Prelude.take n (Prelude.takeWhile (not . predicate) ls))
                 Left _ -> property False
             where
@@ -516,7 +516,7 @@ many =
                     FL.Fold fldstp (return (FL.Partial [])) return
                 prsr =
                     P.many concatFold
-                        $ P.fromFold $ FL.sliceSepBy (== 1) FL.toList
+                        $ P.fromFold $ FL.takeEndBy_ (== 1) FL.toList
              in case S.parseD prsr (S.fromList ls) of
                     Right res_list ->
                         checkListEqual res_list (Prelude.filter (== 0) ls)
@@ -536,7 +536,7 @@ some =
                 concatFold = FL.Fold fldstp (return (FL.Partial [])) return
                 prsr =
                     P.some concatFold
-                        $ P.fromFold $ FL.sliceSepBy (== 1) FL.toList
+                        $ P.fromFold $ FL.takeEndBy_ (== 1) FL.toList
              in case S.parseD prsr (S.fromList ls) of
                     Right res_list -> res_list == Prelude.filter (== 0) ls
                     Left _ -> False
@@ -747,7 +747,7 @@ main =
         prop "P.takeWhile1 = Prelude.takeWhile if taken something, else check why failed" takeWhile1
         prop "P.groupBy = Prelude.head . Prelude.groupBy" groupBy
         prop "groupByRolling" groupByRolling
-        prop "P.sliceSepByMax = Prelude.take n (Prelude.takeWhile (not . predicate)" sliceSepByMax
+        prop "P.takeEndByOrMax = Prelude.take n (Prelude.takeWhile (not . predicate)" takeEndByOrMax
         prop "many (P.wordBy ' ') = words'" wordBy
         prop "parse 0, then 1, else fail" serialWith
         prop "fail due to die as left parser" splitWithFailLeft
@@ -765,8 +765,8 @@ main =
         prop "pass even if die is left parser" longestPassLeft
         prop "pass even if die is right parser" longestPassRight
         prop "fail due to die as both parsers" longestFailBoth
-        prop "P.many concatFold $ P.sliceSepBy (== 1) FL.toList = Prelude.filter (== 0)" many
+        prop "P.many concatFold $ P.takeEndBy_ (== 1) FL.toList = Prelude.filter (== 0)" many
         prop "[] due to parser being die" many_empty
-        prop "P.some concatFold $ P.sliceSepBy (== 1) FL.toList = Prelude.filter (== 0)" some
+        prop "P.some concatFold $ P.takeEndBy_ (== 1) FL.toList = Prelude.filter (== 0)" some
         prop "fail due to parser being die" someFail
     takeProperties


### PR DESCRIPTION
This commit has no functional change, only renaming and doc edits.

I have changed `Fold.map` back to Fold.lmap to avoid confusion with `fmap`. This is the only deviation from the names of the APIs in Stream module. It probably makes sense to distinguish names explicitly when we have the same operation as covariant as well as contravariant.