### PR TITLE
Use limit-build-mem by default in bench/test scripts

### DIFF
--- a/benchmark/bench-report/bin/bench-runner.sh
+++ b/benchmark/bench-report/bin/bench-runner.sh
@@ -466,7 +466,7 @@ MEASURE=1
 GAUGE_ARGS=
 BUILD_ONCE=0
 
-CABAL_BUILD_OPTIONS="--flag fusion-plugin "
+CABAL_BUILD_OPTIONS="--flag fusion-plugin --flag limit-build-mem"
 
 #-----------------------------------------------------------------------------
 # Read command line

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -49,6 +49,7 @@ COVERAGE=0
 MEASURE=1
 HPC_REPORT_OPTIONS=
 RAW=0
+CABAL_BUILD_OPTIONS="--flag limit-build-mem"
 
 # XXX add a bisect option
 while test -n "$1"
@@ -58,7 +59,7 @@ do
     # options with arguments
     --targets) shift; TARGETS=$1; shift ;;
     --with-compiler) shift; CABAL_WITH_COMPILER=$1; shift ;;
-    --cabal-build-options) shift; CABAL_BUILD_OPTIONS=$1; shift ;;
+    --cabal-build-options) shift; CABAL_BUILD_OPTIONS+=$1; shift ;;
     --hpc-report-options) shift; HPC_REPORT_OPTIONS=$1; shift ;;
     --rtsopts) shift; RTS_OPTIONS=$1; shift ;;
     # flags


### PR DESCRIPTION
Otherwise we may accidentally run into memory hog issues.