### PR TITLE
Fix performance regressions in GHC-9

### DIFF
--- a/benchmark/Streamly/Benchmark/Data/Parser/ParserD.hs
+++ b/benchmark/Streamly/Benchmark/Data/Parser/ParserD.hs
@@ -94,6 +94,10 @@ takeWhile value = IP.parseD (drainWhile (<= value))
 takeP :: MonadThrow m => Int -> SerialT m a -> m ()
 takeP value = IP.parseD (PR.takeP value (PR.fromFold FL.drain))
 
+{-# INLINE takeBetween #-}
+takeBetween :: MonadCatch m => Int -> SerialT m a -> m ()
+takeBetween value =  IP.parseD (PR.takeBetween 0 value FL.drain)
+
 {-# INLINE groupBy #-}
 groupBy :: MonadThrow m => SerialT m Int -> m ()
 groupBy = IP.parseD (PR.groupBy (<=) FL.drain)
@@ -318,6 +322,7 @@ o_1_space_serial :: Int -> [Benchmark]
 o_1_space_serial value =
     [ benchIOSink value "takeWhile" $ takeWhile value
     , benchIOSink value "takeP" $ takeP value
+    , benchIOSink value "takeBetween" $ takeBetween value
     , benchIOSink value "sliceBeginWith" $ sliceBeginWith value
     , benchIOSink value "groupBy" $ groupBy
     , benchIOSink value "groupByRolling" $ groupByRolling

--- a/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
+++ b/benchmark/Streamly/Benchmark/FileSystem/Handle/ReadWrite.hs
@@ -159,7 +159,6 @@ o_1_space_copy_fromBytes env =
     ]
 
 -- | Send the file contents ('defaultChunkSize') to /dev/null
-{-# NOINLINE writeReadWithBufferOf #-}
 writeReadWithBufferOf :: Handle -> Handle -> IO ()
 writeReadWithBufferOf inh devNull = IUF.fold fld unf (defaultChunkSize, inh)
 
@@ -177,7 +176,6 @@ inspect $ 'writeReadWithBufferOf `hasNoType` ''AT.ArrayUnsafe -- FH.write/writeN
 #endif
 
 -- | Send the file contents ('AT.defaultChunkSize') to /dev/null
-{-# NOINLINE writeRead #-}
 writeRead :: Handle -> Handle -> IO ()
 writeRead inh devNull = IUF.fold fld unf inh
 

--- a/src/Streamly/Internal/Data/Array/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign.hs
@@ -136,7 +136,7 @@ import Streamly.Internal.Data.Array.Foreign.Type (Array(..), length)
 import Streamly.Internal.Data.Fold.Type (Fold(..))
 import Streamly.Internal.Data.Producer.Type (Producer(..))
 import Streamly.Internal.Data.Stream.Serial (SerialT(..))
-import Streamly.Internal.Data.Tuple.Strict (Tuple3'(..))
+import Streamly.Internal.Data.Tuple.Strict (Tuple3Fused'(..))
 import Streamly.Internal.Data.Unfold.Type (Unfold(..))
 import Streamly.Internal.System.IO (unsafeInlineIO)
 
@@ -302,15 +302,15 @@ writeLastN n
 
     where
 
-    step (Tuple3' rb rh i) a = do
+    step (Tuple3Fused' rb rh i) a = do
         rh1 <- liftIO $ RB.unsafeInsert rb rh a
-        return $ FL.Partial $ Tuple3' rb rh1 (i + 1)
+        return $ FL.Partial $ Tuple3Fused' rb rh1 (i + 1)
 
     initial =
-        let f (a, b) = FL.Partial $ Tuple3' a b (0 :: Int)
+        let f (a, b) = FL.Partial $ Tuple3Fused' a b (0 :: Int)
          in fmap f $ liftIO $ RB.new n
 
-    done (Tuple3' rb rh i) = do
+    done (Tuple3Fused' rb rh i) = do
         arr <- liftIO $ MA.newArray n
         foldFunc i rh snoc' arr rb
 

--- a/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
@@ -2042,7 +2042,7 @@ fromStreamD m = arrayStreamKFromStreamD m >>= fromArrayStreamK
 -- | Create an 'Array' from a list. The list must be of finite size.
 --
 -- @since 0.7.0
-{-# INLINABLE fromList #-}
+{-# INLINE fromList #-}
 fromList :: (MonadIO m, Storable a) => [a] -> m (Array a)
 fromList xs = fromStreamD $ D.fromList xs
 

--- a/src/Streamly/Internal/Data/Array/Foreign/Type.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign/Type.hs
@@ -357,7 +357,7 @@ fromListRevN _n _xs = undefined
 -- /Since 0.7.0 (Streamly.Memory.Array)/
 --
 -- @since 0.8.0
-{-# INLINABLE fromList #-}
+{-# INLINE fromList #-}
 fromList :: Storable a => [a] -> Array a
 fromList xs = unsafePerformIO $ unsafeFreeze <$> MA.fromList xs
 

--- a/src/Streamly/Internal/Data/Array/Stream/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Stream/Foreign.hs
@@ -545,7 +545,6 @@ parseD (PRD.Parser pstep initial extract) stream@(D.Stream step state) = do
     -- XXX currently we are using a dumb list based approach for backtracking
     -- buffer. This can be replaced by a sliding/ring buffer using Data.Array.
     -- That will allow us more efficient random back and forth movement.
-    {-# INLINE go #-}
     go !_ st backBuf !pst = do
         r <- step defState st
         case r of
@@ -558,6 +557,7 @@ parseD (PRD.Parser pstep initial extract) stream@(D.Stream step state) = do
                 return (b, D.nil)
 
     -- Use strictness on "cur" to keep it unboxed
+    {-# INLINE gobuf #-}
     gobuf !_ s backBuf fp@(ForeignPtr end _) !cur !pst
         | cur == Ptr end = do
             liftIO $ touchForeignPtr fp
@@ -642,7 +642,6 @@ parseArrD (PRD.Parser pstep initial extract) stream@(D.Stream step state) = do
     -- XXX currently we are using a dumb list based approach for backtracking
     -- buffer. This can be replaced by a sliding/ring buffer using Data.Array.
     -- That will allow us more efficient random back and forth movement.
-    {-# INLINE go #-}
     go !_ st backBuf !pst = do
         r <- step defState st
         case r of
@@ -652,6 +651,7 @@ parseArrD (PRD.Parser pstep initial extract) stream@(D.Stream step state) = do
                 b <- extract pst
                 return (b, D.nil)
 
+    {-# INLINE gobuf #-}
     gobuf !_ [] s backBuf !pst = go SPEC s backBuf pst
     gobuf !_ (x:xs) s backBuf !pst = do
         pRes <- pstep pst x

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -809,7 +809,7 @@ toListRev = foldl' (flip (:)) []
 -- > drainN n = Fold.take n Fold.drain
 --
 -- /Pre-release/
-{-# INLINABLE drainN #-}
+{-# INLINE drainN #-}
 drainN :: Monad m => Int -> Fold m a ()
 drainN n = take n drain
 

--- a/src/Streamly/Internal/Data/Fold.hs
+++ b/src/Streamly/Internal/Data/Fold.hs
@@ -478,7 +478,7 @@ postscan (Fold stepL initialL extractL) (Fold stepR initialR extractR) =
 -- See also: 'Streamly.Prelude.mapM_'
 --
 -- @since 0.7.0
-{-# INLINABLE drainBy #-}
+{-# INLINE drainBy #-}
 drainBy ::  Monad m => (a -> m b) -> Fold m a ()
 drainBy f = lmapM f drain
 
@@ -487,7 +487,7 @@ drainBy f = lmapM f drain
 -- > last = fmap getLast $ Fold.foldMap (Last . Just)
 --
 -- @since 0.7.0
-{-# INLINABLE last #-}
+{-# INLINE last #-}
 last :: Monad m => Fold m a (Maybe a)
 last = foldl1' (\_ x -> x)
 
@@ -612,7 +612,7 @@ minimum = foldl1' min
 -- stream.
 --
 -- @since 0.7.0
-{-# INLINABLE mean #-}
+{-# INLINE mean #-}
 mean :: (Monad m, Fractional a) => Fold m a a
 mean = fmap done $ foldl' step begin
 
@@ -630,7 +630,7 @@ mean = fmap done $ foldl' step begin
 -- the input stream.
 --
 -- @since 0.7.0
-{-# INLINABLE variance #-}
+{-# INLINE variance #-}
 variance :: (Monad m, Fractional a) => Fold m a a
 variance = fmap done $ foldl' step begin
 
@@ -653,7 +653,7 @@ variance = fmap done $ foldl' step begin
 -- elements in the input stream.
 --
 -- @since 0.7.0
-{-# INLINABLE stdDev #-}
+{-# INLINE stdDev #-}
 stdDev :: (Monad m, Floating a) => Fold m a a
 stdDev = sqrt <$> variance
 
@@ -669,7 +669,7 @@ stdDev = sqrt <$> variance
 -- See https://en.wikipedia.org/wiki/Rolling_hash
 --
 -- @since 0.8.0
-{-# INLINABLE rollingHashWithSalt #-}
+{-# INLINE rollingHashWithSalt #-}
 rollingHashWithSalt :: (Monad m, Enum a) => Int64 -> Fold m a Int64
 rollingHashWithSalt = foldl' step
 
@@ -689,7 +689,7 @@ defaultSalt = -2578643520546668380
 -- > rollingHash = Fold.rollingHashWithSalt defaultSalt
 --
 -- @since 0.8.0
-{-# INLINABLE rollingHash #-}
+{-# INLINE rollingHash #-}
 rollingHash :: (Monad m, Enum a) => Fold m a Int64
 rollingHash = rollingHashWithSalt defaultSalt
 
@@ -699,7 +699,7 @@ rollingHash = rollingHashWithSalt defaultSalt
 -- > rollingHashFirstN = Fold.take n Fold.rollingHash
 --
 -- /Pre-release/
-{-# INLINABLE rollingHashFirstN #-}
+{-# INLINE rollingHashFirstN #-}
 rollingHashFirstN :: (Monad m, Enum a) => Int -> Fold m a Int64
 rollingHashFirstN n = take n rollingHash
 
@@ -749,7 +749,7 @@ mconcat = sconcat mempty
 -- Sum {getSum = 55}
 --
 -- @since 0.7.0
-{-# INLINABLE foldMap #-}
+{-# INLINE foldMap #-}
 foldMap :: (Monad m, Monoid b
 #if !MIN_VERSION_base(4,11,0)
     , Semigroup b
@@ -767,7 +767,7 @@ foldMap f = lmap f mconcat
 -- Sum {getSum = 55}
 --
 -- @since 0.7.0
-{-# INLINABLE foldMapM #-}
+{-# INLINE foldMapM #-}
 foldMapM ::  (Monad m, Monoid b) => (a -> m b) -> Fold m a b
 foldMapM act = foldlM' step (pure mempty)
 
@@ -795,7 +795,7 @@ foldMapM act = foldlM' step (pure mempty)
 -- @since 0.8.0
 
 --  xn : ... : x2 : x1 : []
-{-# INLINABLE toListRev #-}
+{-# INLINE toListRev #-}
 toListRev :: Monad m => Fold m a [a]
 toListRev = foldl' (flip (:)) []
 
@@ -820,7 +820,7 @@ drainN n = take n drain
 -- | Like 'index', except with a more general 'Integral' argument
 --
 -- /Pre-release/
-{-# INLINABLE genericIndex #-}
+{-# INLINE genericIndex #-}
 genericIndex :: (Integral i, Monad m) => i -> Fold m a (Maybe a)
 genericIndex i = mkFold step (Partial 0) (const Nothing)
 
@@ -836,21 +836,21 @@ genericIndex i = mkFold step (Partial 0) (const Nothing)
 -- See also: 'Streamly.Prelude.!!'
 --
 -- @since 0.7.0
-{-# INLINABLE index #-}
+{-# INLINE index #-}
 index :: Monad m => Int -> Fold m a (Maybe a)
 index = genericIndex
 
 -- | Extract the first element of the stream, if any.
 --
 -- @since 0.7.0
-{-# INLINABLE head #-}
+{-# INLINE head #-}
 head :: Monad m => Fold m a (Maybe a)
 head = mkFold_ (const (Done . Just)) (Partial Nothing)
 
 -- | Returns the first element that satisfies the given predicate.
 --
 -- @since 0.7.0
-{-# INLINABLE find #-}
+{-# INLINE find #-}
 find :: Monad m => (a -> Bool) -> Fold m a (Maybe a)
 find predicate = mkFold step (Partial ()) (const Nothing)
 
@@ -867,7 +867,7 @@ find predicate = mkFold step (Partial ()) (const Nothing)
 -- > lookup = snd <$> Fold.find ((==) . fst)
 --
 -- @since 0.7.0
-{-# INLINABLE lookup #-}
+{-# INLINE lookup #-}
 lookup :: (Eq a, Monad m) => a -> Fold m (a,b) (Maybe b)
 lookup a0 = mkFold step (Partial ()) (const Nothing)
 
@@ -881,7 +881,7 @@ lookup a0 = mkFold step (Partial ()) (const Nothing)
 -- | Returns the first index that satisfies the given predicate.
 --
 -- @since 0.7.0
-{-# INLINABLE findIndex #-}
+{-# INLINE findIndex #-}
 findIndex :: Monad m => (a -> Bool) -> Fold m a (Maybe Int)
 findIndex predicate = mkFold step (Partial 0) (const Nothing)
 
@@ -897,7 +897,7 @@ findIndex predicate = mkFold step (Partial 0) (const Nothing)
 -- > elemIndex a = Fold.findIndex (== a)
 --
 -- @since 0.7.0
-{-# INLINABLE elemIndex #-}
+{-# INLINE elemIndex #-}
 elemIndex :: (Eq a, Monad m) => a -> Fold m a (Maybe Int)
 elemIndex a = findIndex (a ==)
 
@@ -910,7 +910,7 @@ elemIndex a = findIndex (a ==)
 -- > null = fmap isJust Fold.head
 --
 -- @since 0.7.0
-{-# INLINABLE null #-}
+{-# INLINE null #-}
 null :: Monad m => Fold m a Bool
 null = mkFold (\() _ -> Done False) (Partial ()) (const True)
 
@@ -940,7 +940,7 @@ any predicate = mkFold_ step initial
 -- > elem a = Fold.any (== a)
 --
 -- @since 0.7.0
-{-# INLINABLE elem #-}
+{-# INLINE elem #-}
 elem :: (Eq a, Monad m) => a -> Fold m a Bool
 elem a = any (a ==)
 
@@ -952,7 +952,7 @@ elem a = any (a ==)
 -- > all p = Fold.lmap p Fold.and
 --
 -- @since 0.7.0
-{-# INLINABLE all #-}
+{-# INLINE all #-}
 all :: Monad m => (a -> Bool) -> Fold m a Bool
 all predicate = mkFold_ step initial
 
@@ -970,7 +970,7 @@ all predicate = mkFold_ step initial
 -- > notElem a = Fold.all (/= a)
 --
 -- @since 0.7.0
-{-# INLINABLE notElem #-}
+{-# INLINE notElem #-}
 notElem :: (Eq a, Monad m) => a -> Fold m a Bool
 notElem a = all (a /=)
 
@@ -1782,6 +1782,6 @@ toStream = fmap SerialT toStreamK
 -- /Pre-release/
 
 --  xn : ... : x2 : x1 : []
-{-# INLINABLE toStreamRev #-}
+{-# INLINE toStreamRev #-}
 toStreamRev :: Monad m => Fold m a (SerialT n a)
 toStreamRev = fmap SerialT toStreamKRev

--- a/src/Streamly/Internal/Data/Fold/Type.hs
+++ b/src/Streamly/Internal/Data/Fold/Type.hs
@@ -528,7 +528,7 @@ fromRefold (Refold step inject extract) c =
 -- > drain = drainBy (const (return ()))
 --
 -- @since 0.7.0
-{-# INLINABLE drain #-}
+{-# INLINE drain #-}
 drain :: Monad m => Fold m a ()
 drain = foldl' (\_ _ -> ()) ()
 

--- a/src/Streamly/Internal/Data/Fold/Type.hs
+++ b/src/Streamly/Internal/Data/Fold/Type.hs
@@ -541,7 +541,7 @@ drain = foldl' (\_ _ -> ()) ()
 -- > toList = foldr (:) []
 --
 -- @since 0.7.0
-{-# INLINABLE toList #-}
+{-# INLINE toList #-}
 toList :: Monad m => Fold m a [a]
 toList = foldr (:) []
 
@@ -556,7 +556,7 @@ toList = foldr (:) []
 -- /Pre-release/
 
 --  xn : ... : x2 : x1 : []
-{-# INLINABLE toStreamKRev #-}
+{-# INLINE toStreamKRev #-}
 toStreamKRev :: Monad m => Fold m a (K.Stream n a)
 toStreamKRev = foldl' (flip K.cons) K.nil
 
@@ -987,7 +987,7 @@ concatMap f (Fold stepa initiala extracta) = Fold stepc initialc extractc
 -- > lmap = Fold.lmapM return
 --
 -- @since 0.8.0
-{-# INLINABLE lmap #-}
+{-# INLINE lmap #-}
 lmap :: (a -> b) -> Fold m b r -> Fold m a r
 lmap f (Fold step begin done) = Fold step' begin done
     where
@@ -996,7 +996,7 @@ lmap f (Fold step begin done) = Fold step' begin done
 -- | @lmapM f fold@ maps the monadic function @f@ on the input of the fold.
 --
 -- @since 0.8.0
-{-# INLINABLE lmapM #-}
+{-# INLINE lmapM #-}
 lmapM :: Monad m => (a -> m b) -> Fold m b r -> Fold m a r
 lmapM f (Fold step begin done) = Fold step' begin done
     where
@@ -1014,7 +1014,7 @@ lmapM f (Fold step begin done) = Fold step' begin done
 -- > filter f = Fold.filterM (return . f)
 --
 -- @since 0.8.0
-{-# INLINABLE filter #-}
+{-# INLINE filter #-}
 filter :: Monad m => (a -> Bool) -> Fold m a r -> Fold m a r
 filter f (Fold step begin done) = Fold step' begin done
     where
@@ -1023,7 +1023,7 @@ filter f (Fold step begin done) = Fold step' begin done
 -- | Like 'filter' but with a monadic predicate.
 --
 -- @since 0.8.0
-{-# INLINABLE filterM #-}
+{-# INLINE filterM #-}
 filterM :: Monad m => (a -> m Bool) -> Fold m a r -> Fold m a r
 filterM f (Fold step begin done) = Fold step' begin done
     where
@@ -1105,7 +1105,7 @@ take n (Fold fstep finitial fextract) = Fold step initial extract
 -- fold.  Compare with 'snoc' which appends a singleton value to the fold.
 --
 -- /Pre-release/
-{-# INLINABLE duplicate #-}
+{-# INLINE duplicate #-}
 duplicate :: Monad m => Fold m a b -> Fold m a (Fold m a b)
 duplicate (Fold step1 initial1 extract1) =
     Fold step initial (\s -> pure $ Fold step1 (pure $ Partial s) extract1)

--- a/src/Streamly/Internal/Data/Fold/Type.hs
+++ b/src/Streamly/Internal/Data/Fold/Type.hs
@@ -1209,7 +1209,6 @@ many (Fold sstep sinitial sextract) (Fold cstep cinitial cextract) =
             Partial ss -> return $ Partial $ f ss cs
             Done sb -> cstep cs sb >>= collect
 
-    {-# INLINE collect #-}
     collect cres =
         case cres of
             Partial cs -> sinitial >>= split ManyFirst cs
@@ -1269,7 +1268,6 @@ manyPost (Fold sstep sinitial sextract) (Fold cstep cinitial cextract) =
             Partial ss1 -> return $ Partial $ Tuple' ss1 cs
             Done sb -> cstep cs sb >>= collect
 
-    {-# INLINE collect #-}
     collect cres =
         case cres of
             Partial cs -> sinitial >>= split cs
@@ -1333,7 +1331,6 @@ refoldMany (Fold sstep sinitial sextract) (Refold cstep cinject cextract) =
             Partial ss -> return $ Partial $ Tuple' cs (f ss)
             Done sb -> cstep cs sb >>= collect
 
-    {-# INLINE collect #-}
     collect cres =
         case cres of
             Partial cs -> sinitial >>= split cs Left
@@ -1385,7 +1382,6 @@ refoldMany1 (Refold sstep sinject sextract) (Fold cstep cinitial cextract) =
             Partial ss -> return $ Partial $ ConsumeMany x cs (f ss)
             Done sb -> cstep cs sb >>= collect x
 
-    {-# INLINE collect #-}
     collect x cres =
         case cres of
             Partial cs -> sinject x >>= split x cs Left

--- a/src/Streamly/Internal/Data/Maybe/Strict.hs
+++ b/src/Streamly/Internal/Data/Maybe/Strict.hs
@@ -29,20 +29,20 @@ where
 data Maybe' a = Just' !a | Nothing' deriving Show
 
 -- | Convert strict Maybe' to lazy Maybe
-{-# INLINABLE toMaybe #-}
+{-# INLINE toMaybe #-}
 toMaybe :: Maybe' a -> Maybe a
 toMaybe  Nothing' = Nothing
 toMaybe (Just' a) = Just a
 
 -- | Extract the element out of a Just' and throws an error if its argument is
 -- Nothing'.
-{-# INLINABLE fromJust' #-}
+{-# INLINE fromJust' #-}
 fromJust' :: Maybe' a -> a
 fromJust' (Just' a) = a
 fromJust' Nothing' = error "fromJust' cannot be run in Nothing'"
 
 -- | Returns True iff its argument is of the form "Just' _".
-{-# INLINABLE isJust' #-}
+{-# INLINE isJust' #-}
 isJust' :: Maybe' a -> Bool
 isJust' (Just' _) = True
 isJust' Nothing' = False

--- a/src/Streamly/Internal/Data/Parser.hs
+++ b/src/Streamly/Internal/Data/Parser.hs
@@ -534,7 +534,7 @@ drainWhile p = takeWhile p FL.drain
 --
 -- /Pre-release/
 --
-{-# INLINABLE sliceSepByP #-}
+{-# INLINE sliceSepByP #-}
 sliceSepByP ::
     MonadCatch m =>
     (a -> Bool) -> Parser m a b -> Parser m a b
@@ -544,7 +544,7 @@ sliceSepByP cond = K.toParserK . D.sliceSepByP cond . K.fromParserK
 -- separator is emitted as a separate element in the output.
 --
 -- /Unimplemented/
-{-# INLINABLE sliceSepWith #-}
+{-# INLINE sliceSepWith #-}
 sliceSepWith :: -- MonadCatch m =>
     (a -> Bool) -> Fold m a b -> Parser m a b
 sliceSepWith _cond = undefined -- K.toParserK . D.sliceSepBy cond
@@ -583,7 +583,7 @@ sliceSepWith _cond = undefined -- K.toParserK . D.sliceSepBy cond
 --
 -- /Pre-release/
 --
-{-# INLINABLE sliceBeginWith #-}
+{-# INLINE sliceBeginWith #-}
 sliceBeginWith ::
     MonadCatch m =>
     (a -> Bool) -> Fold m a b -> Parser m a b
@@ -593,7 +593,7 @@ sliceBeginWith cond = K.toParserK . D.sliceBeginWith cond
 -- escape char determined by the second predicate.
 --
 -- /Unimplemented/
-{-# INLINABLE escapedSliceSepBy #-}
+{-# INLINE escapedSliceSepBy #-}
 escapedSliceSepBy :: -- MonadCatch m =>
     (a -> Bool) -> (a -> Bool) -> Fold m a b -> Parser m a b
 escapedSliceSepBy _cond _esc = undefined
@@ -622,7 +622,7 @@ escapedSliceSepBy _cond _esc = undefined
 -- @
 --
 -- /Unimplemented/
-{-# INLINABLE escapedFrameBy #-}
+{-# INLINE escapedFrameBy #-}
 escapedFrameBy :: -- MonadCatch m =>
     (a -> Bool) -> (a -> Bool) -> (a -> Bool) -> Fold m a b -> Parser m a b
 escapedFrameBy _begin _end _escape _p = undefined
@@ -672,7 +672,7 @@ wordBy f = K.toParserK . D.wordBy f
 --
 -- /Pre-release/
 --
-{-# INLINABLE groupBy #-}
+{-# INLINE groupBy #-}
 groupBy :: MonadCatch m => (a -> a -> Bool) -> Fold m a b -> Parser m a b
 groupBy eq = K.toParserK . D.groupBy eq
 
@@ -706,7 +706,7 @@ groupBy eq = K.toParserK . D.groupBy eq
 --
 -- /Pre-release/
 --
-{-# INLINABLE groupByRolling #-}
+{-# INLINE groupByRolling #-}
 groupByRolling :: MonadCatch m => (a -> a -> Bool) -> Fold m a b -> Parser m a b
 groupByRolling eq = K.toParserK . D.groupByRolling eq
 
@@ -720,7 +720,7 @@ groupByRolling eq = K.toParserK . D.groupByRolling eq
 -- Fold.toList Fold.toList'.
 --
 -- /Unimplemented/
-{-# INLINABLE groupByRollingEither #-}
+{-# INLINE groupByRollingEither #-}
 groupByRollingEither :: MonadCatch m =>
     (a -> a -> Bool) -> Fold m a b -> Fold m a c -> Parser m a (Either b c)
 groupByRollingEither eq f1 = K.toParserK . D.groupByRollingEither eq f1

--- a/src/Streamly/Internal/Data/Parser/ParserD.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD.hs
@@ -268,7 +268,7 @@ fromFold (Fold fstep finitial fextract) = Parser step initial fextract
 --
 -- /Pre-release/
 --
-{-# INLINABLE peek #-}
+{-# INLINE peek #-}
 peek :: MonadThrow m => Parser m a a
 peek = Parser step initial extract
 
@@ -284,7 +284,7 @@ peek = Parser step initial extract
 --
 -- /Pre-release/
 --
-{-# INLINABLE eof #-}
+{-# INLINE eof #-}
 eof :: Monad m => Parser m a ()
 eof = Parser step initial return
 
@@ -805,7 +805,7 @@ data GroupByStatePair a s1 s2
     | GroupByGroupingPairL !a !s1 !s2
     | GroupByGroupingPairR !a !s1 !s2
 
-{-# INLINABLE groupByRollingEither #-}
+{-# INLINE groupByRollingEither #-}
 groupByRollingEither :: MonadCatch m =>
     (a -> a -> Bool) -> Fold m a b -> Fold m a c -> Parser m a (Either b c)
 groupByRollingEither

--- a/src/Streamly/Internal/Data/Parser/ParserD.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD.hs
@@ -1176,7 +1176,7 @@ manyTill (Fold fstep finitial fextract)
 
     -- Caution: Mutual recursion
 
-    -- Don't inline this
+    {-# INLINE scrutR #-}
     scrutL fs p c d e = do
         resL <- initialL
         case resL of
@@ -1188,7 +1188,6 @@ manyTill (Fold fstep finitial fextract)
                     FL.Done fb -> return $ d fb
             IError err -> return $ e err
 
-    {-# INLINE scrutR #-}
     scrutR fs p c d e = do
         resR <- initialR
         case resR of

--- a/src/Streamly/Internal/Data/Parser/ParserD/Type.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD/Type.hs
@@ -732,7 +732,6 @@ splitMany (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
     -- Caution! There is mutual recursion here, inlining the right functions is
     -- important.
 
-    {-# INLINE handleCollect #-}
     handleCollect partial done fres =
         case fres of
             FL.Partial fs -> do
@@ -744,7 +743,7 @@ splitMany (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
                     IError _ -> done <$> fextract fs
             FL.Done fb -> return $ done fb
 
-    -- Do not inline this
+    {-# INLINE handleCollect #-}
     runCollectorWith cont fs pb = fstep fs pb >>= cont
 
     initial = finitial >>= handleCollect IPartial IDone
@@ -794,7 +793,6 @@ splitManyPost (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
     -- Caution! There is mutual recursion here, inlining the right functions is
     -- important.
 
-    {-# INLINE handleCollect #-}
     handleCollect partial done fres =
         case fres of
             FL.Partial fs -> do
@@ -806,7 +804,7 @@ splitManyPost (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
                     IError _ -> done <$> fextract fs
             FL.Done fb -> return $ done fb
 
-    -- Do not inline this
+    {-# INLINE handleCollect #-}
     runCollectorWith cont fs pb = fstep fs pb >>= cont
 
     initial = finitial >>= handleCollect IPartial IDone
@@ -854,7 +852,6 @@ splitSome (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
     -- Caution! There is mutual recursion here, inlining the right functions is
     -- important.
 
-    {-# INLINE handleCollect #-}
     handleCollect partial done fres =
         case fres of
             FL.Partial fs -> do
@@ -866,7 +863,7 @@ splitSome (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
                     IError _ -> done <$> fextract fs
             FL.Done fb -> return $ done fb
 
-    -- Do not inline this
+    {-# INLINE handleCollect #-}
     runCollectorWith cont fs pb = fstep fs pb >>= cont
 
     initial = do

--- a/src/Streamly/Internal/Data/Producer/Source.hs
+++ b/src/Streamly/Internal/Data/Producer/Source.hs
@@ -135,7 +135,6 @@ parseD
     -- XXX currently we are using a dumb list based approach for backtracking
     -- buffer. This can be replaced by a sliding/ring buffer using Data.Array.
     -- That will allow us more efficient random back and forth movement.
-    {-# INLINE go #-}
     go !_ st buf !pst = do
         r <- ustep st
         case r of
@@ -166,6 +165,7 @@ parseD
                 b <- extract pst
                 return (b, unread (reverse $ getList buf) (source Nothing))
 
+    {-# INLINE gobuf #-}
     gobuf !_ s buf (List []) !pst = go SPEC s buf pst
     gobuf !_ s buf (List (x:xs)) !pst = do
         pRes <- pstep pst x

--- a/src/Streamly/Internal/Data/Stream/IsStream/Common.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Common.hs
@@ -680,7 +680,7 @@ splitOnSeq patt f m =
 -- | Like 'zipWith' but using a monadic zipping function.
 --
 -- @since 0.4.0
-{-# INLINABLE zipWithM #-}
+{-# INLINE zipWithM #-}
 zipWithM :: (IsStream t, Monad m) => (a -> b -> m c) -> t m a -> t m b -> t m c
 zipWithM f m1 m2 =
     IsStream.fromStreamS
@@ -699,7 +699,7 @@ zipWithM f m1 m2 =
 -- @
 --
 -- @since 0.1.0
-{-# INLINABLE zipWith #-}
+{-# INLINE zipWith #-}
 zipWith :: (IsStream t, Monad m) => (a -> b -> c) -> t m a -> t m b -> t m c
 zipWith f m1 m2 =
     IsStream.fromStreamS

--- a/src/Streamly/Internal/Data/Stream/IsStream/Expand.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Expand.hs
@@ -745,7 +745,7 @@ mergeBy f m1 m2 = fromStream $ K.mergeBy f (toStream m1) (toStream m2)
 -- See also: 'mergeByMFused'
 --
 -- @since 0.6.0
-{-# INLINABLE mergeByM #-}
+{-# INLINE mergeByM #-}
 mergeByM
     :: (IsStream t, Monad m)
     => (a -> a -> m Ordering) -> t m a -> t m a -> t m a

--- a/src/Streamly/Internal/Data/Stream/IsStream/Reduce.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Reduce.hs
@@ -1492,7 +1492,7 @@ classifySessionsBy tick reset ejectPred tmout
 --
 -- /Pre-release/
 --
-{-# INLINABLE classifyKeepAliveSessions #-}
+{-# INLINE classifyKeepAliveSessions #-}
 classifyKeepAliveSessions ::
        (IsStream t, MonadAsync m, Ord k)
     => (Int -> m Bool) -- ^ predicate to eject sessions on session count
@@ -1539,7 +1539,7 @@ classifyChunksOf wsize = classifyChunksBy wsize False
 --
 -- /Pre-release/
 --
-{-# INLINABLE classifySessionsOf #-}
+{-# INLINE classifySessionsOf #-}
 classifySessionsOf ::
        (IsStream t, MonadAsync m, Ord k)
     => (Int -> m Bool) -- ^ predicate to eject sessions on session count

--- a/src/Streamly/Internal/Data/Stream/IsStream/Type.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Type.hs
@@ -654,7 +654,7 @@ concatMapWith par f xs = bindWith par xs f
 -- /Since: 0.8.0 (Renamed foldMapWith to concatMapFoldableWith)/
 --
 -- /Since: 0.1.0 ("Streamly")/
-{-# INLINABLE concatMapFoldableWith #-}
+{-# INLINE concatMapFoldableWith #-}
 concatMapFoldableWith :: (IsStream t, Foldable f)
     => (t m b -> t m b -> t m b) -> (a -> t m b) -> f a -> t m b
 concatMapFoldableWith f g = Prelude.foldr (f . g) nil

--- a/src/Streamly/Internal/Data/Stream/StreamD/Eliminate.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Eliminate.hs
@@ -166,7 +166,6 @@ parse_ (PRD.Parser pstep initial extract) stream@(Stream step state) = do
     -- XXX currently we are using a dumb list based approach for backtracking
     -- buffer. This can be replaced by a sliding/ring buffer using Data.Array.
     -- That will allow us more efficient random back and forth movement.
-    {-# INLINE go #-}
     go !_ st buf !pst = do
         r <- step defState st
         case r of
@@ -199,6 +198,7 @@ parse_ (PRD.Parser pstep initial extract) stream@(Stream step state) = do
                 b <- extract pst
                 return (b, let List buffer = buf in fromList buffer)
 
+    {-# INLINE gobuf #-}
     gobuf !_ s buf (List []) !pst = go SPEC s buf pst
     gobuf !_ s buf (List (x:xs)) !pst = do
         pRes <- pstep pst x

--- a/src/Streamly/Internal/Data/Tuple/Strict.hs
+++ b/src/Streamly/Internal/Data/Tuple/Strict.hs
@@ -21,15 +21,24 @@ module Streamly.Internal.Data.Tuple.Strict
     (
       Tuple' (..)
     , Tuple3' (..)
+    , Tuple3Fused' (..)
     , Tuple4' (..)
     )
 where
 
+import Fusion.Plugin.Types (Fuse(..))
+
 -- | A strict '(,)'
 data Tuple' a b = Tuple' !a !b deriving Show
 
+-- XXX Add TupleFused'
+
 -- | A strict '(,,)'
+{-# ANN type Tuple3Fused' Fuse #-}
 data Tuple3' a b c = Tuple3' !a !b !c deriving Show
+
+-- | A strict '(,,)'
+data Tuple3Fused' a b c = Tuple3Fused' !a !b !c deriving Show
 
 -- | A strict '(,,,)'
 data Tuple4' a b c d = Tuple4' !a !b !c !d deriving Show

--- a/src/Streamly/Internal/FileSystem/Dir.hs
+++ b/src/Streamly/Internal/FileSystem/Dir.hs
@@ -103,7 +103,7 @@ readArrayUpto size h = do
 -- | @toChunksWithBufferOf size h@ reads a stream of arrays from file handle @h@.
 -- The maximum size of a single array is specified by @size@. The actual size
 -- read may be less than or equal to @size@.
-{-# INLINABLE _toChunksWithBufferOf #-}
+{-# INLINE _toChunksWithBufferOf #-}
 _toChunksWithBufferOf :: (IsStream t, MonadIO m)
     => Int -> Handle -> t m (Array Word8)
 _toChunksWithBufferOf size h = go

--- a/src/Streamly/Internal/FileSystem/FD.hs
+++ b/src/Streamly/Internal/FileSystem/FD.hs
@@ -277,7 +277,7 @@ writeIOVec (Handle fd) iov =
 -- | @readArraysOfUpto size h@ reads a stream of arrays from file handle @h@.
 -- The maximum size of a single array is specified by @size@. The actual size
 -- read may be less than or equal to @size@.
-{-# INLINABLE _readArraysOfUpto #-}
+{-# INLINE _readArraysOfUpto #-}
 _readArraysOfUpto :: (IsStream t, MonadIO m)
     => Int -> Handle -> t m (Array Word8)
 _readArraysOfUpto size h = go

--- a/src/Streamly/Internal/FileSystem/File.hs
+++ b/src/Streamly/Internal/FileSystem/File.hs
@@ -151,14 +151,14 @@ withFile file mode = S.bracket (liftIO $ openFile file mode) (liftIO . hClose)
 --
 -- /Pre-release/
 --
-{-# INLINABLE usingFile #-}
+{-# INLINE usingFile #-}
 usingFile :: (MonadCatch m, MonadAsync m)
     => Unfold m Handle a -> Unfold m FilePath a
 usingFile =
     UF.bracket (\file -> liftIO $ openFile file ReadMode)
                (liftIO . hClose)
 
-{-# INLINABLE usingFile2 #-}
+{-# INLINE usingFile2 #-}
 usingFile2 :: (MonadCatch m, MonadAsync m)
     => Unfold m (x, Handle) a -> Unfold m (x, FilePath) a
 usingFile2 = UF.bracket before after
@@ -171,7 +171,7 @@ usingFile2 = UF.bracket before after
 
     after (_, h) = liftIO $ hClose h
 
-{-# INLINABLE usingFile3 #-}
+{-# INLINE usingFile3 #-}
 usingFile3 :: (MonadCatch m, MonadAsync m)
     => Unfold m (x, y, z, Handle) a -> Unfold m (x, y, z, FilePath) a
 usingFile3 = UF.bracket before after
@@ -215,7 +215,7 @@ appendArray file arr = SIO.withFile file AppendMode (`FH.putChunk` arr)
 -- | @toChunksWithBufferOf size file@ reads a stream of arrays from file @file@.
 -- The maximum size of a single array is specified by @size@. The actual size
 -- read may be less than or equal to @size@.
-{-# INLINABLE toChunksWithBufferOf #-}
+{-# INLINE toChunksWithBufferOf #-}
 toChunksWithBufferOf :: (IsStream t, MonadCatch m, MonadAsync m)
     => Int -> FilePath -> t m (Array Word8)
 toChunksWithBufferOf size file =

--- a/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/src/Streamly/Internal/FileSystem/Handle.hs
@@ -206,7 +206,7 @@ getChunkOf = undefined
 -- | @toChunksWithBufferOf size h@ reads a stream of arrays from file handle @h@.
 -- The maximum size of a single array is specified by @size@. The actual size
 -- read may be less than or equal to @size@.
-{-# INLINABLE _toChunksWithBufferOf #-}
+{-# INLINE _toChunksWithBufferOf #-}
 _toChunksWithBufferOf :: (IsStream t, MonadIO m)
     => Int -> Handle -> t m (Array Word8)
 _toChunksWithBufferOf size h = go

--- a/src/Streamly/Internal/Network/Inet/TCP.hs
+++ b/src/Streamly/Internal/Network/Inet/TCP.hs
@@ -277,7 +277,7 @@ withConnectionM addr port =
 -- exception, then this exception will be raised by 'usingConnection'.
 --
 -- /Pre-release/
-{-# INLINABLE usingConnection #-}
+{-# INLINE usingConnection #-}
 usingConnection :: (MonadCatch m, MonadAsync m)
     => Unfold m Socket a
     -> Unfold m ((Word8, Word8, Word8, Word8), PortNumber) a
@@ -297,7 +297,7 @@ usingConnection =
 -- 'withConnection' rather than any exception raised by 'act'.
 --
 -- /Pre-release/
-{-# INLINABLE withConnection #-}
+{-# INLINE withConnection #-}
 withConnection :: (IsStream t, MonadCatch m, MonadAsync m)
     => (Word8, Word8, Word8, Word8) -> PortNumber -> (Socket -> t m a) -> t m a
 withConnection addr port =
@@ -418,7 +418,7 @@ write = writeWithBufferOf defaultChunkSize
 -- Transformations
 -------------------------------------------------------------------------------
 
-{-# INLINABLE withInputConnect #-}
+{-# INLINE withInputConnect #-}
 withInputConnect
     :: (IsStream t, MonadCatch m, MonadAsync m)
     => (Word8, Word8, Word8, Word8)
@@ -446,7 +446,7 @@ withInputConnect addr port input f = S.bracket pre post handler
 --
 -- /Pre-release/
 --
-{-# INLINABLE processBytes #-}
+{-# INLINE processBytes #-}
 processBytes
     :: (IsStream t, MonadAsync m, MonadCatch m)
     => (Word8, Word8, Word8, Word8)

--- a/src/Streamly/Internal/Network/Socket.hs
+++ b/src/Streamly/Internal/Network/Socket.hs
@@ -324,7 +324,7 @@ writeChunk = writeArrayWith sendAll
 -- Stream of Arrays IO
 -------------------------------------------------------------------------------
 
-{-# INLINABLE _readChunksUptoWith #-}
+{-# INLINE _readChunksUptoWith #-}
 _readChunksUptoWith :: (IsStream t, MonadIO m)
     => (Int -> h -> IO (Array Word8))
     -> Int -> h -> t m (Array Word8)


### PR DESCRIPTION
See #1061, #1066, #1067, #1068, #1428 .

There were several fixes in GHC mentioned in the issues above.

The type of fixes required in streamly are:

* INLINE annotation added in a few cases, or INLINABLE converted to INLINE
* INLINE pragma was swapped in mutually recursive cases (deciding the loop breaker)
* Remove NOINLINE from some benchmarks
* Fuse annotation added in one case

There are still some cases remaining to be fixed.
