### PR TITLE
Use lowercased comparison for benchmark fields

### DIFF
--- a/benchmark/Chart.hs
+++ b/benchmark/Chart.hs
@@ -186,7 +186,7 @@ main = do
                     { presentation = Groups PercentDiff
                     , selectBenchmarks = selectBench (sortByName opts)
                     , selectFields = filter
-                        ( flip elem fs
+                        ( flip elem (fmap (fmap toLower) fs)
                         . fmap toLower
                         )
                     }


### PR DESCRIPTION
For case insensitive comparison we were lowercasing the fields in the
benchmark csv header but not the fields being compared. So the fields
were not matching if we passed them in mixed case.