### PR TITLE
Use full module names in documentation

### DIFF
--- a/src/Streamly/Internal/Data/Stream/IsStream/Enumeration.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Enumeration.hs
@@ -78,10 +78,13 @@ import qualified Streamly.Internal.Data.Stream.Serial as Serial (map)
 -- check for overflow, underflow or bounds.
 --
 -- @
--- > S.toList $ S.take 4 $ S.enumerateFromStepIntegral 0 2
+-- >>> import Streamly.Internal.Data.Stream.IsStream.Enumeration as Stream
+-- >>> Stream.toList $ Stream.take 4 $ Stream.enumerateFromStepIntegral 0 2
 -- [0,2,4,6]
--- > S.toList $ S.take 3 $ S.enumerateFromStepIntegral 0 (-2)
+--
+-- >>> Stream.toList $ Stream.take 3 $ Stream.enumerateFromStepIntegral 0 (-2)
 -- [0,-2,-4]
+--
 -- @
 --
 -- @since 0.6.0
@@ -97,8 +100,9 @@ enumerateFromStepIntegral from stride =
 -- increments of @1@. The stream is bounded by the size of the 'Integral' type.
 --
 -- @
--- > S.toList $ S.take 4 $ S.enumerateFromIntegral (0 :: Int)
+-- >>> Stream.toList $ Stream.take 4 $ Stream.enumerateFromIntegral (0 :: Int)
 -- [0,1,2,3]
+--
 -- @
 --
 -- @since 0.6.0
@@ -114,10 +118,12 @@ enumerateFromIntegral from = fromStreamD $ D.enumerateFromIntegral from
 -- The stream is bounded by the size of the 'Integral' type.
 --
 -- @
--- > S.toList $ S.take 4 $ S.enumerateFromThenIntegral (0 :: Int) 2
+-- >>> Stream.toList $ Stream.take 4 $ Stream.enumerateFromThenIntegral (0 :: Int) 2
 -- [0,2,4,6]
--- > S.toList $ S.take 4 $ S.enumerateFromThenIntegral (0 :: Int) (-2)
+--
+-- >>> Stream.toList $ Stream.take 4 $ Stream.enumerateFromThenIntegral (0 :: Int) (-2)
 -- [0,-2,-4,-6]
+--
 -- @
 --
 -- @since 0.6.0
@@ -134,8 +140,9 @@ enumerateFromThenIntegral from next =
 -- @to@.
 --
 -- @
--- > S.toList $ S.enumerateFromToIntegral 0 4
+-- >>> Stream.toList $ Stream.enumerateFromToIntegral 0 4
 -- [0,1,2,3,4]
+--
 -- @
 --
 -- @since 0.6.0
@@ -150,10 +157,12 @@ enumerateFromToIntegral from to =
 -- elements are in increments of @then - from@ up to @to@.
 --
 -- @
--- > S.toList $ S.enumerateFromThenToIntegral 0 2 6
+-- >>> Stream.toList $ Stream.enumerateFromThenToIntegral 0 2 6
 -- [0,2,4,6]
--- > S.toList $ S.enumerateFromThenToIntegral 0 (-2) (-6)
+--
+-- >>> Stream.toList $ Stream.enumerateFromThenToIntegral 0 (-2) (-6)
 -- [0,-2,-4,-6]
+--
 -- @
 --
 -- @since 0.6.0
@@ -181,8 +190,9 @@ enumerateFromThenToIntegral from next to =
 -- This is the equivalent to 'enumFrom' for 'Fractional' types. For example:
 --
 -- @
--- > S.toList $ S.take 4 $ S.enumerateFromFractional 1.1
+-- >>> Stream.toList $ Stream.take 4 $ Stream.enumerateFromFractional 1.1
 -- [1.1,2.1,3.1,4.1]
+--
 -- @
 --
 --
@@ -201,10 +211,12 @@ enumerateFromFractional from = fromStreamD $ D.numFrom from
 -- example:
 --
 -- @
--- > S.toList $ S.take 4 $ S.enumerateFromThenFractional 1.1 2.1
+-- >>> Stream.toList $ Stream.take 4 $ Stream.enumerateFromThenFractional 1.1 2.1
 -- [1.1,2.1,3.1,4.1]
