### PR TITLE
Ensure minimum chunk size of one element

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 * Fix a bug in classifySessionsBy, see PR #1311. The bug could cause
   premature ejection of a session when nput events with the same key are
   split into multiple sessions.
+* Fix array: unnecessary additional allocation due to a bug
 
 ## 0.8.0 (Jun 2021)
 

--- a/benchmark/bench-report/bin/build-lib.sh
+++ b/benchmark/bench-report/bin/build-lib.sh
@@ -120,7 +120,7 @@ set_targets() {
 # $4: command to find
 cabal_which_builddir() {
   local noopt=""
-  if test "$TEST_QUICK_MODE" -eq 1
+  if test "$TEST_QUICK_MODE" = "1"
   then
     noopt="/noopt"
   fi

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -86,7 +86,7 @@ TARGET_EXE_ARGS=$*
 
 set_derived_vars
 
-if test "$TEST_QUICK_MODE" -eq 1
+if test $TEST_QUICK_MODE -eq 1
 then
   CABAL_BUILD_OPTIONS+=" --disable-optimization --flags -opt"
 fi

--- a/src/Streamly/Internal/Data/Array/Stream/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Stream/Foreign.hs
@@ -75,8 +75,8 @@ import Streamly.Internal.Data.Stream.Serial (SerialT)
 import Streamly.Internal.Data.Stream.IsStream.Type
     (IsStream, fromStreamD, toStreamD)
 import Streamly.Internal.Data.SVar (adaptState, defState)
-import Streamly.Internal.Data.Array.Foreign.Mut.Type (memcpy, bytesToElemCount)
-import Streamly.Internal.System.IO (mkChunkSizeKB)
+import Streamly.Internal.Data.Array.Foreign.Mut.Type
+    (memcpy, allocBytesToElemCount)
 
 import qualified Streamly.Internal.Data.Array.Foreign as A
 import qualified Streamly.Internal.Data.Array.Foreign as Array
@@ -470,8 +470,8 @@ _spliceArraysBuffered s = do
 spliceArraysRealloced :: forall m a. (MonadIO m, Storable a)
     => SerialT m (Array a) -> m (Array a)
 spliceArraysRealloced s = do
-    let idst = liftIO $ MA.newArray (bytesToElemCount (undefined :: a)
-                                  (mkChunkSizeKB 4))
+    let n = allocBytesToElemCount (undefined :: a) (4 * 1024)
+        idst = liftIO $ MA.newArray n
 
     arr <- S.foldlM' MA.spliceExp idst (S.map A.unsafeThaw s)
     liftIO $ A.unsafeFreeze <$> MA.rightSize arr


### PR DESCRIPTION
Also fix a bug where we were using chunk size in bytes as element count.