### PR TITLE
Reformat and compact the description

### DIFF
--- a/streamly.cabal
+++ b/streamly.cabal
@@ -3,32 +3,30 @@ name:               streamly
 version:            0.7.2
 synopsis:           Data flow programming and declarative concurrency
 description:
-  Streamly is a framework for modular data flow based programming and
-  declarative concurrency.  Powerful stream fusion framework in streamly
-  allows high performance combinatorial programming even when using byte level
-  streams. Key features include:
+  <https://streamly.composewell.com Streamly> is a framework to build
+  reliable and scalable software systems from modular building blocks
+  using data flow programming (streaming) and declarative concurrency.
+  Powerful stream fusion framework in streamly allows high-performance,
+  modular combinatorial programming. Key features include:
   .
-  * Performance at par with C
-  * Simple API, similar to standard Haskell lists.
-  * Declarative, auto scaled concurrency
-  * Simple, yet powerful abstractions
-      * Unifies streams, arrays and parsers
-      * Obviates the need for text and bytestring
-      * Covers the functionality of list-t and logict
-      * Covers all Data.List combinators
-      * Supports numerous time domain combinators
-      * Interworks with other streaming libraries
-  * Filesystem, fsnotify, network and unicode support included
+  * Performance on par with C (<https://github.com/composewell/streaming-benchmarks Benchmarks>)
+  * Simple API, similar to standard Haskell lists (<https://github.com/composewell/streamly-examples Examples>)
+  * Declarative concurrency with automatic scaling
+  * Filesystem, fsnotify, network, and Unicode support included
   * More functionality provided via many ecosystem packages
   .
-  Where to find more information:
+  Simple, unified, and powerful abstractions:
   .
-  * /Documentation/: <https://streamly.composewell.com Documentation portal>
-  * /Examples/: <https://github.com/composewell/streamly-examples Streamly Examples>
-  * <https://github.com/composewell/streaming-benchmarks Streaming Benchmarks>
-  * <https://github.com/composewell/concurrency-benchmarks Concurrency Benchmarks>
+      * Unifies streams, arrays, folds, and parsers
+      * Unified streams and arrays obviate the need for text and bytestring
+      * Unifies Data.List, list-t, and logict with streams
+      * Supports numerous time-domain combinators
+      * Interworks with other streaming libraries
+      * Arrays interwork with bytestring
   .
-
+  We recommend the better-organized module documentation on the
+  <https://streamly.composewell.com Streamly homepage>.
+  .
 
 homepage:            https://github.com/composewell/streamly
 bug-reports:         https://github.com/composewell/streamly/issues


### PR DESCRIPTION
Second level bullets are not rendered properly so use a separate
paragraph instead to avoid the issue.