### PR TITLE
Use the demux input to determine the fold

### DIFF
--- a/benchmark/Streamly/Benchmark/Data/Fold.hs
+++ b/benchmark/Streamly/Benchmark/Data/Fold.hs
@@ -193,27 +193,27 @@ partitionByMinM =
 
 {-# INLINE demuxWith  #-}
 demuxWith :: (Monad m, Ord k) =>
-    (a -> k) -> (k -> m (Fold m a b)) -> SerialT m a -> m (Map k b)
+    (a -> k) -> (a -> m (Fold m a b)) -> SerialT m a -> m (Map k b)
 demuxWith f g = S.fold (FL.demuxWith f g)
 
 {-# INLINE demuxWithInt  #-}
 demuxWithInt :: Monad m =>
-    (a -> Int) -> (Int -> m (Fold m a b)) -> SerialT m a -> m (IntMap b)
+    (a -> Int) -> (a -> m (Fold m a b)) -> SerialT m a -> m (IntMap b)
 demuxWithInt f g = S.fold (FL.demuxWith f g)
 
 {-# INLINE demuxWithHash  #-}
 demuxWithHash :: (Monad m, Ord k, Hashable k) =>
-    (a -> k) -> (k -> m (Fold m a b)) -> SerialT m a -> m (HashMap k b)
+    (a -> k) -> (a -> m (Fold m a b)) -> SerialT m a -> m (HashMap k b)
 demuxWithHash f g = S.fold (FL.demuxWith f g)
 
 {-# INLINE demuxMutWith  #-}
 demuxMutWith :: (MonadIO m, Ord k) =>
-    (a -> k) -> (k -> m (Fold m a b)) -> SerialT m a -> m (Map k b)
+    (a -> k) -> (a -> m (Fold m a b)) -> SerialT m a -> m (Map k b)
 demuxMutWith f g = S.fold (FL.demuxMutWith f g)
 
 {-# INLINE demuxMutWithHash  #-}
 demuxMutWithHash :: (MonadIO m, Ord k, Hashable k) =>
-    (a -> k) -> (k -> m (Fold m a b)) -> SerialT m a -> m (HashMap k b)
+    (a -> k) -> (a -> m (Fold m a b)) -> SerialT m a -> m (HashMap k b)
 demuxMutWithHash f g = S.fold (FL.demuxMutWith f g)
 
 {-# INLINE classifyWith #-}
@@ -429,15 +429,15 @@ o_n_heap_serial value =
     , bgroup "key-value"
             [
               benchIOSink value "demuxWith (64 buckets) [sum, length]"
-                $ demuxWith (getKey 64) getFold
+                $ demuxWith (getKey 64) (getFold . getKey 64)
             , benchIOSink value "demuxWithInt (64 buckets) [sum, length]"
-                $ demuxWithInt (getKey 64) getFold
+                $ demuxWithInt (getKey 64) (getFold . getKey 64)
             , benchIOSink value "demuxWithHash (64 buckets) [sum, length]"
-                $ demuxWithHash (getKey 64) getFold
+                $ demuxWithHash (getKey 64) (getFold . getKey 64)
             , benchIOSink value "demuxMutWith (64 buckets) [sum, length]"
-                $ demuxMutWith (getKey 64) getFold
+                $ demuxMutWith (getKey 64) (getFold . getKey 64)
             , benchIOSink value "demuxMutWithHash (64 buckets) [sum, length]"
-                $ demuxMutWithHash (getKey 64) getFold
+                $ demuxMutWithHash (getKey 64) (getFold . getKey 64)
 
             -- classify: immutable
             , benchIOSink value "classifyWith (64 buckets) sum"

--- a/test/Streamly/Test/Data/Fold.hs
+++ b/test/Streamly/Test/Data/Fold.hs
@@ -590,7 +590,7 @@ demuxWith =
 
         input = Stream.fromList [1, 2, 3, 4 :: Int]
     in Stream.fold
-        (F.demuxWith getKey getFold)
+        (F.demuxWith getKey (getFold . getKey))
         input
         `shouldReturn`
         Data.Map.fromList [("PRODUCT",3),("SUM",6)]


### PR DESCRIPTION
We may want to use the entire value to determine the fold and not just
the key. For example, we may have the key as an Int that uniquely
determines the fold (for example a connection/request id). Once the
fold starts we can always lookup the fold using this key. However, to
determine what fold to use initially we may need more information than
just the request-id (e.g. the type of the message).