### PR TITLE
Replace Ring with the experimental implmenetation

### DIFF
--- a/src/Streamly/Internal/Data/Array/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign.hs
@@ -122,7 +122,6 @@ import Data.Functor.Identity (Identity)
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup ((<>))
 #endif
-import Data.Primitive.Types (Prim(..))
 import Data.Word (Word8)
 import Foreign.C.String (CString)
 import Foreign.Ptr (plusPtr, castPtr)
@@ -297,7 +296,7 @@ last arr = getIndexRev arr 0
 --
 -- @since 0.8.0
 {-# INLINE writeLastN #-}
-writeLastN :: (Prim a, Storable a, MonadIO m) => Int -> Fold m a (Array a)
+writeLastN :: (Storable a, MonadIO m) => Int -> Fold m a (Array a)
 writeLastN n
     | n <= 0 = fmap (const mempty) FL.drain
     | otherwise = A.unsafeFreeze <$> Fold step initial done

--- a/src/Streamly/Internal/Data/Stream/IsStream/Common.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Common.hs
@@ -66,6 +66,7 @@ where
 
 import Control.Concurrent (threadDelay)
 import Control.Monad.IO.Class (MonadIO(..))
+import Data.Primitive.Types (Prim(..))
 import Foreign.Storable (Storable)
 import Streamly.Internal.Control.Concurrent (MonadAsync)
 import Streamly.Internal.Data.Array.Foreign.Type (Array)
@@ -668,7 +669,7 @@ concatM generator = concatMapM (\() -> generator) (fromPure ())
 -- that we can search files in files for example.
 {-# INLINE splitOnSeq #-}
 splitOnSeq
-    :: (IsStream t, MonadIO m, Storable a, Enum a, Eq a)
+    :: (IsStream t, MonadIO m, Prim a, Storable a, Enum a, Eq a)
     => Array a -> Fold m a b -> t m a -> t m b
 splitOnSeq patt f m =
     IsStream.fromStreamD $ D.splitOnSeq patt f (IsStream.toStreamD m)

--- a/src/Streamly/Internal/Data/Stream/IsStream/Eliminate.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Eliminate.hs
@@ -157,6 +157,7 @@ where
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class (MonadTrans(..))
+import Data.Primitive.Types (Prim(..))
 import Foreign.Storable (Storable)
 import Streamly.Internal.Control.Concurrent (MonadAsync)
 import Streamly.Internal.Data.Parser (Parser (..))
@@ -933,7 +934,7 @@ isPrefixOf m1 m2 = D.isPrefixOf (toStreamD m1) (toStreamD m2)
 -- /Requires 'Storable' constraint/
 --
 {-# INLINE isInfixOf #-}
-isInfixOf :: (MonadIO m, Eq a, Enum a, Storable a)
+isInfixOf :: (MonadIO m, Eq a, Enum a, Prim a, Storable a)
     => SerialT m a -> SerialT m a -> m Bool
 isInfixOf infx stream = do
     arr <- fold A.write infx

--- a/src/Streamly/Internal/Data/Stream/IsStream/Reduce.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Reduce.hs
@@ -153,6 +153,7 @@ import Control.Monad.IO.Class (MonadIO(..))
 import Data.Heap (Entry(..))
 import Data.Kind (Type)
 import Data.Maybe (isNothing)
+import Data.Primitive.Types (Prim(..))
 import Foreign.Storable (Storable)
 import Streamly.Internal.Control.Concurrent (MonadAsync)
 import Streamly.Internal.Data.Fold.Type (Fold (..))
@@ -875,7 +876,7 @@ splitOnAny subseq f m = undefined
 -- /Pre-release/
 {-# INLINE splitBySeq #-}
 splitBySeq
-    :: (IsStream t, MonadAsync m, Storable a, Enum a, Eq a)
+    :: (IsStream t, MonadAsync m, Prim a, Storable a, Enum a, Eq a)
     => Array a -> Fold m a b -> t m a -> t m b
 splitBySeq patt f m =
     intersperseM (fold f (A.toStream patt)) $ splitOnSeq patt f m


### PR DESCRIPTION
```
Generating reports for Prelude.Serial...
Prelude.Serial(cpuTime)
Benchmark                                                                             default(0)(ms) default(1) - default(0)(%)
------------------------------------------------------------------------------------- -------------- --------------------------
All.Prelude.Serial/o-1-space.split.S.splitOnSeq 100k long pattern                             263.06                     +17.60
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "catcatcatcatcat" FL.drain                    257.32                     +14.48
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "abcdefghi" FL.drain                          259.26                     +13.36
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "abcdefgh" FL.drain                           139.17                     +13.13
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "abcdefghijklmnopqrstuvwxyz" FL.drain         258.78                     +13.02
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "\r\n" FL.drain                               109.71                      +6.98
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "\n" FL.drain                                 140.03                      +2.54
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "" FL.drain                                    47.94                      -2.45
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "aaaa" FL.drain                               140.05                      -4.54
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "a" FL.drain                                  124.01                     -12.03
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "aa" FL.drain                                 137.54                     -27.76
```