### PR TITLE
Breaking changes and other changes for next major release

### DIFF
--- a/src/Streamly/Internal/Data/Stream/IsStream/Expand.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Expand.hs
@@ -709,8 +709,7 @@ zipAsyncWith f = zipAsyncWithM (\a b -> return (f a b))
 --
 -- @since 0.6.0
 {-# INLINE mergeBy #-}
-mergeBy ::
-       (IsStream t, Monad m) => (a -> a -> Ordering) -> t m a -> t m a -> t m a
+mergeBy :: IsStream t => (a -> a -> Ordering) -> t m a -> t m a -> t m a
 mergeBy f m1 m2 = fromStream $ K.mergeBy f (toStream m1) (toStream m2)
 
 -- | Like 'mergeBy' but with a monadic comparison function.

--- a/src/Streamly/Internal/Data/Stream/IsStream/Expand.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Expand.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-
 -- |
 -- Module      : Streamly.Internal.Data.Stream.IsStream.Expand
 -- Copyright   : (c) 2017 Composewell Technologies

--- a/src/Streamly/Internal/Data/Stream/IsStream/Generate.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Generate.hs
@@ -223,7 +223,7 @@ unfoldr step seed = fromStreamS (S.unfoldr step seed)
 --
 -- /Since: 0.1.0/
 {-# INLINE_EARLY unfoldrM #-}
-unfoldrM :: forall t m b a. (IsStream t, MonadAsync m) =>
+unfoldrM :: forall t m a b. (IsStream t, MonadAsync m) =>
     (b -> m (Maybe (a, b))) -> b -> t m a
 unfoldrM step = fromStream . K.unfoldrMWith (IsStream.toConsK (consM @t)) step
 


### PR DESCRIPTION
The `next-major` branch accumulates the changes for the next major release. The `master` branch is used for the minor release. Any breaking changes or changes targeted to 0.9.0 are to be pushed on this branch and we keep rebasing this periodically on master.