### PR TITLE
Allow different types of Map in classify

### DIFF
--- a/benchmark/streamly-benchmarks.cabal
+++ b/benchmark/streamly-benchmarks.cabal
@@ -125,6 +125,8 @@ common bench-depends
     , random              >= 1.0   && < 2.0
     , transformers        >= 0.4   && < 0.7
     , containers          >= 0.5   && < 0.7
+    , hashable            >= 1.3   && < 1.5
+    , unordered-containers >= 0.2 && < 0.3
     , process             >= 1.4 && < 1.7
     , directory         >= 1.2.2 && < 1.4
     , filepath          >= 1.4.1 && < 1.5

--- a/core/src/Streamly/Internal/Data/IsMap.hs
+++ b/core/src/Streamly/Internal/Data/IsMap.hs
@@ -1,0 +1,61 @@
+-- |
+-- Module      : Streamly.Internal.Data.IsMap
+-- Copyright   : (c) 2022 Composewell Technologies
+-- License     : BSD-3-Clause
+-- Maintainer  : streamly@composewell.com
+-- Stability   : experimental
+-- Portability : GHC
+
+module Streamly.Internal.Data.IsMap (IsMap(..)) where
+
+import Data.Hashable (Hashable)
+import Data.Kind (Type)
+import Data.Map.Strict (Map)
+
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.IntMap.Strict as IntMap
+import qualified Data.Map.Strict as Map
+
+-- XXX Try unpacked-containers
+
+class IsMap f where
+    type Key f :: Type
+
+    mapEmpty :: f a
+    mapAlterF :: Functor g =>
+        (Maybe a -> g (Maybe a)) -> Key f -> f a -> g (f a)
+    -- These can be implemented in terms of alterF itself
+    mapLookup :: Key f -> f a -> Maybe a
+    mapInsert :: Key f -> a -> f a -> f a
+    mapDelete :: Key f -> f a -> f a
+    mapUnion :: f a -> f a -> f a
+
+instance Ord k => IsMap (Map k) where
+    type Key (Map k) = k
+
+    mapEmpty = Map.empty
+    mapAlterF = Map.alterF
+    mapLookup = Map.lookup
+    mapInsert = Map.insert
+    mapDelete = Map.delete
+    mapUnion = Map.union
+
+instance IsMap IntMap.IntMap where
+    type Key IntMap.IntMap = Int
+
+    mapEmpty = IntMap.empty
+    mapAlterF = IntMap.alterF
+    mapLookup = IntMap.lookup
+    mapInsert = IntMap.insert
+    mapDelete = IntMap.delete
+    mapUnion = IntMap.union
+
+instance (Hashable k, Eq k) => IsMap (HashMap.HashMap k) where
+    type Key (HashMap.HashMap k) = k
+
+    mapEmpty = HashMap.empty
+    mapAlterF = HashMap.alterF
+    mapLookup = HashMap.lookup
+    mapInsert = HashMap.insert
+    mapDelete = HashMap.delete
+    mapUnion = HashMap.union

--- a/core/streamly-core.cabal
+++ b/core/streamly-core.cabal
@@ -221,6 +221,7 @@ library
                      , Streamly.Internal.Data.Cont
                      , Streamly.Internal.Foreign.Malloc
                      , Streamly.Internal.System.IO
+                     , Streamly.Internal.Data.IsMap
 
                      -- streamly-strict-data
                      , Streamly.Internal.Data.Tuple.Strict
@@ -337,7 +338,8 @@ library
                      , primitive         >= 0.5.4 && < 0.8
                      , heaps             >= 0.3     && < 0.5
                      , deque             >= 0.4   && < 0.5
-
+                     , hashable          >= 1.3   && < 1.5
+                     , unordered-containers >= 0.2 && < 0.3
     if flag(use-unliftio)
       build-depends:   unliftio-core     >= 0.2 && < 0.3
     else

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -145,6 +145,7 @@ extra-source-files:
     core/src/Streamly/Internal/Data/Cont.hs
     core/src/Streamly/Internal/Foreign/Malloc.hs
     core/src/Streamly/Internal/System/IO.hs
+    core/src/Streamly/Internal/Data/IsMap.hs
     core/src/Streamly/Internal/Data/Tuple/Strict.hs
     core/src/Streamly/Internal/Data/Maybe/Strict.hs
     core/src/Streamly/Internal/Data/Either/Strict.hs


### PR DESCRIPTION
IntMap and HashMap can provide better performance than Map.

Also, allow mutable cells in classify for better performance.