--- > S.toList $ S.take 4 $ S.enumerateFromThenFractional 1.1 (-2.1)
+--
+-- >>> Stream.toList $ Stream.take 4 $ Stream.enumerateFromThenFractional 1.1 (-2.1)
 -- [1.1,-2.1,-5.300000000000001,-8.500000000000002]
+--
 -- @
 --
 -- @since 0.6.0
@@ -223,10 +235,12 @@ enumerateFromThenFractional from next = fromStreamD $ D.numFromThen from next
 -- example:
 --
 -- @
--- > S.toList $ S.enumerateFromToFractional 1.1 4
+-- >>> Stream.toList $ Stream.enumerateFromToFractional 1.1 4
 -- [1.1,2.1,3.1,4.1]
--- > S.toList $ S.enumerateFromToFractional 1.1 4.6
+--
+-- >>> Stream.toList $ Stream.enumerateFromToFractional 1.1 4.6
 -- [1.1,2.1,3.1,4.1,5.1]
+--
 -- @
 --
 -- Notice that the last element is equal to the specified @to@ value after
@@ -249,10 +263,12 @@ enumerateFromToFractional from to =
 -- example:
 --
 -- @
--- > S.toList $ S.enumerateFromThenToFractional 0.1 2 6
+-- >>> Stream.toList $ Stream.enumerateFromThenToFractional 0.1 2 6
 -- [0.1,2.0,3.9,5.799999999999999]
--- > S.toList $ S.enumerateFromThenToFractional 0.1 (-2) (-6)
+--
+-- >>> Stream.toList $ Stream.enumerateFromThenToFractional 0.1 (-2) (-6)
 -- [0.1,-2.0,-4.1000000000000005,-6.200000000000001]
+--
 -- @
 --
 --
@@ -327,16 +343,18 @@ class Enum a => Enumerable a where
     -- generating an infinite stream when the type is not 'Bounded'.
     --
     -- @
-    -- > S.toList $ S.take 4 $ S.enumerateFrom (0 :: Int)
+    -- >>> Stream.toList $ Stream.take 4 $ Stream.enumerateFrom (0 :: Int)
     -- [0,1,2,3]
+    --
     -- @
     --
     -- For 'Fractional' types, enumeration is numerically stable. However, no
     -- overflow or underflow checks are performed.
     --
     -- @
-    -- > S.toList $ S.take 4 $ S.enumerateFrom 1.1
+    -- >>> Stream.toList $ Stream.take 4 $ Stream.enumerateFrom 1.1
     -- [1.1,2.1,3.1,4.1]
+    --
     -- @
     --
     -- @since 0.6.0
@@ -347,18 +365,21 @@ class Enum a => Enumerable a where
     -- empty stream is returned.
     --
     -- @
-    -- > S.toList $ S.enumerateFromTo 0 4
+    -- >>> Stream.toList $ Stream.enumerateFromTo 0 4
     -- [0,1,2,3,4]
+    --
     -- @
     --
     -- For 'Fractional' types, the last element is equal to the specified @to@
     -- value after rounding to the nearest integral value.
     --
     -- @
-    -- > S.toList $ S.enumerateFromTo 1.1 4
+    -- >>> Stream.toList $ Stream.enumerateFromTo 1.1 4
     -- [1.1,2.1,3.1,4.1]
-    -- > S.toList $ S.enumerateFromTo 1.1 4.6
+    --
+    -- >>> Stream.toList $ Stream.enumerateFromTo 1.1 4.6
     -- [1.1,2.1,3.1,4.1,5.1]
+    --
     -- @
     --
     -- @since 0.6.0
@@ -372,10 +393,12 @@ class Enum a => Enumerable a where
     -- unbounded types it keeps enumerating infinitely.
     --
     -- @
-    -- > S.toList $ S.take 4 $ S.enumerateFromThen 0 2
+    -- >>> Stream.toList $ Stream.take 4 $ Stream.enumerateFromThen 0 2
     -- [0,2,4,6]
