### PR TITLE
Rename Consumer to Refold

### DIFF
--- a/benchmark/Streamly/Benchmark/Prelude/Serial/NestedFold.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial/NestedFold.hs
@@ -20,7 +20,7 @@ import Control.Monad.IO.Class (MonadIO(..))
 import Data.Monoid (Sum(..))
 import GHC.Generics (Generic)
 
-import qualified Streamly.Internal.Data.Consumer.Type as Consumer
+import qualified Streamly.Internal.Data.Refold.Type as Refold
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Stream.IsStream as Internal
 import qualified Streamly.Prelude  as S
@@ -141,12 +141,12 @@ foldMany =
     . Internal.foldMany (FL.take 2 FL.mconcat)
     . S.map Sum
 
-{-# INLINE consumeMany #-}
-consumeMany :: Monad m => SerialT m Int -> m ()
-consumeMany =
+{-# INLINE refoldMany #-}
+refoldMany :: Monad m => SerialT m Int -> m ()
+refoldMany =
       S.drain
     . S.map getSum
-    . Internal.consumeMany (Consumer.take 2 Consumer.sconcat) (return mempty)
+    . Internal.refoldMany (Refold.take 2 Refold.sconcat) (return mempty)
     . S.map Sum
 
 {-# INLINE foldIterateM #-}
@@ -158,13 +158,13 @@ foldIterateM =
             (return . FL.take 2 . FL.sconcat) (return (Sum 0))
         . S.map Sum
 
-{-# INLINE consumeIterateM #-}
-consumeIterateM :: Monad m => SerialT m Int -> m ()
-consumeIterateM =
+{-# INLINE refoldIterateM #-}
+refoldIterateM :: Monad m => SerialT m Int -> m ()
+refoldIterateM =
     S.drain
         . S.map getSum
-        . Internal.consumeIterateM
-            (Consumer.take 2 Consumer.sconcat) (return (Sum 0))
+        . Internal.refoldIterateM
+            (Refold.take 2 Refold.sconcat) (return (Sum 0))
         . S.map Sum
 
 o_1_space_grouping :: Int -> [Benchmark]
@@ -177,9 +177,9 @@ o_1_space_grouping value =
         , benchIOSink value "groupsByRollingLT" groupsByRollingLT
         , benchIOSink value "groupsByRollingEq" groupsByRollingEq
         , benchIOSink value "foldMany" foldMany
-        , benchIOSink value "consumeMany" consumeMany
+        , benchIOSink value "refoldMany" refoldMany
         , benchIOSink value "foldIterateM" foldIterateM
-        , benchIOSink value "consumeIterateM" consumeIterateM
+        , benchIOSink value "refoldIterateM" refoldIterateM
         ]
     ]
 

--- a/src/Streamly/Internal/Data/Stream/IsStream/Reduce.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Reduce.hs
@@ -29,10 +29,10 @@ module Streamly.Internal.Data.Stream.IsStream.Reduce
     -- | Apply folds on a stream.
     , foldMany
     , foldManyPost
-    , consumeMany
+    , refoldMany
     , foldSequence
     , foldIterateM
-    , consumeIterateM
+    , refoldIterateM
 
     -- ** Chunking
     -- | Element unaware grouping.
@@ -155,7 +155,7 @@ import Data.Maybe (isNothing)
 import Foreign.Storable (Storable)
 import Streamly.Internal.Control.Concurrent (MonadAsync)
 import Streamly.Internal.Data.Fold.Type (Fold (..))
-import Streamly.Internal.Data.Consumer.Type (Consumer (..))
+import Streamly.Internal.Data.Refold.Type (Refold (..))
 import Streamly.Internal.Data.Parser (Parser (..))
 import Streamly.Internal.Data.Array.Foreign.Type (Array)
 import Streamly.Internal.Data.Stream.IsStream.Common
@@ -295,13 +295,13 @@ foldMany
     -> t m b
 foldMany f m = fromStreamD $ D.foldMany f (toStreamD m)
 
--- | Like 'foldMany' but using the 'Consumer' type instead of 'Fold'.
+-- | Like 'foldMany' but using the 'Refold' type instead of 'Fold'.
 --
 -- /Pre-release/
-{-# INLINE consumeMany #-}
-consumeMany :: (IsStream t, Monad m) =>
-    Consumer m c a b -> m c -> t m a -> t m b
-consumeMany f action = fromStreamD . D.consumeMany f action . toStreamD
+{-# INLINE refoldMany #-}
+refoldMany :: (IsStream t, Monad m) =>
+    Refold m c a b -> m c -> t m a -> t m b
+refoldMany f action = fromStreamD . D.refoldMany f action . toStreamD
 
 -- | Apply a stream of folds to an input stream and emit the results in the
 -- output stream.
@@ -339,14 +339,14 @@ foldIterateM ::
        (IsStream t, Monad m) => (b -> m (Fold m a b)) -> m b -> t m a -> t m b
 foldIterateM f i m = fromStreamD $ D.foldIterateM f i (toStreamD m)
 
--- | Like 'foldIterateM' but using the 'Consumer' type instead. This could be
+-- | Like 'foldIterateM' but using the 'Refold' type instead. This could be
 -- much more efficient due to stream fusion.
 --
 -- /Internal/
-{-# INLINE consumeIterateM #-}
-consumeIterateM :: (IsStream t, Monad m) =>
-    Consumer m b a b -> m b -> t m a -> t m b
-consumeIterateM c i m = fromStreamD $ D.consumeIterateM c i (toStreamD m)
+{-# INLINE refoldIterateM #-}
+refoldIterateM :: (IsStream t, Monad m) =>
+    Refold m b a b -> m b -> t m a -> t m b
+refoldIterateM c i m = fromStreamD $ D.refoldIterateM c i (toStreamD m)
 
 ------------------------------------------------------------------------------
 -- Parsing

--- a/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
@@ -112,9 +112,9 @@ module Streamly.Internal.Data.Stream.StreamD.Nesting
     -- ** Folding
     -- | Apply folds on a stream.
     , foldMany
-    , consumeMany
+    , refoldMany
     , foldIterateM
-    , consumeIterateM
+    , refoldIterateM
 
     -- ** Parsing
     -- | Parsing is opposite to flattening. 'parseMany' is dual to concatMap or
@@ -159,7 +159,7 @@ import Fusion.Plugin.Types (Fuse(..))
 import GHC.Types (SPEC(..))
 
 import Streamly.Internal.Data.Array.Foreign.Type (Array(..))
-import Streamly.Internal.Data.Consumer.Type (Consumer(..))
+import Streamly.Internal.Data.Refold.Type (Refold(..))
 import Streamly.Internal.Data.Fold.Type (Fold(..))
 import Streamly.Internal.Data.Parser (ParseError(..))
 import Streamly.Internal.Data.SVar.Type (adaptState)
@@ -1032,14 +1032,14 @@ data CIterState s f fs b
     | CIterYield b (CIterState s f fs b)
     | CIterStop
 
--- | Like 'foldIterateM' but using the 'Consumer' type instead. This could be
+-- | Like 'foldIterateM' but using the 'Refold' type instead. This could be
 -- much more efficient due to stream fusion.
 --
 -- /Internal/
-{-# INLINE_NORMAL consumeIterateM #-}
-consumeIterateM ::
-       Monad m => Consumer m b a b -> m b -> Stream m a -> Stream m b
-consumeIterateM (Consumer fstep finject fextract) initial (Stream step state) =
+{-# INLINE_NORMAL refoldIterateM #-}
+refoldIterateM ::
+       Monad m => Refold m b a b -> m b -> Stream m a -> Stream m b
+refoldIterateM (Refold fstep finject fextract) initial (Stream step state) =
     Stream stepOuter (CIterInit state initial)
 
     where

--- a/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
@@ -84,7 +84,7 @@ module Streamly.Internal.Data.Stream.StreamD.Type
     , FoldManyPost (..)
     , foldMany
     , foldManyPost
-    , consumeMany
+    , refoldMany
     , chunksOf
     )
 where
@@ -100,7 +100,7 @@ import GHC.Types (SPEC(..))
 import Prelude hiding (map, mapM, foldr, take, concatMap, takeWhile)
 
 import Streamly.Internal.Data.Fold.Type (Fold(..))
-import Streamly.Internal.Data.Consumer.Type (Consumer(..))
+import Streamly.Internal.Data.Refold.Type (Refold(..))
 import Streamly.Internal.Data.Stream.StreamD.Step (Step (..))
 import Streamly.Internal.Data.SVar.Type (State, adaptState, defState)
 import Streamly.Internal.Data.Unfold.Type (Unfold(..))
@@ -949,12 +949,12 @@ chunksOf n f = foldMany (FL.take n f)
 
 -- Keep the argument order consistent with consumeIterateM
 --
--- | Like 'foldMany' but for the 'Consumer' type.
+-- | Like 'foldMany' but for the 'Refold' type.
 --
 -- /Internal/
-{-# INLINE_NORMAL consumeMany #-}
-consumeMany :: Monad m => Consumer m x a b -> m x -> Stream m a -> Stream m b
-consumeMany (Consumer fstep inject extract) action (Stream step state) =
+{-# INLINE_NORMAL refoldMany #-}
+refoldMany :: Monad m => Refold m x a b -> m x -> Stream m a -> Stream m b
+refoldMany (Refold fstep inject extract) action (Stream step state) =
     Stream step' (FoldManyStart state)
 
     where

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -386,7 +386,7 @@ library
                      , Streamly.Internal.Data.SVar
                      , Streamly.Internal.Data.Stream.StreamK.Type
                      , Streamly.Internal.Data.Fold.Step
-                     , Streamly.Internal.Data.Consumer.Type
+                     , Streamly.Internal.Data.Refold.Type
                      , Streamly.Internal.Data.Fold.Type
                      , Streamly.Internal.Data.Stream.StreamD.Step
                      , Streamly.Internal.Data.Stream.StreamD.Type


### PR DESCRIPTION
Consumer is a very generic name. One cannot intuitively distinguish
between Consumer and Fold. "Refold" gives a better idea that its a
slightly modified version of Fold with a starting value. Also, it fits
better as a dual to Unfold.