### PR TITLE
Make regression checking CI dispatchable manually

### DIFF
--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -1,7 +1,8 @@
 name: Regression checking
 
-on: pull_request
-
+on:
+  workflow_dispatch:
+  pull_request:
 
 # References:
 # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow


### PR DESCRIPTION
Sometimes the github CI runs on an incorrect branch/commit. We need a way to manually run the CI on a specific commit.