### PR TITLE
GHC-9: Remove INLINE on mutually rec funcs

### DIFF
--- a/src/Streamly/Internal/Data/Array/Stream/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Stream/Foreign.hs
@@ -545,7 +545,6 @@ parseD (PRD.Parser pstep initial extract) stream@(D.Stream step state) = do
     -- XXX currently we are using a dumb list based approach for backtracking
     -- buffer. This can be replaced by a sliding/ring buffer using Data.Array.
     -- That will allow us more efficient random back and forth movement.
-    {-# INLINE go #-}
     go !_ st backBuf !pst = do
         r <- step defState st
         case r of
@@ -642,7 +641,6 @@ parseArrD (PRD.Parser pstep initial extract) stream@(D.Stream step state) = do
     -- XXX currently we are using a dumb list based approach for backtracking
     -- buffer. This can be replaced by a sliding/ring buffer using Data.Array.
     -- That will allow us more efficient random back and forth movement.
-    {-# INLINE go #-}
     go !_ st backBuf !pst = do
         r <- step defState st
         case r of

--- a/src/Streamly/Internal/Data/Fold/Type.hs
+++ b/src/Streamly/Internal/Data/Fold/Type.hs
@@ -1212,7 +1212,6 @@ many (Fold sstep sinitial sextract) (Fold cstep cinitial cextract) =
             Partial ss -> return $ Partial $ f ss cs
             Done sb -> cstep cs sb >>= collect
 
-    {-# INLINE collect #-}
     collect cres =
         case cres of
             Partial cs -> sinitial >>= split ManyFirst cs
@@ -1272,7 +1271,6 @@ manyPost (Fold sstep sinitial sextract) (Fold cstep cinitial cextract) =
             Partial ss1 -> return $ Partial $ Tuple' ss1 cs
             Done sb -> cstep cs sb >>= collect
 
-    {-# INLINE collect #-}
     collect cres =
         case cres of
             Partial cs -> sinitial >>= split cs
@@ -1336,7 +1334,6 @@ refoldMany (Fold sstep sinitial sextract) (Refold cstep cinject cextract) =
             Partial ss -> return $ Partial $ Tuple' cs (f ss)
             Done sb -> cstep cs sb >>= collect
 
-    {-# INLINE collect #-}
     collect cres =
         case cres of
             Partial cs -> sinitial >>= split cs Left
@@ -1388,7 +1385,6 @@ refoldMany1 (Refold sstep sinject sextract) (Fold cstep cinitial cextract) =
             Partial ss -> return $ Partial $ ConsumeMany x cs (f ss)
             Done sb -> cstep cs sb >>= collect x
 
-    {-# INLINE collect #-}
     collect x cres =
         case cres of
             Partial cs -> sinject x >>= split x cs Left

--- a/src/Streamly/Internal/Data/Parser/ParserD.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD.hs
@@ -1176,7 +1176,6 @@ manyTill (Fold fstep finitial fextract)
 
     -- Caution: Mutual recursion
 
-    -- Don't inline this
     scrutL fs p c d e = do
         resL <- initialL
         case resL of
@@ -1188,7 +1187,6 @@ manyTill (Fold fstep finitial fextract)
                     FL.Done fb -> return $ d fb
             IError err -> return $ e err
 
-    {-# INLINE scrutR #-}
     scrutR fs p c d e = do
         resR <- initialR
         case resR of

--- a/src/Streamly/Internal/Data/Parser/ParserD/Type.hs
+++ b/src/Streamly/Internal/Data/Parser/ParserD/Type.hs
@@ -767,7 +767,6 @@ splitMany (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
     -- Caution! There is mutual recursion here, inlining the right functions is
     -- important.
 
-    {-# INLINE handleCollect #-}
     handleCollect partial done fres =
         case fres of
             FL.Partial fs -> do
@@ -779,7 +778,6 @@ splitMany (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
                     IError _ -> done <$> fextract fs
             FL.Done fb -> return $ done fb
 
-    -- Do not inline this
     runCollectorWith cont fs pb = fstep fs pb >>= cont
 
     initial = finitial >>= handleCollect IPartial IDone
@@ -829,7 +827,6 @@ splitManyPost (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
     -- Caution! There is mutual recursion here, inlining the right functions is
     -- important.
 
-    {-# INLINE handleCollect #-}
     handleCollect partial done fres =
         case fres of
             FL.Partial fs -> do
@@ -841,7 +838,6 @@ splitManyPost (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
                     IError _ -> done <$> fextract fs
             FL.Done fb -> return $ done fb
 
-    -- Do not inline this
     runCollectorWith cont fs pb = fstep fs pb >>= cont
 
     initial = finitial >>= handleCollect IPartial IDone
@@ -889,7 +885,6 @@ splitSome (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
     -- Caution! There is mutual recursion here, inlining the right functions is
     -- important.
 
-    {-# INLINE handleCollect #-}
     handleCollect partial done fres =
         case fres of
             FL.Partial fs -> do
@@ -901,7 +896,6 @@ splitSome (Parser step1 initial1 extract1) (Fold fstep finitial fextract) =
                     IError _ -> done <$> fextract fs
             FL.Done fb -> return $ done fb
 
-    -- Do not inline this
     runCollectorWith cont fs pb = fstep fs pb >>= cont
 
     initial = do

--- a/src/Streamly/Internal/Data/Producer/Source.hs
+++ b/src/Streamly/Internal/Data/Producer/Source.hs
@@ -135,7 +135,6 @@ parseD
     -- XXX currently we are using a dumb list based approach for backtracking
     -- buffer. This can be replaced by a sliding/ring buffer using Data.Array.
     -- That will allow us more efficient random back and forth movement.
-    {-# INLINE go #-}
     go !_ st buf !pst = do
         r <- ustep st
         case r of

--- a/src/Streamly/Internal/Data/Stream/StreamD/Eliminate.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Eliminate.hs
@@ -166,7 +166,6 @@ parse_ (PRD.Parser pstep initial extract) stream@(Stream step state) = do
     -- XXX currently we are using a dumb list based approach for backtracking
     -- buffer. This can be replaced by a sliding/ring buffer using Data.Array.
     -- That will allow us more efficient random back and forth movement.
-    {-# INLINE go #-}
     go !_ st buf !pst = do
         r <- step defState st
         case r of


### PR DESCRIPTION
They seem to do find without it. In some cases wrong INLINE causes perf
issues.