### PR TITLE
Add left and right fold constructors

### DIFF
--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -1803,7 +1803,7 @@ chunksBetween _low _high _f1 _f2 = undefined
 -- /Pre-release/
 {-# INLINE toStream #-}
 toStream :: Monad m => Fold m a (SerialT Identity a)
-toStream = mkAccum (\f x -> f . (x `K.cons`)) id ($ K.nil)
+toStream = mkFoldr K.cons K.nil
 
 -- This is more efficient than 'toStream'. toStream is exactly the same as
 -- reversing the stream after toStreamRev.


### PR DESCRIPTION
mkfoldr/mkfoldl are better names as the signature directly correspond to `foldl` and `foldr`. We should remove `mkAccum*`. I have kept the names as `mkFoldl` and `mkFoldr` but I like `mkfoldl` and `mkfoldr` etc. more.