### PR TITLE
Use byteLength instead of length in putChunk

### DIFF
--- a/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
@@ -206,6 +206,9 @@ where
 
 import Control.Exception (assert)
 import Control.DeepSeq (NFData(..))
+#if MIN_VERSION_deepseq(1,4,3)
+import Control.DeepSeq (NFData1(..))
+#endif
 import Control.Monad (when, void)
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Bits (shiftR, (.|.), (.&.))
@@ -2286,3 +2289,9 @@ cmp arr1 arr2 =
 instance NFData (Array a) where
     {-# INLINE rnf #-}
     rnf Array {} = ()
+
+#if MIN_VERSION_deepseq(1,4,3)
+instance NFData1 Array where
+    {-# INLINE liftRnf #-}
+    liftRnf _ Array{} = ()
+#endif

--- a/src/Streamly/Internal/Data/Array/Foreign/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Type.hs
@@ -78,6 +78,9 @@ where
 
 import Control.Exception (assert)
 import Control.DeepSeq (NFData(..))
+#if MIN_VERSION_deepseq(1,4,3)
+import Control.DeepSeq (NFData1(..))
+#endif
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Functor.Identity (Identity(..))
 import Data.Word (Word8)
@@ -737,6 +740,11 @@ instance (Storable a, Eq a) => Eq (Array a) where
 instance NFData (Array a) where
     {-# INLINE rnf #-}
     rnf Array {} = ()
+
+#if MIN_VERSION_deepseq(1,4,3)
+instance NFData1 Array where
+    liftRnf _ Array{} = ()
+#endif
 
 instance (Storable a, Ord a) => Ord (Array a) where
     {-# INLINE compare #-}

--- a/src/Streamly/Internal/FileSystem/File.hs
+++ b/src/Streamly/Internal/FileSystem/File.hs
@@ -88,7 +88,6 @@ where
 import Control.Monad.Catch (MonadCatch)
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Word (Word8)
-import Foreign.Storable (Storable(..))
 import System.IO (Handle, openFile, IOMode(..), hClose)
 import Prelude hiding (read)
 
@@ -198,14 +197,14 @@ usingFile3 = UF.bracket before after
 --
 -- @since 0.7.0
 {-# INLINABLE putChunk #-}
-putChunk :: Storable a => FilePath -> Array a -> IO ()
+putChunk :: FilePath -> Array a -> IO ()
 putChunk file arr = SIO.withFile file WriteMode (`FH.putChunk` arr)
 
 -- | append an array to a file.
 --
 -- @since 0.7.0
 {-# INLINABLE appendArray #-}
-appendArray :: Storable a => FilePath -> Array a -> IO ()
+appendArray :: FilePath -> Array a -> IO ()
 appendArray file arr = SIO.withFile file AppendMode (`FH.putChunk` arr)
 
 -------------------------------------------------------------------------------
@@ -322,7 +321,7 @@ readShared = undefined
 -------------------------------------------------------------------------------
 
 {-# INLINE fromChunksMode #-}
-fromChunksMode :: (MonadAsync m, MonadCatch m, Storable a)
+fromChunksMode :: (MonadAsync m, MonadCatch m)
     => IOMode -> FilePath -> SerialT m (Array a) -> m ()
 fromChunksMode mode file xs = S.drain $
     withFile file mode (\h -> S.mapM (FH.putChunk h) xs)
@@ -331,7 +330,7 @@ fromChunksMode mode file xs = S.drain $
 --
 -- @since 0.7.0
 {-# INLINE fromChunks #-}
-fromChunks :: (MonadAsync m, MonadCatch m, Storable a)
+fromChunks :: (MonadAsync m, MonadCatch m)
     => FilePath -> SerialT m (Array a) -> m ()
 fromChunks = fromChunksMode WriteMode
 
@@ -376,7 +375,7 @@ write = toHandleWith A.defaultChunkSize
 --
 -- /Pre-release/
 {-# INLINE writeChunks #-}
-writeChunks :: (MonadIO m, MonadCatch m, Storable a)
+writeChunks :: (MonadIO m, MonadCatch m)
     => FilePath -> Fold m (Array a) ()
 writeChunks path = Fold step initial extract
     where
@@ -422,7 +421,7 @@ write = writeWithBufferOf defaultChunkSize
 --
 -- @since 0.7.0
 {-# INLINE appendChunks #-}
-appendChunks :: (MonadAsync m, MonadCatch m, Storable a)
+appendChunks :: (MonadAsync m, MonadCatch m)
     => FilePath -> SerialT m (Array a) -> m ()
 appendChunks = fromChunksMode AppendMode
 

--- a/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/src/Streamly/Internal/FileSystem/Handle.hs
@@ -396,8 +396,8 @@ toBytes = AS.concat . toChunks
 --
 -- @since 0.8.1
 {-# INLINABLE putChunk #-}
-putChunk :: (MonadIO m, Storable a) => Handle -> Array a -> m ()
-putChunk _ arr | A.length arr == 0 = return ()
+putChunk :: MonadIO m => Handle -> Array a -> m ()
+putChunk _ arr | byteLength arr == 0 = return ()
 putChunk h Array{..} =
     liftIO $ hPutBuf h arrStart aLen >> touch arrContents
 
@@ -420,8 +420,7 @@ putChunk h Array{..} =
 --
 -- @since 0.7.0
 {-# INLINE putChunks #-}
-putChunks :: (MonadIO m, Storable a)
-    => Handle -> SerialT m (Array a) -> m ()
+putChunks :: MonadIO m => Handle -> SerialT m (Array a) -> m ()
 putChunks h = S.mapM_ (putChunk h)
 
 -- XXX AS.compact can be written idiomatically in terms of foldMany, just like
@@ -471,14 +470,14 @@ putBytes = putBytesWithBufferOf defaultChunkSize
 --
 -- @since 0.7.0
 {-# INLINE writeChunks #-}
-writeChunks :: (MonadIO m, Storable a) => Handle -> Fold m (Array a) ()
+writeChunks :: MonadIO m => Handle -> Fold m (Array a) ()
 writeChunks h = FL.drainBy (putChunk h)
 
 -- | Like writeChunks but uses the experimental 'Refold' API.
 --
 -- /Internal/
 {-# INLINE consumeChunks #-}
-consumeChunks :: (MonadIO m, Storable a) => Refold m Handle (Array a) ()
+consumeChunks :: MonadIO m => Refold m Handle (Array a) ()
 consumeChunks = Refold.drainBy putChunk
 
 -- XXX lpackArraysChunksOf should be written idiomatically


### PR DESCRIPTION
This remove `Storable` constraint from exposed APIs so targeted to 0.9.0.