### PR TITLE
Implement folds for substring matching

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -185,7 +185,12 @@ jobs:
         chmod +x ./ghcup
         if test "$GHCVER" = "head"
         then
-          ./ghcup install ghc -u https://gitlab.haskell.org/ghc/ghc/-/jobs/artifacts/master/raw/ghc-x86_64-deb10-linux-integer-simple.tar.xz?job=validate-x86_64-linux-deb10-integer-simple head
+          # The URL may change, to find a working URL go to https://gitlab.haskell.org/ghc/ghc/-/jobs/
+          # Find a debian10 job, click on a passed/failed job, at the
+          # end of the output you will find the tar.xz name, put that after
+          # "raw/", and put the job name after "job=".
+          # Also see https://github.com/mpickering/ghc-artefact-nix/blob/master/gitlab-artifact.nix
+          ./ghcup install ghc -u https://gitlab.haskell.org/ghc/ghc/-/jobs/artifacts/master/raw/ghc-x86_64-linux-deb10-int_native-validate.tar.xz?job=x86_64-linux-deb10-int_native-validate head
         else
           ./ghcup install ghc $GHCVER
         fi

--- a/benchmark/Streamly/Benchmark/Prelude/Serial/Split.hs
+++ b/benchmark/Streamly/Benchmark/Prelude/Serial/Split.hs
@@ -156,6 +156,12 @@ splitOnSuffixSeq str inh =
 -- inspect $ 'splitOnSuffixSeq `hasNoType` ''Step
 #endif
 
+-- | Split on suffix sequence.
+splitWithSuffixSeq :: String -> Handle -> IO Int
+splitWithSuffixSeq str inh =
+    S.length $ IP.splitWithSuffixSeq (toarr str) FL.drain
+        $ S.unfold FH.read inh -- >>= print
+
 o_1_space_reduce_read_split :: BenchEnv -> [Benchmark]
 o_1_space_reduce_read_split env =
     [ bgroup "split"
@@ -185,6 +191,8 @@ o_1_space_reduce_read_split env =
             splitOnSeq "\r\n" inh
         , mkBench "S.splitOnSuffixSeq \"\\r\\n\" FL.drain" env $ \inh _ ->
             splitOnSuffixSeq "\r\n" inh
+        , mkBench "S.splitWithSuffixSeq \"\\r\\n\" FL.drain" env $ \inh _ ->
+            splitWithSuffixSeq "\r\n" inh
         , mkBench "S.splitOnSeq \"aa\" FL.drain" env $ \inh _ ->
             splitOnSeq "aa" inh
         , mkBench "S.splitOnSeq \"aaaa\" FL.drain" env $ \inh _ ->
@@ -201,6 +209,8 @@ o_1_space_reduce_read_split env =
             env $ \inh _ -> splitOnSeq100k inh
         , mkBenchSmall "S.splitOnSuffixSeq \"abcdefghijklmnopqrstuvwxyz\" FL.drain"
             env $ \inh _ -> splitOnSuffixSeq "abcdefghijklmnopqrstuvwxyz" inh
+        , mkBenchSmall "S.splitWithSuffixSeq \"abcdefghijklmnopqrstuvwxyz\" FL.drain"
+            env $ \inh _ -> splitWithSuffixSeq "abcdefghijklmnopqrstuvwxyz" inh
         ]
     ]
 


### PR DESCRIPTION
Commit by commit review may work better, 3rd and 4th commits are the important ones.

I have added commented out stream splitting operations in terms of the fold operations. The stream tests pass with those operations. Measured performance with those definitions enabled and compared it to the earlier versions of these operations. Allocations are the same, however, CPU performance is not as good for one of the operations, though it is quite good in absolute sense.

