### PR TITLE
Fix and test for concurrent applicative

### DIFF
--- a/benchmark/Streamly/Benchmark/Prelude/ZipAsync.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/ZipAsync.hs
@@ -41,6 +41,12 @@ zipAsyncAp count n =
     S.fromZipAsync $
         (,) <$> sourceUnfoldrM count n <*> sourceUnfoldrM count (n + 1)
 
+fromZipAsyncTraverse :: String -> Int -> Benchmark
+fromZipAsyncTraverse name count =
+    bench name
+        $ nfIO
+        $ S.drain $ S.fromZipAsync $ traverse S.fromPure [0 :: Int .. count]
+
 o_1_space_joining :: Int -> [Benchmark]
 o_1_space_joining value =
     [ bgroup "joining"
@@ -50,6 +56,7 @@ o_1_space_joining value =
                                                        (value `div` 2))
         , benchIOSrc fromSerial "zipAsyncAp (2,x/2)" (zipAsyncAp (value `div` 2))
         , benchIOSink value "fmap zipAsyncly" $ fmapN S.fromZipAsync 1
+        , fromZipAsyncTraverse "ZipAsync Applicative (x/100)" (value `div` 100)
         ]
     ]
 

--- a/docs/ConcurrentStreams.hs
+++ b/docs/ConcurrentStreams.hs
@@ -723,19 +723,20 @@ import Control.Monad.Trans.Class   (MonadTrans (lift))
 -- 'fromZipAsync' type combinator can be used to switch to parallel applicative
 -- zip composition:
 --
--- This takes 7 seconds to zip, which is max (1,3) + max (2,4) because 1 and 3
--- are produced concurrently, and 2 and 4 are produced concurrently:
---
 -- >>> d n = delay n >> return n
--- >>> s1 = Stream.fromSerial $ d 1 <> d 2
--- >>> s2 = Stream.fromSerial $ d 3 <> d 4
+-- >>> s1 = Stream.fromSerial $ d 2 <> d 4
+-- >>> s2 = Stream.fromSerial $ d 3 <> d 1
 -- >>> (Stream.toList $ Stream.fromZipAsync $ (,) <$> s1 <*> s2) >>= print
--- ThreadId ...: Delay 1
 -- ThreadId ...: Delay 2
 -- ThreadId ...: Delay 3
+-- ThreadId ...: Delay 1
 -- ThreadId ...: Delay 4
--- [(1,3),(2,4)]
+-- [(2,3),(4,1)]
 --
+-- The actions within each stream are executed serially, however, the two
+-- streams are run concurrently with respect to each other. Therefore, it takes
+-- 6 seconds to zip the two streams, which is the maximum of the time to
+-- evaluate stream s1 (2 + 4 = 6 seconds) and stream s2 (3 + 1 = 4 seconds).
 
 -- $concurrent
 --


### PR DESCRIPTION
This is a breaking change as it modifies the behavior of `<*>` in `ZipAsyncM`