-    -- > S.toList $ S.take 4 $ S.enumerateFromThen 0 (-2)
+    --
+    -- >>> Stream.toList $ Stream.take 4 $ Stream.enumerateFromThen 0 (-2)
     -- [0,-2,-4,-6]
+    --
     -- @
     --
     -- @since 0.6.0
@@ -388,10 +411,12 @@ class Enum a => Enumerable a where
     -- after @from@.
     --
     -- @
-    -- > S.toList $ S.enumerateFromThenTo 0 2 6
+    -- >>> Stream.toList $ Stream.enumerateFromThenTo 0 2 6
     -- [0,2,4,6]
-    -- > S.toList $ S.enumerateFromThenTo 0 (-2) (-6)
+    --
+    -- >>> Stream.toList $ Stream.enumerateFromThenTo 0 (-2) (-6)
     -- [0,-2,-4,-6]
+    --
     -- @
     --
     -- @since 0.6.0

--- a/src/Streamly/Internal/Data/Stream/IsStream/Expand.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Expand.hs
@@ -187,6 +187,7 @@ import Prelude hiding (concat, concatMap)
 
 -- $setup
 -- >>> :m
+-- >>> import Data.IORef
 -- >>> import Prelude hiding (zipWith, concatMap, concat)
 -- >>> import qualified Streamly.Prelude as Stream
 -- >>> import Streamly.Internal.Data.Stream.IsStream as Stream
@@ -237,6 +238,7 @@ append m1 m2 = fromStreamD $ D.append (toStreamD m1) (toStreamD m2)
 -- >>> import Data.Functor.Identity (Identity)
 -- >>> Stream.interleave "ab" ",,,," :: Stream.SerialT Identity Char
 -- fromList "a,b,,,"
+--
 -- >>> Stream.interleave "abcd" ",," :: Stream.SerialT Identity Char
 -- fromList "a,b,cd"
 --
@@ -369,27 +371,27 @@ mergeBy f m1 m2 = fromStreamS $ S.mergeBy f (toStreamS m1) (toStreamS m2)
 --
 -- @
 -- > randomly _ _ = randomIO >>= \x -> return $ if x then LT else GT
--- > S.toList $ S.mergeByM randomly (S.fromList [1,1,1,1]) (S.fromList [2,2,2,2])
+-- > Stream.toList $ Stream.mergeByM randomly (Stream.fromList [1,1,1,1]) (Stream.fromList [2,2,2,2])
 -- [2,1,2,2,2,1,1,1]
 -- @
 --
 -- Merge two streams in a proportion of 2:1:
 --
 -- @
--- proportionately m n = do
---  ref <- newIORef $ cycle $ concat [replicate m LT, replicate n GT]
---  return $ \\_ _ -> do
---      r <- readIORef ref
---      writeIORef ref $ tail r
---      return $ head r
---
--- main = do
+-- >>> :{
+-- do    
+--  let proportionately m n = do
+--       ref <- newIORef $ cycle $ Prelude.concat [Prelude.replicate m LT, Prelude.replicate n GT]
+--       return $ \_ _ -> do
+--          r <- readIORef ref
+--          writeIORef ref $ Prelude.tail r
+--          return $ Prelude.head r  
 --  f <- proportionately 2 1
---  xs <- S.toList $ S.mergeByM f (S.fromList [1,1,1,1,1,1]) (S.fromList [2,2,2])
+--  xs <- Stream.toList $ Stream.mergeByM f (Stream.fromList [1,1,1,1,1,1]) (Stream.fromList [2,2,2])
 --  print xs
--- @
--- @
+-- :}
 -- [1,1,2,1,1,2,1,1,2]
+--
 -- @
 --
 -- @since 0.6.0
@@ -420,7 +422,7 @@ mergeEndByFirst f m1 m2 = fromStreamS $
 -- | Same as @'mergeBy' 'compare'@.
 --
 -- @
--- > S.toList $ S.merge (S.fromList [1,3,5]) (S.fromList [2,4,6,8])
+-- >>> Stream.toList $ Stream.merge (Stream.fromList [1,3,5]) (Stream.fromList [2,4,6,8])
 -- [1,2,3,4,5,6,8]
 -- @
 --

