### PR TITLE
Revert "Fix zipWith(M) to work concurrently according to the stream t…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,9 +15,6 @@
 * `encodeLatin1` now silently truncates any character beyond 255 to incorrect
   characters in the input stream. Use `encodeLatin1'` to recover previous
   functionality.
-* The zipping functions `Streamly.Prelude.zipWith` and
-  `Streamly.Prelude.zipWithM` are now applied concurrently for concurrent
-  streams.
 
 ### Breaking type changes
 

--- a/benchmark/Streamly/Benchmark/Data/Stream/StreamK.hs
+++ b/benchmark/Streamly/Benchmark/Data/Stream/StreamK.hs
@@ -372,7 +372,7 @@ iterateDropWhileTrue streamLen iterStreamLen maxIters = iterateSource iterStream
 -------------------------------------------------------------------------------
 
 {-# INLINE zipWith #-}
-zipWith :: S.MonadAsync m => Stream m Int -> m ()
+zipWith :: Monad m => Stream m Int -> m ()
 zipWith src = drain $ S.zipWith (,) src src
 
 -------------------------------------------------------------------------------

--- a/src/Streamly/Internal/Data/Stream/StreamK.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamK.hs
@@ -995,40 +995,34 @@ mapMaybe f m = go m
 -- Serial Zipping
 ------------------------------------------------------------------------------
 
--- XXX We can probably implement zipWith in terms of zipWithM
--- | Zip two streams serially using a pure zipping function. The zipping
--- function is applied concurrently for concurrent streams.
+-- | Zip two streams serially using a pure zipping function.
 --
 -- @since 0.1.0
 {-# INLINABLE zipWith #-}
-zipWith ::
-       (IsStream t, MonadAsync m) => (a -> b -> c) -> t m a -> t m b -> t m c
+zipWith :: IsStream t => (a -> b -> c) -> t m a -> t m b -> t m c
 zipWith f = go
     where
     go mx my = mkStream $ \st yld sng stp -> do
         let merge a ra =
                 let single2 b = sng (f a b)
-                    runIt x = foldStream st yld sng stp x
-                    yield2 b rb = runIt (return (f a b) `consM` go ra rb)
+                    yield2 b rb = yld (f a b) (go ra rb)
                  in foldStream (adaptState st) yield2 single2 stp my
         let single1 a = merge a nil
             yield1 = merge
         foldStream (adaptState st) yield1 single1 stp mx
 
--- | Zip two streams serially using a monadic zipping function. The zipping
--- function is applied concurrently for concurrent streams.
+-- | Zip two streams serially using a monadic zipping function.
 --
 -- @since 0.1.0
 {-# INLINABLE zipWithM #-}
-zipWithM ::
-       (IsStream t, MonadAsync m) => (a -> b -> m c) -> t m a -> t m b -> t m c
+zipWithM :: (IsStream t, Monad m) => (a -> b -> m c) -> t m a -> t m b -> t m c
 zipWithM f m1 m2 = go m1 m2
     where
     go mx my = mkStream $ \st yld sng stp -> do
         let merge a ra =
                 let runIt x = foldStream st yld sng stp x
                     single2 b   = f a b >>= sng
-                    yield2 b rb = runIt (f a b `consM` go ra rb)
+                    yield2 b rb = f a b >>= \x -> runIt (x `cons` go ra rb)
                  in foldStream (adaptState st) yield2 single2 stp my
         let single1 a = merge a nil
             yield1 = merge


### PR DESCRIPTION
This reverts commit 1ddcfc46345cd4e4c3115a955668a6d5158a64cd.

This requires MonadAsync constraint which breaks the existing
zipWith for pure streams e.g. 'SerialT Identity' (for example in
streaming-benchmarks package). We can possibly have different zipWith
APIs for concurrent zipping.