```
Prelude.Serial(cpuTime)
Benchmark                                                                                                     default(0)(ms) default(1) - default(0)(%)
------------------------------------------------------------------------------------------------------------- -------------- --------------------------
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "aaaa" FL.drain                                                       145.63                    +287.75
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "aa" FL.drain                                                         154.13                    +271.49
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "\r\n" FL.drain                                                       152.63                    +266.38
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "abcdefgh" FL.drain                                                   150.60                    +259.38
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "catcatcatcatcat" FL.drain                                            358.45                    +195.06
All.Prelude.Serial/o-1-space.split.S.splitOnSeq 100k long pattern                                                     353.30                    +194.52
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "abcdefghi" FL.drain                                                  361.08                    +179.03
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "abcdefghijklmnopqrstuvwxyz" FL.drain                                 380.73                    +168.12
All.Prelude.Serial/o-1-space.split/toChunks.S.splitOnSeqUtf8 "abcdefgh" FL.drain . US.decodeUtf8Arrays (1/10)         157.34                     +34.80
All.Prelude.Serial/o-1-space.split/toChunks.S.splitOnSeqUtf8 "abcdefghijklmnopqrstuvwxyz" FL.drain (1/10)             151.72                     +34.38
All.Prelude.Serial/o-1-space.split.S.splitOn (== lf) FL.drain                                                         149.41                      +3.15
All.Prelude.Serial/o-1-space.split.S.splitOnSuffixSeq "" FL.drain                                                      68.16                      +1.08
All.Prelude.Serial/o-1-space.split.S.wordsBy isSpace FL.drain                                                         227.40                      -0.77
All.Prelude.Serial/o-1-space.split.S.splitOnSuffixSeq "\n" FL.drain                                                    79.73                      -1.03
All.Prelude.Serial/o-1-space.split.S.foldMany (FL.takeEndBy_ (== lf) FL.drain)                                         80.50                      -2.51
All.Prelude.Serial/o-1-space.split.S.splitOnSuffixSeq "abcdefghijklmnopqrstuvwxyz" FL.drain (1/10)                    106.01                      -3.22
All.Prelude.Serial/o-1-space.split.S.splitOnSuffixSeq "\r\n" FL.drain                                                 579.33                      -3.73
All.Prelude.Serial/o-1-space.split.S.splitOnSuffix (== lf) FL.drain                                                    79.03                      -4.64
All.Prelude.Serial/o-1-space.split.S.splitWithSuffix (== lf) FL.drain                                                  80.84                     -10.34
All.Prelude.Serial/o-1-space.split.S.parseMany (FL.takeEndBy_ (== lf) FL.drain)                                        93.71                     -16.78
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "" FL.drain                                                            83.97                     -21.07
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "\n" FL.drain                                                         150.84                     -80.58
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "a" FL.drain                                                          149.36                     -84.81

Prelude.Serial(Allocated)
Benchmark                                                                                                     default(0)(MiB) default(1) - default(0)(%)
------------------------------------------------------------------------------------------------------------- --------------- --------------------------
All.Prelude.Serial/o-1-space.split.S.splitOnSeq 100k long pattern                                                      102.12                      +5.60
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "\r\n" FL.drain                                                        101.63                      +0.74
All.Prelude.Serial/o-1-space.split.S.parseMany (FL.takeEndBy_ (== lf) FL.drain)                                        101.63                      +0.57
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "aaaa" FL.drain                                                        101.51                      +0.54
All.Prelude.Serial/o-1-space.split.S.splitOnSuffixSeq "abcdefghijklmnopqrstuvwxyz" FL.drain (1/10)                      10.30                      +0.31
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "abcdefghi" FL.drain                                                   102.08                      +0.16
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "a" FL.drain                                                           102.16                      +0.05
All.Prelude.Serial/o-1-space.split/toChunks.S.splitOnSeqUtf8 "abcdefghijklmnopqrstuvwxyz" FL.drain (1/10)               10.70                      +0.01
All.Prelude.Serial/o-1-space.split.S.splitOnSuffixSeq "\r\n" FL.drain                                                  101.51                       0.00
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "abcdefgh" FL.drain                                                    101.61                      -0.00
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "" FL.drain                                                            101.51                      -0.00
All.Prelude.Serial/o-1-space.split.S.wordsBy isSpace FL.drain                                                          101.51                      -0.00
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "catcatcatcatcat" FL.drain                                             102.05                      -0.01
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "abcdefghijklmnopqrstuvwxyz" FL.drain                                  102.08                      -0.04
All.Prelude.Serial/o-1-space.split.S.splitOnSuffixSeq "\n" FL.drain                                                    102.21                      -0.05
All.Prelude.Serial/o-1-space.split.S.splitOnSuffixSeq "" FL.drain                                                      101.61                      -0.10
All.Prelude.Serial/o-1-space.split.S.splitOnSuffix (== lf) FL.drain                                                    102.18                      -0.10
All.Prelude.Serial/o-1-space.split.S.foldMany (FL.takeEndBy_ (== lf) FL.drain)                                         102.15                      -0.11
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "aa" FL.drain                                                          101.63                      -0.12
All.Prelude.Serial/o-1-space.split.S.splitOn (== lf) FL.drain                                                          102.09                      -0.48
All.Prelude.Serial/o-1-space.split.S.splitWithSuffix (== lf) FL.drain                                                  102.05                      -0.54
All.Prelude.Serial/o-1-space.split.S.splitOnSeq "\n" FL.drain                                                          102.11                      -0.59
All.Prelude.Serial/o-1-space.split/toChunks.S.splitOnSeqUtf8 "abcdefgh" FL.drain . US.decodeUtf8Arrays (1/10)           10.28                      -1.02
```

