### PR TITLE
Bump the upper bound of unicode-data

### DIFF
--- a/benchmark/streamly-benchmarks.cabal
+++ b/benchmark/streamly-benchmarks.cabal
@@ -114,7 +114,7 @@ common bench-depends
     -- Core libraries shipped with ghc, the min and max
     -- constraints of these libraries should match with
     -- the GHC versions we support
-      base                >= 4.9   && < 5
+      base                >= 4.9   && < 4.17
     , deepseq             >= 1.4.1 && < 1.5
     , mtl                 >= 2.2   && < 2.3
 

--- a/docs/streamly-docs.cabal
+++ b/docs/streamly-docs.cabal
@@ -28,6 +28,6 @@ library
     ReactiveProgramming
 
   build-depends:
-      base              >= 4.9   &&  < 5
+      base              >= 4.9   &&  < 4.17
     , transformers      >= 0.4   && < 0.6
     , streamly

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -528,7 +528,7 @@ library
                     -- packages depending on the "ghc" package (packages
                     -- depending on doctest is a common example) can
                     -- depend on streamly.
-                       base              >= 4.9   &&  < 5
+                       base              >= 4.9   && < 4.17
                      , containers        >= 0.5   && < 0.7
                      , deepseq           >= 1.4.1 && < 1.5
                      , directory         >= 1.2.2 && < 1.4

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -539,7 +539,7 @@ library
                      , transformers      >= 0.4   && < 0.7
 
                      , heaps             >= 0.3     && < 0.5
-                     , filepath          >= 1.2.0.0 && < 1.4.3.0
+                     , filepath          >= 1.2.0.0 && < 1.5
 
                     -- concurrency
                      , atomic-primops    >= 0.8   && < 0.9

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -550,7 +550,7 @@ library
                      , transformers-base >= 0.4   && < 0.5
 
                      , fusion-plugin-types >= 0.1 && < 0.2
-                     , unicode-data      >= 0.1   && < 0.3
+                     , unicode-data      >= 0.1   && < 0.4
 
                     -- Network
                      , network           >= 2.6   && < 3.2

--- a/test/streamly-tests.cabal
+++ b/test/streamly-tests.cabal
@@ -139,7 +139,7 @@ common optimization-options
 common test-dependencies
   build-depends:
       streamly
-    , base              >= 4.9   && < 5
+    , base              >= 4.9   && < 4.17
     , containers        >= 0.5   && < 0.7
     , exceptions        >= 0.8   && < 0.11
     , ghc


### PR DESCRIPTION
- Used in normalization combinators
- Essentially the normalization helpers did not change over the versions
- Admit 0.3.*