### PR TITLE
Fix missing touch

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 * Fix a bug in classifySessionsBy, see PR #1311. The bug could cause
   premature ejection of a session when nput events with the same key are
   split into multiple sessions.
+* Fix array: missing pointer touch could potentially cause use of freed memory.
 * Fix array: unnecessary additional allocation due to a bug
 
 ## 0.8.0 (Jun 2021)

--- a/src/Streamly/Internal/Ring/Foreign.hs
+++ b/src/Streamly/Internal/Ring/Foreign.hs
@@ -127,7 +127,7 @@ unsafeEqArrayN :: Ring a -> Ptr a -> A.Array a -> Int -> Bool
 unsafeEqArrayN Ring{..} rh A.Array{..} n =
     let !res = unsafeInlineIO $ do
             let rs = unsafeForeignPtrToPtr ringStart
-                as = unsafeForeignPtrToPtr aStart
+                as = arrStart
             assert (aEnd `minusPtr` as >= ringBound `minusPtr` rs) (return ())
             let len = ringBound `minusPtr` rh
             r1 <- memcmp (castPtr rh) (castPtr as) (min len n)
@@ -153,7 +153,7 @@ unsafeEqArray :: Ring a -> Ptr a -> A.Array a -> Bool
 unsafeEqArray Ring{..} rh A.Array{..} =
     let !res = unsafeInlineIO $ do
             let rs = unsafeForeignPtrToPtr ringStart
-            let as = unsafeForeignPtrToPtr aStart
+            let as = arrStart
             assert (aEnd `minusPtr` as >= ringBound `minusPtr` rs)
                    (return ())
             let len = ringBound `minusPtr` rh

--- a/src/Streamly/Internal/System/IOVec.hs
+++ b/src/Streamly/Internal/System/IOVec.hs
@@ -26,7 +26,6 @@ where
 #if !defined(mingw32_HOST_OS)
 import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO(..))
-import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import Foreign.Ptr (castPtr)
 import Streamly.Internal.Data.Array.Foreign.Mut.Type (length)
 import Streamly.Internal.Data.SVar (adaptState)
@@ -74,7 +73,7 @@ groupIOVecsOfMut n maxIOVLen (D.Stream step state) =
         r <- step (adaptState gst) st
         case r of
             D.Yield arr s -> do
-                let p = unsafeForeignPtrToPtr (aStart arr)
+                let p = arrStart arr
                     len = MArray.byteLength arr
                 iov <- liftIO $ MArray.newArray maxIOVLen
                 iov' <- liftIO $ MArray.snocUnsafe iov (IOVec (castPtr p)
@@ -89,7 +88,7 @@ groupIOVecsOfMut n maxIOVLen (D.Stream step state) =
         r <- step (adaptState gst) st
         case r of
             D.Yield arr s -> do
-                let p = unsafeForeignPtrToPtr (aStart arr)
+                let p = arrStart arr
                     alen = MArray.byteLength arr
                     len' = len + alen
                 if len' > n || length iov >= maxIOVLen


### PR DESCRIPTION
Adding a touchForeignPtr led to significant regressions. Fixing that required a bigger change to use a simpler type in the array instead of using ForeignPtr.