### PR TITLE
Add skeleton for groupByRollingEither

### DIFF
--- a/benchmark/Streamly/Benchmark/Prelude/Merge.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Merge.hs
@@ -238,6 +238,11 @@ o_n_heap_concat value =
             "concatPairsWithMergeByFused compare (sqrtVal of sqrtVal)"
             (concatPairsWithMergeByFused compare sqrtVal sqrtVal)
         ]
+    -- TODO: change sourceUnfoldrM to generate alternating bigger and lower
+    -- numbers to simulate a random input for a worst case sort benchmark. We
+    -- can use 0 and value as two ints in the state and alternate each in the
+    -- output streams, incrementing the lower number of decrementing the higher
+    -- number.
     , bgroup "sorting"
         [ benchIOSink value "sortBy compare" (sortBy compare)
         , benchIOSink value "sortBy (flip compare)" (sortBy (flip compare))

--- a/src/Streamly/Internal/Data/Parser.hs
+++ b/src/Streamly/Internal/Data/Parser.hs
@@ -97,6 +97,7 @@ module Streamly.Internal.Data.Parser
     , wordBy
     , groupBy
     , groupByRolling
+    , groupByRollingEither
     , eqBy
     -- | Unimplemented
     --
@@ -698,6 +699,21 @@ groupBy eq = K.toParserK . D.groupBy eq
 {-# INLINABLE groupByRolling #-}
 groupByRolling :: MonadCatch m => (a -> a -> Bool) -> Fold m a b -> Parser m a b
 groupByRolling eq = K.toParserK . D.groupByRolling eq
+
+-- | Like 'groupByRolling', but if the predicate is 'True' then collects using
+-- the first fold as long as the predicate holds 'True', if the predicate is
+-- 'False' collects using the second fold as long as it remains 'False'.
+-- Returns 'Left' for the first case and 'Right' for the second case.
+--
+-- For example, if we want to detect sorted sequences in a stream, both
+-- ascending and descending cases we can use 'groupByRollingEither (<=)
+-- Fold.toList Fold.toList'.
+--
+-- /Unimplemented/
+{-# INLINABLE groupByRollingEither #-}
+groupByRollingEither :: -- MonadCatch m =>
+    (a -> a -> Bool) -> Fold m a b -> Fold m a b -> Parser m a (Either b b)
+groupByRollingEither = undefined
 
 -- | Match the given sequence of elements using the given comparison function.
 --

--- a/src/Streamly/Internal/Data/Stream/IsStream/Top.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Top.hs
@@ -181,6 +181,9 @@ sampleBurstStart gap =
 -- input stream is almost sorted (ascending/descending) or random. We could
 -- serialize the stream to an array and use quicksort.
 --
+-- Use 'groupByRollingEither (\x -> (< GT) . f x) Fold.toList Fold.toListRev'
+-- to generate sorted segments before merging. Compare the perf.
+--
 -- | Sort the input stream using a supplied comparison function.
 --
 -- /O(n) space/


### PR DESCRIPTION
The driving use case for this is to make the sorting faster by detecting
sorted sequences in the input.