### PR TITLE
Fix the space requirements of two benchmarks

### DIFF
--- a/benchmark/Streamly/Benchmark/Prelude/Serial/Elimination.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial/Elimination.hs
@@ -471,7 +471,6 @@ o_1_space_elimination_folds value =
         , benchIOSink value "and" (and value)
         , benchIOSink value "or" (or value)
 
-        , benchPureSink value "showsPrec pure streams" showInstance
         -- length is used to check for foldr/build fusion
         , benchPureSink value "length . IsList.toList" (Prelude.length . GHC.toList)
         ]
@@ -513,6 +512,8 @@ o_n_heap_elimination_buffered value =
         -- XXX can the outputs be streaming? Can we have special read/show
         -- style type classes, readM/showM supporting streaming effects?
         [ bench "showPrec Haskell lists" $ nf showInstanceList (mkList value)
+        -- XXX This is not o-1-space for GHC-8.10
+        , benchPureSink value "showsPrec pure streams" showInstance
         ]
     ]
 

--- a/bin/bench-exec-one.sh
+++ b/bin/bench-exec-one.sh
@@ -102,6 +102,8 @@ bench_rts_opts_specific () {
     Data.SmallArray/o-1-sp*) echo -n "-K128K" ;;
     # For tasty-bench
     Data.Array*/o-1-space/generation/show) echo -n "-M32M" ;;
+    # XXX For GHC-8.10
+    Data.Array/o-1-space/transformationX4/map) echo -n "-M32M" ;;
     *) echo -n "" ;;
   esac
 }

--- a/bin/bench-exec-one.sh
+++ b/bin/bench-exec-one.sh
@@ -104,6 +104,9 @@ bench_rts_opts_specific () {
     Data.Array*/o-1-space/generation/show) echo -n "-M32M" ;;
     # XXX For GHC-8.10
     Data.Array/o-1-space/transformationX4/map) echo -n "-M32M" ;;
+    # DEVBUILD only benchmarks - array foldable instance
+    Data.Array.Foreign/o-1-space/elimination/foldable/foldl*) echo -n "-K8M" ;;
+    Data.Array.Foreign/o-1-space/elimination/foldable/sum) echo -n "-K8M" ;;
     *) echo -n "" ;;
   esac
 }


### PR DESCRIPTION
Move showInstance benchmark for pure streams to o-n-space
Increase the heap space for array map x 4