### PR TITLE
Remove MonadIO constraint

### DIFF
--- a/src/Streamly/Internal/Data/Array/Foreign/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Type.hs
@@ -120,6 +120,9 @@ import qualified Data.Foldable as F
 -- >>> import Prelude hiding (length, foldr, read, unlines, splitAt)
 -- >>> import Streamly.Internal.Data.Array.Foreign as Array
 
+-- XXX Since these are immutable arrays MonadIO constraint can be removed from
+-- most places.
+
 -------------------------------------------------------------------------------
 -- Array Data Type
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Is this a breaking change? We have relaxed the constraint so it should admit everything as before. It may result in a warning about redundant constraints though.