### PR TITLE
Timeout combinator for File Handle write buffer

### DIFF
--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
@@ -172,13 +172,13 @@ writeReadWithBufferOf inh devNull = IUF.fold fld unf (defaultChunkSize, inh)
 
 {-# NOINLINE writeReadWithBufferOfMaybe #-}
 writeReadWithBufferOfMaybe :: Handle -> Handle -> IO ()
-writeReadWithBufferOfMaybe inh devNull = S.fold fld strm 
+writeReadWithBufferOfMaybe inh devNull = S.fold fld strm
 
     where
 
     fld = FH.writeMaybesWithBufferOf defaultChunkSize devNull
-    strm = ISS.justsOfTimeout defaultChunkSize 0.5 
-            $ S.unfold FH.readWithBufferOf (defaultChunkSize, inh)  
+    strm = ISS.justsOfTimeout defaultChunkSize 0.5
+            $ S.unfold FH.readWithBufferOf (defaultChunkSize, inh)
 
 #ifdef INSPECTION
 inspect $ hasNoTypeClasses 'writeReadWithBufferOf
@@ -214,7 +214,7 @@ o_1_space_copy env =
         , mkBench "FH.writeWithBufferOf . FH.readWithBufferOf" env $ \inh _ ->
             writeReadWithBufferOf inh (nullH env)
         , mkBench "FH.writeWithBufferOfMaybe . FH.readWithBufferOf" env $ \inh _ ->
-            writeReadWithBufferOfMaybe inh (nullH env)    
+            writeReadWithBufferOfMaybe inh (nullH env)
     ]
     ]
 

--- a/src/Streamly/FileSystem/Handle.hs
+++ b/src/Streamly/FileSystem/Handle.hs
@@ -88,6 +88,7 @@ module Streamly.FileSystem.Handle
 
     , write
     , writeWithBufferOf
+    , writeMaybesWithBufferOf
     , writeChunks
     )
 where

--- a/src/Streamly/Internal/Data/Array/Foreign/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Type.hs
@@ -65,6 +65,7 @@ module Streamly.Internal.Data.Array.Foreign.Type
     , writeNAlignedUnmanaged
     , write
     , writeAligned
+    , writeMaybesN
 
     -- * Streams of arrays
     , arraysOf
@@ -696,3 +697,9 @@ nil = Array nullForeignPtr (Ptr nullAddr#)
 instance Storable a => Monoid (Array a) where
     mempty = nil
     mappend = (<>)
+
+{-# INLINE_NORMAL writeMaybesN #-}
+writeMaybesN :: forall m a. (MonadIO m, Storable a)
+    => Int -> Fold m (Maybe a) (Array a)
+writeMaybesN n = unsafeFreeze <$> MA.writeMaybesN n  
+  

--- a/src/Streamly/Internal/Data/Array/Foreign/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Type.hs
@@ -701,5 +701,4 @@ instance Storable a => Monoid (Array a) where
 {-# INLINE_NORMAL writeMaybesN #-}
 writeMaybesN :: forall m a. (MonadIO m, Storable a)
     => Int -> Fold m (Maybe a) (Array a)
-writeMaybesN n = unsafeFreeze <$> MA.writeMaybesN n  
-  
+writeMaybesN n = unsafeFreeze <$> MA.writeMaybesN n

--- a/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Transform.hs
@@ -114,6 +114,7 @@ module Streamly.Internal.Data.Stream.IsStream.Transform
     , intersperseSuffix
     , intersperseSuffixBySpan
     , interjectSuffix
+    , justsOfTimeout
 
     -- , interspersePrefix
     -- , interspersePrefixBySpan
@@ -1666,3 +1667,24 @@ applyAsync = (|$)
 x |& f = f |$ x
 
 infixl 1 |&
+
+-- | Transform a stream of @a@ to @(Just a)@
+-- /Internal/
+--
+{-# INLINE justsOf #-}
+justsOf :: (MonadIO m, IsStream t)
+    => t m a -> t m (Maybe a)
+justsOf = map Just
+
+-- | Transform a stream of @a@ to stream of @(Just a)@ then intersperse a
+-- Nothing intothe input stream after every n elements then interject Nothing
+-- after every @t@ seconds.
+-- /Pre-release/
+--
+{-# INLINE justsOfTimeout #-}
+justsOfTimeout :: (MonadIO m, IsStream t, MonadAsync m)
+    => Int -> Double -> t m a -> t m (Maybe a)
+justsOfTimeout n t =
+      interjectSuffix t (return Nothing)
+    . intersperseSuffixBySpan n (return Nothing)
+    . justsOf

--- a/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/src/Streamly/Internal/FileSystem/Handle.hs
@@ -504,7 +504,7 @@ writeWithBufferOf2 :: MonadIO m => Int -> Fold2 m Handle Word8 ()
 writeWithBufferOf2 n = FL.chunksOf2 n (writeNUnsafe n) writeChunks2
 
 {-# INLINE writeMaybesWithBufferOf #-}
-writeMaybesWithBufferOf :: (MonadIO m ) => 
+writeMaybesWithBufferOf :: (MonadIO m ) =>
     Int -> Handle -> Fold m (Maybe Word8) ()
 writeMaybesWithBufferOf n h = FL.many (writeMaybesN n) (writeChunks h)
 

--- a/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/src/Streamly/Internal/FileSystem/Handle.hs
@@ -51,6 +51,7 @@ module Streamly.Internal.FileSystem.Handle
     -- , writeByFrames
     -- , writeLines
     , writeWithBufferOf
+    , writeMaybesWithBufferOf
 
     , putBytes
     , putBytesWithBufferOf
@@ -114,7 +115,7 @@ import Streamly.Internal.Data.Fold (Fold)
 import Streamly.Internal.Data.Fold.Type (Fold2(..))
 import Streamly.Internal.Data.Unfold.Type (Unfold(..))
 import Streamly.Internal.Data.Array.Foreign.Type
-       (Array(..), writeNUnsafe, unsafeFreezeWithShrink)
+       (Array(..), writeNUnsafe, writeMaybesN, unsafeFreezeWithShrink)
 import Streamly.Internal.Data.Array.Foreign.Mut.Type (mutableArray)
 import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Stream.IsStream.Type
@@ -501,6 +502,12 @@ writeWithBufferOf n h = FL.chunksOf n (writeNUnsafe n) (writeChunks h)
 {-# INLINE writeWithBufferOf2 #-}
 writeWithBufferOf2 :: MonadIO m => Int -> Fold2 m Handle Word8 ()
 writeWithBufferOf2 n = FL.chunksOf2 n (writeNUnsafe n) writeChunks2
+
+{-# INLINE writeMaybesWithBufferOf #-}
+writeMaybesWithBufferOf :: (MonadIO m ) => 
+    Int -> Handle -> Fold m (Maybe Word8) ()
+writeMaybesWithBufferOf n h = FL.many (writeMaybesN n) (writeChunks h)
+
 
 -- | Write a byte stream to a file handle. Accumulates the input in chunks of
 -- up to 'Streamly.Internal.Data.Array.Foreign.Type.defaultChunkSize' before writing


### PR DESCRIPTION
Benchmarks below:
  
      FH.writeWithBufferOf . FH.readWithBufferOf:      OK (8.14s)
        2.71 s ±  13 ms,  17 GB allocated, 129 MB copied
      FH.writeWithBufferOfMaybe . FH.readWithBufferOf: OK (84.10s)
        28.01 s ± 172 ms,  82 GB allocated, 4.5 GB copied