### PR TITLE
Link the github and streamly-examples in the docs

### DIFF
--- a/docs/Developer/Github.link
+++ b/docs/Developer/Github.link
@@ -1,0 +1,1 @@
+https://github.com/composewell/streamly

--- a/docs/User/HowTo/Examples.link
+++ b/docs/User/HowTo/Examples.link
@@ -1,0 +1,1 @@
+https://github.com/composewell/streamly-examples

--- a/docs/User/ProjectRelated/Github.link
+++ b/docs/User/ProjectRelated/Github.link
@@ -1,0 +1,1 @@
+https://github.com/composewell/streamly

--- a/docs/User/Tutorials/Examples.link
+++ b/docs/User/Tutorials/Examples.link
@@ -1,0 +1,1 @@
+https://github.com/composewell/streamly-examples

--- a/docs/streamly-docs.cabal
+++ b/docs/streamly-docs.cabal
@@ -18,13 +18,16 @@ build-type:         Simple
 extra-doc-files:
   User/*.md
   User/Tutorials/*.md
+  User/Tutorials/*.link
   User/HowTo/*.md
+  User/HowTo/*.link
   User/Explanatory/*.md
   User/Explanatory/streaming-pradigms.rst
   User/ProjectRelated/*.md
-  User/ProjectRelated/Roadmap.link
+  User/ProjectRelated/*.link
   Developer/*.png
   Developer/*.md
+  Developer/*.link
   Developer/*.rst
 
 library

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -224,15 +224,18 @@ extra-doc-files:
     docs/Developer/*.png
     docs/Developer/*.md
     docs/Developer/*.rst
+    docs/Developer/*.link
     docs/User/*.md
     docs/User/Tutorials/*.md
+    docs/User/Tutorials/*.link
     docs/User/Tutorials/*.hs
     docs/User/HowTo/*.md
+    docs/User/HowTo/*.link
     docs/User/HowTo/*.svg
     docs/User/Explanatory/*.md
     docs/User/Explanatory/streaming-pradigms.rst
     docs/User/ProjectRelated/*.md
-    docs/User/ProjectRelated/Roadmap.link
+    docs/User/ProjectRelated/*.link
     docs/User/ProjectRelated/API-changelog.txt
     test/README.md
     docs/Developer/Tests.md


### PR DESCRIPTION
- Add a github link in the user and developer docs
- Link streamly-examples under Tutorials and HowTo

See,
https://github.com/composewell/streamly-site/issues/144
https://github.com/composewell/streamly-site/issues/142

Need to come up with a way to reduce duplication.