--- a/src/Streamly/Internal/Data/Stream/IsStream/Generate.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Generate.hs
@@ -165,14 +165,15 @@ unfold0 unf = unfold unf (error "unfold0: unexpected void evaluation")
 -- For example,
 --
 -- @
+-- >>> :{
 -- let f b =
 --         if b > 3
 --         then Nothing
 --         else Just (b, b + 1)
--- in toList $ unfoldr f 0
--- @
--- @
+-- in Stream.toList $ Stream.unfoldr f 0
+-- :}
 -- [0,1,2,3]
+--
 -- @
 --
 -- @since 0.1.0
@@ -188,17 +189,15 @@ unfoldr step seed = fromStreamS (S.unfoldr step seed)
 -- example,
 --
 -- @
+-- >>> :{
 -- let f b =
 --         if b > 3
 --         then return Nothing
---         else print b >> return (Just (b, b + 1))
--- in drain $ unfoldrM f 0
--- @
--- @
---  0
---  1
---  2
---  3
+--         else return (Just (b, b + 1))
+-- in Stream.toList $ Stream.unfoldrM f 0
+-- :}
+-- [0,1,2,3]
+--
 -- @
 -- When run concurrently, the next unfold step can run concurrently with the
 -- processing of the output of the previous step.  Note that more than one step
@@ -441,8 +440,9 @@ fromIndicesMSerial = fromStreamS . S.fromIndicesM
 -- element.
 --
 -- @
--- > S.toList $ S.take 5 $ S.iterate (+1) 1
+-- >>> Stream.toList $ Stream.take 5 $ Stream.iterate (+1) 1
 -- [1,2,3,4,5]
+--
 -- @
 --
 -- @since 0.1.2

--- a/src/Streamly/Internal/Data/Stream/IsStream/Reduce.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Reduce.hs
@@ -312,10 +312,10 @@ foldSequence _f _m = undefined
 -- the fold is used to generate the next fold and so on.
 --
 -- @
--- > import Data.Monoid (Sum(..))
--- > f x = return (Fold.take 2 (Fold.sconcat x))
--- > s = Stream.map Sum $ Stream.fromList [1..10]
--- > Stream.toList $ Stream.map getSum $ Stream.foldIterateM f 0 s
+-- >>> import Data.Monoid (Sum(..))
+-- >>> f x = return (Fold.take 2 (Fold.sconcat x))
+-- >>> s = Stream.map Sum $ Stream.fromList [1..10]
+-- >>> Stream.toList $ Stream.map getSum $ Stream.foldIterateM f 0 s
 -- [3,10,21,36,55,55]
 --
 -- @

--- a/src/Streamly/Prelude.hs
+++ b/src/Streamly/Prelude.hs
@@ -1124,8 +1124,9 @@ import Streamly.Internal.Data.Stream.IsStream
 -- works. For example:
 --
 -- @
--- > S.foldl' (+) 0 $ S.fromList [1,2,3,4]
+-- >>> Stream.foldl' (+) 0 $ Stream.fromList [1,2,3,4]
 -- 10
+--
 -- @
 --
 -- @
@@ -1148,8 +1149,9 @@ import Streamly.Internal.Data.Stream.IsStream
 -- reverse (LIFO) order:
 --
 -- @
--- > S.foldl' (flip (:)) [] $ S.fromList [1,2,3,4]
+-- >>> Stream.foldl' (flip (:)) [] $ Stream.fromList [1,2,3,4]
 -- [4,3,2,1]
+--
 -- @
 --
 -- A left fold is a push fold. The producer pushes its contents to the step
@@ -1198,8 +1200,8 @@ import Streamly.Internal.Data.Stream.IsStream
 --
 -- @
 --  ...
---  $ S.maxBuffer 10
---  $ S.mapM ...
+--  $ Stream.maxBuffer 10
+--  $ Stream.mapM ...
 --  ...
 -- @
 --
@@ -1209,8 +1211,8 @@ import Streamly.Internal.Data.Stream.IsStream
 --
 -- @
 --  ...
---  & S.maxBuffer 10
---  & S.mapM ...
+--  & Stream.maxBuffer 10
+--  & Stream.mapM ...
 --  ...
 -- @
 


### PR DESCRIPTION
Fix #872 