### PR TITLE
Remove dependency of lower level modules on higher level ones

### DIFF
--- a/src/Streamly/Internal/Data/Array/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Foreign.hs
@@ -144,7 +144,6 @@ import qualified Streamly.Internal.Data.Array.Foreign.Mut as MA
 import qualified Streamly.Internal.Data.Array.Foreign.Type as A
 import qualified Streamly.Internal.Data.Fold as FL
 import qualified Streamly.Internal.Data.Producer as Producer
-import qualified Streamly.Internal.Data.Stream.IsStream.Type as IsStream
 import qualified Streamly.Internal.Data.Stream.Prelude as P
 import qualified Streamly.Internal.Data.Stream.StreamD as D
 import qualified Streamly.Internal.Data.Unfold as Unfold
@@ -393,7 +392,7 @@ getSliceUnsafe index len (Array contents start e) =
 splitOn :: (Monad m, Storable a) =>
     (a -> Bool) -> Array a -> SerialT m (Array a)
 splitOn predicate arr =
-    IsStream.fromStreamD
+    SerialT $ D.toStreamK
         $ fmap (\(i, len) -> getSliceUnsafe i len arr)
         $ D.sliceOnSuffix predicate (A.toStreamD arr)
 

--- a/src/Streamly/Internal/Data/Array/Stream/Mut/Foreign.hs
+++ b/src/Streamly/Internal/Data/Array/Stream/Mut/Foreign.hs
@@ -35,8 +35,6 @@ import Foreign.Storable (Storable(..))
 import Streamly.Internal.Data.Array.Foreign.Mut.Type (Array(..))
 import Streamly.Internal.Data.Fold.Type (Fold(..))
 import Streamly.Internal.Data.Stream.Serial (SerialT(..))
-import Streamly.Internal.Data.Stream.IsStream.Type
-    (IsStream, fromStreamD, toStreamD)
 import Streamly.Internal.Data.Tuple.Strict (Tuple'(..))
 
 import qualified Streamly.Internal.Data.Array.Foreign.Mut.Type as MArray
@@ -53,9 +51,10 @@ import qualified Streamly.Internal.Data.Parser.ParserD as ParserD
 --
 -- /Pre-release/
 {-# INLINE arraysOf #-}
-arraysOf :: (IsStream t, MonadIO m, Storable a)
-    => Int -> t m a -> t m (Array a)
-arraysOf n = fromStreamD . MArray.arraysOf n . toStreamD
+arraysOf :: (MonadIO m, Storable a)
+    => Int -> SerialT m a -> SerialT m (Array a)
+arraysOf n (SerialT xs) =
+    SerialT $ D.toStreamK $ MArray.arraysOf n $ D.fromStreamK xs
 
 -------------------------------------------------------------------------------
 -- Compact

--- a/src/Streamly/Internal/Data/Stream/StreamD/Generate.hs
+++ b/src/Streamly/Internal/Data/Stream/StreamD/Generate.hs
@@ -329,7 +329,7 @@ enumerateFromThenToFractional from next to =
 ------------------------------------------------------------------------------
 
 {-# INLINE_NORMAL times #-}
-times :: MonadAsync m => Double -> Stream m (AbsTime, RelTime64)
+times :: MonadIO m => Double -> Stream m (AbsTime, RelTime64)
 times g = Stream step Nothing
 
     where

--- a/src/Streamly/Internal/System/IOVec.hs
+++ b/src/Streamly/Internal/System/IOVec.hs
@@ -28,7 +28,7 @@ import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO(..))
 import Foreign.Ptr (castPtr)
 import Streamly.Internal.Data.Array.Foreign.Mut.Type (length)
-import Streamly.Internal.Data.SVar (adaptState)
+import Streamly.Internal.Data.SVar.Type (adaptState)
 import Streamly.Internal.Data.Array.Foreign.Mut.Type (Array(..))
 
 import qualified Streamly.Internal.Data.Array.Foreign.Type as Array


### PR DESCRIPTION
These modules will be part of the lower level package streamly-core so should not depend on higher level ones.