### PR TITLE
Add TreeArray variant to Arrays

### DIFF
--- a/core/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
+++ b/core/src/Streamly/Internal/Data/Array/Foreign/Mut/Type.hs
@@ -29,6 +29,7 @@ module Streamly.Internal.Data.Array.Foreign.Mut.Type
 
     -- *** Uninitialized Arrays
     , newArray
+    , newArrayUnitialized
     , newArrayAligned
     , newArrayAlignedUnmanaged
     , newArrayWith
@@ -526,6 +527,13 @@ newArrayAligned = newArrayWith (\s a -> liftIO $ newAlignedArrayContents s a)
 {-# INLINE newArray #-}
 newArray :: forall m a. (MonadIO m, Storable a) => Int -> m (Array a)
 newArray = newArrayAligned (alignment (undefined :: a))
+
+newArrayUnitialized :: forall m a. (MonadIO m, Storable a) => Int -> m (Array a)
+newArrayUnitialized count = do
+    arr <- newArrayAligned (alignment (undefined :: a)) count
+    -- set end of array to allocated boundary
+    -- declaring that the array is full
+    return $ arr { aEnd = aBound arr }
 
 -- | Allocate an Array of the given size and run an IO action passing the array
 -- start pointer.

--- a/core/src/Streamly/Internal/Data/Array/Mut/Type.hs
+++ b/core/src/Streamly/Internal/Data/Array/Mut/Type.hs
@@ -20,6 +20,7 @@ module Streamly.Internal.Data.Array.Mut.Type
 
     -- *** Uninitialized Arrays
     , newArray
+    , newArrayUninitialized
     -- , newArrayWith
 
     -- *** From streams
@@ -238,6 +239,10 @@ newArray n@(I# n#) =
                   (# s1#, arr# #) ->
                       let ma = Array arr# 0 0 n
                        in (# s1#, ma #)
+
+{-# INLINE newArrayUninitialized #-}
+newArrayUninitialized :: forall m a. MonadIO m => Int -> m (Array a)
+newArrayUninitialized = fmap (\arr -> arr { arrLen = arrTrueLen arr }) . newArray
 
 -------------------------------------------------------------------------------
 -- Random writes

--- a/core/src/Streamly/Internal/Data/Array/Tree/Type.hs
+++ b/core/src/Streamly/Internal/Data/Array/Tree/Type.hs
@@ -1,28 +1,68 @@
 module Streamly.Internal.Data.Array.Tree.Type where
 
 import Control.Monad.IO.Class (MonadIO (..))
-import qualified Streamly.Internal.Data.Array.Foreign.Mut as U
-import qualified Streamly.Internal.Data.Array as B
+import qualified Streamly.Internal.Data.Array as BArray
+import qualified Streamly.Internal.Data.Array.Foreign.Mut as UArray
 import qualified Streamly.Internal.Data.Fold as F
+import Streamly.Internal.Data.Unboxed (Storable)
 
-treeWidth :: Int
-treeWidth = 8
+branchWidth :: Int
+branchWidth = 8
+
+leafWidth :: Int
+leafWidth = 1024
+
+type Count = Int
+
+type Depth = Int
+
+type Index = Int
 
 -- A tree of unboxed, mutable arrays with a pre-defined
 -- fixed width each
-data TreeArray a = Branch {offset :: U.Array Int, children :: B.Array (Maybe (TreeArray a))} | Leaf (U.Array a)
+data TreeArray a = TreeArray Count Depth (TreeArrayInternal a)
 
-newTreeArray :: MonadIO m => m (TreeArray a)
+data TreeArrayInternal a = Branch (BArray.Array (TreeArrayInternal a)) | Leaf (UArray.Array a)
+
+newTreeArray :: (MonadIO m, Storable a) => m (TreeArray a)
 newTreeArray = do
-    offset <- U.newArray treeWidth
-    children <- F.finish $ B.writeN treeWidth
-    return $ Branch offset children
+  leafArray <- UArray.newArray leafWidth
+  return $ TreeArray 0 0 $ Leaf leafArray
 
-insertAtOffset :: a -> Int -> TreeArray a -> TreeArray a
-insertAtOffset = undefined
+-- TODO: Handle case where leaf array becomes full
+append :: (MonadIO m, Storable a) => a -> TreeArray a -> m ()
+append v (TreeArray count depth treeArray) =
+  go depth (count + 1) v treeArray
+  where
+    go :: (MonadIO m, Storable a) => Depth -> Index -> a -> TreeArrayInternal a -> m ()
+    go _ i v (Leaf leafArray) = UArray.putIndex i v leafArray
+    go d i v (Branch branchArray) =
+      let -- branch will always have a depth greater than 0
+          fullChildTree = (d - 1) ^ branchWidth * leafWidth
+          -- index of next branch to visit
+          childIndex = i `quot` fullChildTree
+          -- index spilled over from skipping children
+          spillOver = i `rem` fullChildTree
+       in go (d - 1) spillOver v $ BArray.getIndexUnsafe branchArray childIndex
 
-findAtOffset :: TreeArray a -> Int -> Maybe a
-findAtOffset = undefined
+getIndex :: (MonadIO m, Storable a) => Index -> TreeArray a -> m a
+getIndex i (TreeArray count depth treeArray) = do
+  if i < count then go depth i treeArray else invalidIndex "findAtOffset" i
+  where
+    go :: (MonadIO m, Storable a) => Depth -> Index -> TreeArrayInternal a -> m a
+    go _ i (Leaf leafArray) = UArray.getIndex i leafArray
+    go d i (Branch branchArray) =
+      let -- branch will always have a depth greater than 0
+          fullChildTree = (d - 1) ^ branchWidth * leafWidth
+          -- index of next branch to visit
+          childIndex = i `quot` fullChildTree
+          -- index spilled over from skipping children
+          spillOver = i `rem` fullChildTree
+       in go (d - 1) spillOver $ BArray.getIndexUnsafe branchArray childIndex
+
+invalidIndex :: String -> Int -> a
+invalidIndex label i =
+  error $ label ++ " : invalid array index " ++ show i
 
 deleteAtOffset :: Int -> Int -> TreeArray a -> TreeArray a
 deleteAtOffset = undefined

--- a/core/src/Streamly/Internal/Data/Array/Tree/Type.hs
+++ b/core/src/Streamly/Internal/Data/Array/Tree/Type.hs
@@ -1,16 +1,17 @@
-module Streamly.Internal.Data.Array.Tree.Type where
+module Streamly.Internal.Data.Array.Tree.Type (TreeArray (count, depth), newArray, getIndex, snoc, appendN) where
 
 import Control.Monad.IO.Class (MonadIO (..))
-import qualified Streamly.Internal.Data.Array as BArray
 import qualified Streamly.Internal.Data.Array.Foreign.Mut as UArray
-import qualified Streamly.Internal.Data.Fold as F
+import qualified Streamly.Internal.Data.Array.Mut.Type as BArray
+import qualified Streamly.Internal.Data.Fold.Type as FL
 import Streamly.Internal.Data.Unboxed (Storable)
+import Debug.Trace (trace)
 
 branchWidth :: Int
-branchWidth = 8
+branchWidth = 2
 
 leafWidth :: Int
-leafWidth = 1024
+leafWidth = 2
 
 type Count = Int
 
@@ -20,31 +21,73 @@ type Index = Int
 
 -- A tree of unboxed, mutable arrays with a pre-defined
 -- fixed width each
-data TreeArray a = TreeArray Count Depth (TreeArrayInternal a)
+data TreeArray a = TreeArray {count :: Count, depth :: Depth, _root :: TreeArrayInternal a}
 
 data TreeArrayInternal a = Branch (BArray.Array (TreeArrayInternal a)) | Leaf (UArray.Array a)
 
-newTreeArray :: (MonadIO m, Storable a) => m (TreeArray a)
-newTreeArray = do
-  leafArray <- UArray.newArray leafWidth
-  return $ TreeArray 0 0 $ Leaf leafArray
+newArray :: MonadIO m => m (TreeArray a)
+newArray = TreeArray 0 1 <$> newBranch
+
+newBranch :: MonadIO m => m (TreeArrayInternal a)
+newBranch = Branch <$> BArray.newArrayUninitialized branchWidth
+
+newLeaf :: (MonadIO m, Storable a) => m (TreeArrayInternal a)
+newLeaf = Leaf <$> UArray.newArrayUnitialized leafWidth
 
 -- TODO: Handle case where leaf array becomes full
-append :: (MonadIO m, Storable a) => a -> TreeArray a -> m ()
-append v (TreeArray count depth treeArray) =
-  go depth (count + 1) v treeArray
+snoc :: (MonadIO m, Storable a, Show a) => a -> TreeArray a -> m (TreeArray a)
+snoc v t@(TreeArray count depth b@(Branch branchArray)) =
+  -- tree is full, add one layer of depth to it.
+  if count == branchWidth ^ depth * leafWidth
+    then
+      ( do
+          let copyBranch = Branch $ BArray.getSlice 0 branchWidth branchArray
+          _ <- BArray.putIndex branchArray 0 copyBranch
+          branch <- newBranch
+          _ <- BArray.putIndex branchArray 1 branch
+          _ <- go depth 0 v branch
+          return $ TreeArray (count + 1) (depth + 1) b
+      )
+    else
+      ( do
+          _ <- go depth count v b
+          return $ TreeArray (count + 1) depth b
+      )
   where
-    go :: (MonadIO m, Storable a) => Depth -> Index -> a -> TreeArrayInternal a -> m ()
+    go :: (MonadIO m, Storable a, Show a) => Depth -> Index -> a -> TreeArrayInternal a -> m ()
+    -- INVARIANT: go should never be called on leaf with
+    -- an index exceeding leaf width
     go _ i v (Leaf leafArray) = UArray.putIndex i v leafArray
-    go d i v (Branch branchArray) =
+    go d i v b@(Branch branchArray) =
       let -- branch will always have a depth greater than 0
-          fullChildTree = (d - 1) ^ branchWidth * leafWidth
+          -- total elements that can be stored by a full child tree
+          fullChildTree = branchWidth ^ (d - 1) * leafWidth
           -- index of next branch to visit
           childIndex = i `quot` fullChildTree
           -- index spilled over from skipping children
           spillOver = i `rem` fullChildTree
-       in go (d - 1) spillOver v $ BArray.getIndexUnsafe branchArray childIndex
+          a = trace $ "depth " ++ show d ++ " index " ++ show i
+       in case (depth == 1, spillOver == 0) of
+            -- reached last level and existing leafs are full
+            -- allocate new leaf and snoc element to it
+            (True, True) -> do
+              leaf <- newLeaf
+              _ <- BArray.putIndex branchArray childIndex leaf
+              go 0 0 v leaf
+            (True, False) -> do
+              leaf <- BArray.getIndex branchArray childIndex
+              go 0 spillOver v leaf
+            (False, False) -> do
+              go (d - 1) spillOver v b
+            (False, True) -> do
+              branch <- newBranch
+              _ <- BArray.putIndex branchArray childIndex branch
+              go (d - 1) 0 v branch
+snoc _ _ = error "TreeArray root should always be a Branch constructor"
 
+-- | Lookup the element at the given index. Index starts from 0.
+--  /O(d)/ where d is the depth of the tree. depth of tree is proportional
+--  to log of number of elements to the base of `childWidth`.
 getIndex :: (MonadIO m, Storable a) => Index -> TreeArray a -> m a
 getIndex i (TreeArray count depth treeArray) = do
   if i < count then go depth i treeArray else invalidIndex "findAtOffset" i
@@ -53,16 +96,27 @@ getIndex i (TreeArray count depth treeArray) = do
     go _ i (Leaf leafArray) = UArray.getIndex i leafArray
     go d i (Branch branchArray) =
       let -- branch will always have a depth greater than 0
-          fullChildTree = (d - 1) ^ branchWidth * leafWidth
+          fullChildTree = branchWidth ^ (d - 1) * leafWidth
           -- index of next branch to visit
           childIndex = i `quot` fullChildTree
           -- index spilled over from skipping children
           spillOver = i `rem` fullChildTree
-       in go (d - 1) spillOver $ BArray.getIndexUnsafe branchArray childIndex
+       in do
+            child <- BArray.getIndex branchArray childIndex
+            go (d - 1) spillOver child
+
+{-# INLINE_NORMAL appendN #-}
+appendN ::
+  forall m a.
+  (MonadIO m, Storable a, Show a) =>
+  m (TreeArray a) ->
+  Int ->
+  FL.Fold m a (TreeArray a)
+appendN action n = FL.take n $ FL.foldlM' step initial
+  where
+    initial = action
+    step = flip snoc
 
 invalidIndex :: String -> Int -> a
 invalidIndex label i =
   error $ label ++ " : invalid array index " ++ show i
-
-deleteAtOffset :: Int -> Int -> TreeArray a -> TreeArray a
-deleteAtOffset = undefined

--- a/core/src/Streamly/Internal/Data/Array/Tree/Type.hs
+++ b/core/src/Streamly/Internal/Data/Array/Tree/Type.hs
@@ -1,14 +1,22 @@
-module Streamly.Internal.Data.Array.Tree.Type (TreeArray (count, depth), newArray, getIndex, snoc, appendN, read) where
+module Streamly.Internal.Data.Array.Tree.Type
+  ( TreeArray (count, depth),
+    newArray,
+    getIndex,
+    snoc,
+    appendN,
+    read,
+  )
+where
+
+#include "inline.hs"
 
 import Control.Monad.IO.Class (MonadIO (..))
-import Debug.Trace (trace)
 import qualified Streamly.Internal.Data.Array.Foreign.Mut as UArray
 import qualified Streamly.Internal.Data.Array.Mut.Type as BArray
 import qualified Streamly.Internal.Data.Fold.Type as FL
 import qualified Streamly.Internal.Data.Producer as Producer
 import Streamly.Internal.Data.Producer.Type (Producer (..))
 import qualified Streamly.Internal.Data.Stream.StreamD as D
-import qualified Streamly.Internal.Data.Stream.StreamK as K
 import Streamly.Internal.Data.Unboxed (Storable)
 import Streamly.Internal.Data.Unfold.Type (Unfold (..))
 import Prelude hiding (read)
@@ -29,33 +37,37 @@ type Index = Int
 -- fixed width each
 data TreeArray a = TreeArray {count :: Count, depth :: Depth, _root :: TreeArrayInternal a}
 
-data TreeArrayInternal a = Branch (BArray.Array (TreeArrayInternal a)) | Leaf (UArray.Array a)
+data TreeArrayInternal a = Branch {branchArray :: BArray.Array (TreeArrayInternal a)} | Leaf {_leafArray :: UArray.Array a}
 
+{-# INLINE newArray #-}
 newArray :: MonadIO m => m (TreeArray a)
 newArray = TreeArray 0 1 <$> newBranch
 
+{-# INLINE newBranch #-}
 newBranch :: MonadIO m => m (TreeArrayInternal a)
 newBranch = Branch <$> BArray.newArrayUninitialized branchWidth
 
+{-# INLINE newLeaf #-}
 newLeaf :: (MonadIO m, Storable a) => m (TreeArrayInternal a)
 newLeaf = Leaf <$> UArray.newArrayUnitialized leafWidth
 
+{-# INLINE snoc #-}
 snoc :: (MonadIO m, Storable a, Show a) => TreeArray a -> a -> m (TreeArray a)
-snoc t@(TreeArray count d b@(Branch branchArray)) v =
+snoc t@(TreeArray count d root) v =
   -- tree is full, add one layer of depth to it.
   if count == branchWidth ^ d * leafWidth
     then
       ( do
-          let copyBranch = Branch $ BArray.getSlice 0 branchWidth branchArray
-          _ <- BArray.putIndex branchArray 0 copyBranch
-          branch <- newBranch
-          _ <- BArray.putIndex branchArray 1 branch
-          _ <- go d 0 v branch
-          return $ TreeArray (count + 1) (d + 1) b
+          newRoot <- newBranch
+          _ <- BArray.putIndex (branchArray newRoot) 0 root
+          childBranch <- newBranch
+          _ <- BArray.putIndex (branchArray newRoot) 1 childBranch
+          _ <- go d 0 v childBranch
+          return $ TreeArray (count + 1) (d + 1) newRoot
       )
     else
       ( do
-          _ <- go d count v b
+          _ <- go d count v root
           return $ t {count = count + 1}
       )
   where
@@ -91,11 +103,11 @@ snoc t@(TreeArray count d b@(Branch branchArray)) v =
               childBranch <- newBranch
               _ <- BArray.putIndex branchArray childIndex childBranch
               go (d - 1) 0 v childBranch
-snoc _ _ = error "TreeArray root should always be a Branch constructor"
 
 -- | Lookup the element at the given index. Index starts from 0.
 --  /O(d)/ where d is the depth of the tree. depth of tree is proportional
 --  to log of number of elements to the base of `childWidth`.
+{-# INLINE getIndex #-}
 getIndex :: (MonadIO m, Storable a) => TreeArray a -> Index -> m a
 getIndex (TreeArray count depth treeArray) index = do
   if index < count then go depth index treeArray else invalidIndex "findAtOffset" index
@@ -103,17 +115,13 @@ getIndex (TreeArray count depth treeArray) index = do
     go :: (MonadIO m, Storable a) => Depth -> Index -> TreeArrayInternal a -> m a
     go _ i (Leaf leafArray) = UArray.getIndex i leafArray
     go d i (Branch branchArray) =
-      if d == 0 then error $ "reached here with index " ++ show index ++ " and depth " ++ show depth
-      else
       let -- branch will always have a depth greater than 0
           fullChildTree = branchWidth ^ (d - 1) * leafWidth
           -- index of next branch to visit
           childIndex = i `quot` fullChildTree
           -- index spilled over from skipping children
           spillOver = i `rem` fullChildTree
-       in do
-          liftIO $ print $ "go with d " ++ show d ++ " i " ++ show i
-          go (d - 1) spillOver =<< BArray.getIndex branchArray childIndex
+       in go (d - 1) spillOver =<< BArray.getIndex branchArray childIndex
 
 {-# INLINE_NORMAL appendN #-}
 appendN ::
@@ -132,13 +140,11 @@ invalidIndex label i =
   error $ label ++ " : invalid array index " ++ show i
 
 -- | Resumable unfold of a tree array.
---
+
 {-# INLINE_NORMAL producer #-}
 producer :: (MonadIO m, Storable a) => Producer m (TreeArray a) a
 producer = Producer step inject extract
-
-    where
-
+  where
     {-# INLINE inject #-}
     inject arr = return (arr, 0)
 
@@ -147,13 +153,13 @@ producer = Producer step inject extract
 
     {-# INLINE_LATE step #-}
     step (arr, i)
-        | i >= count arr = return D.Stop
+      | i >= count arr = return D.Stop
     step (arr, i) = do
-        x <- getIndex arr i
-        return $ D.Yield x (arr, i + 1)
+      x <- getIndex arr i
+      return $ D.Yield x (arr, i + 1)
 
 -- | Unfold an array into a stream.
---
+
 {-# INLINE_NORMAL read #-}
 read :: (MonadIO m, Storable a) => Unfold m (TreeArray a) a
 read = Producer.simplify producer

--- a/core/src/Streamly/Internal/Data/Array/Tree/Type.hs
+++ b/core/src/Streamly/Internal/Data/Array/Tree/Type.hs
@@ -1,11 +1,17 @@
-module Streamly.Internal.Data.Array.Tree.Type (TreeArray (count, depth), newArray, getIndex, snoc, appendN) where
+module Streamly.Internal.Data.Array.Tree.Type (TreeArray (count, depth), newArray, getIndex, snoc, appendN, read) where
 
 import Control.Monad.IO.Class (MonadIO (..))
+import Debug.Trace (trace)
 import qualified Streamly.Internal.Data.Array.Foreign.Mut as UArray
 import qualified Streamly.Internal.Data.Array.Mut.Type as BArray
 import qualified Streamly.Internal.Data.Fold.Type as FL
+import qualified Streamly.Internal.Data.Producer as Producer
+import Streamly.Internal.Data.Producer.Type (Producer (..))
+import qualified Streamly.Internal.Data.Stream.StreamD as D
+import qualified Streamly.Internal.Data.Stream.StreamK as K
 import Streamly.Internal.Data.Unboxed (Storable)
-import Debug.Trace (trace)
+import Streamly.Internal.Data.Unfold.Type (Unfold (..))
+import Prelude hiding (read)
 
 branchWidth :: Int
 branchWidth = 2
@@ -34,24 +40,23 @@ newBranch = Branch <$> BArray.newArrayUninitialized branchWidth
 newLeaf :: (MonadIO m, Storable a) => m (TreeArrayInternal a)
 newLeaf = Leaf <$> UArray.newArrayUnitialized leafWidth
 
--- TODO: Handle case where leaf array becomes full
-snoc :: (MonadIO m, Storable a, Show a) => a -> TreeArray a -> m (TreeArray a)
-snoc v t@(TreeArray count depth b@(Branch branchArray)) =
+snoc :: (MonadIO m, Storable a, Show a) => TreeArray a -> a -> m (TreeArray a)
+snoc t@(TreeArray count d b@(Branch branchArray)) v =
   -- tree is full, add one layer of depth to it.
-  if count == branchWidth ^ depth * leafWidth
+  if count == branchWidth ^ d * leafWidth
     then
       ( do
           let copyBranch = Branch $ BArray.getSlice 0 branchWidth branchArray
           _ <- BArray.putIndex branchArray 0 copyBranch
           branch <- newBranch
           _ <- BArray.putIndex branchArray 1 branch
-          _ <- go depth 0 v branch
-          return $ TreeArray (count + 1) (depth + 1) b
+          _ <- go d 0 v branch
+          return $ TreeArray (count + 1) (d + 1) b
       )
     else
       ( do
-          _ <- go depth count v b
-          return $ TreeArray (count + 1) depth b
+          _ <- go d count v b
+          return $ t {count = count + 1}
       )
   where
     go :: (MonadIO m, Storable a, Show a) => Depth -> Index -> a -> TreeArrayInternal a -> m ()
@@ -66,35 +71,40 @@ snoc v t@(TreeArray count depth b@(Branch branchArray)) =
           childIndex = i `quot` fullChildTree
           -- index spilled over from skipping children
           spillOver = i `rem` fullChildTree
-          a = trace $ "depth " ++ show d ++ " index " ++ show i
-       in case (depth == 1, spillOver == 0) of
+       in case (d == 1, spillOver == 0) of
             -- reached last level and existing leafs are full
             -- allocate new leaf and snoc element to it
             (True, True) -> do
               leaf <- newLeaf
               _ <- BArray.putIndex branchArray childIndex leaf
               go 0 0 v leaf
-            (True, False) -> do
-              leaf <- BArray.getIndex branchArray childIndex
-              go 0 spillOver v leaf
-            (False, False) -> do
-              go (d - 1) spillOver v b
+            -- reached last level but existing leaf has space
+            -- recurse into child
+            (True, False) ->
+              go 0 spillOver v =<< BArray.getIndex branchArray childIndex
+            -- did not reach last level and existing leaf has space
+            (False, False) ->
+              go (d - 1) spillOver v =<< BArray.getIndex branchArray childIndex
+            -- did not reach last level and existing leaf does not have
+            -- space. Allocate a new child branch and recurse into it
             (False, True) -> do
-              branch <- newBranch
-              _ <- BArray.putIndex branchArray childIndex branch
-              go (d - 1) 0 v branch
+              childBranch <- newBranch
+              _ <- BArray.putIndex branchArray childIndex childBranch
+              go (d - 1) 0 v childBranch
 snoc _ _ = error "TreeArray root should always be a Branch constructor"
 
 -- | Lookup the element at the given index. Index starts from 0.
 --  /O(d)/ where d is the depth of the tree. depth of tree is proportional
 --  to log of number of elements to the base of `childWidth`.
-getIndex :: (MonadIO m, Storable a) => Index -> TreeArray a -> m a
-getIndex i (TreeArray count depth treeArray) = do
-  if i < count then go depth i treeArray else invalidIndex "findAtOffset" i
+getIndex :: (MonadIO m, Storable a) => TreeArray a -> Index -> m a
+getIndex (TreeArray count depth treeArray) index = do
+  if index < count then go depth index treeArray else invalidIndex "findAtOffset" index
   where
     go :: (MonadIO m, Storable a) => Depth -> Index -> TreeArrayInternal a -> m a
     go _ i (Leaf leafArray) = UArray.getIndex i leafArray
     go d i (Branch branchArray) =
+      if d == 0 then error $ "reached here with index " ++ show index ++ " and depth " ++ show depth
+      else
       let -- branch will always have a depth greater than 0
           fullChildTree = branchWidth ^ (d - 1) * leafWidth
           -- index of next branch to visit
@@ -102,8 +112,8 @@ getIndex i (TreeArray count depth treeArray) = do
           -- index spilled over from skipping children
           spillOver = i `rem` fullChildTree
        in do
-            child <- BArray.getIndex branchArray childIndex
-            go (d - 1) spillOver child
+          liftIO $ print $ "go with d " ++ show d ++ " i " ++ show i
+          go (d - 1) spillOver =<< BArray.getIndex branchArray childIndex
 
 {-# INLINE_NORMAL appendN #-}
 appendN ::
@@ -115,8 +125,35 @@ appendN ::
 appendN action n = FL.take n $ FL.foldlM' step initial
   where
     initial = action
-    step = flip snoc
+    step = snoc
 
 invalidIndex :: String -> Int -> a
 invalidIndex label i =
   error $ label ++ " : invalid array index " ++ show i
+
+-- | Resumable unfold of a tree array.
+--
+{-# INLINE_NORMAL producer #-}
+producer :: (MonadIO m, Storable a) => Producer m (TreeArray a) a
+producer = Producer step inject extract
+
+    where
+
+    {-# INLINE inject #-}
+    inject arr = return (arr, 0)
+
+    {-# INLINE extract #-}
+    extract (arr, _) = return arr
+
+    {-# INLINE_LATE step #-}
+    step (arr, i)
+        | i >= count arr = return D.Stop
+    step (arr, i) = do
+        x <- getIndex arr i
+        return $ D.Yield x (arr, i + 1)
+
+-- | Unfold an array into a stream.
+--
+{-# INLINE_NORMAL read #-}
+read :: (MonadIO m, Storable a) => Unfold m (TreeArray a) a
+read = Producer.simplify producer

--- a/core/src/Streamly/Internal/Data/Array/Tree/Type.hs
+++ b/core/src/Streamly/Internal/Data/Array/Tree/Type.hs
@@ -1,0 +1,28 @@
+module Streamly.Internal.Data.Array.Tree.Type where
+
+import Control.Monad.IO.Class (MonadIO (..))
+import qualified Streamly.Internal.Data.Array.Foreign.Mut as U
+import qualified Streamly.Internal.Data.Array as B
+import qualified Streamly.Internal.Data.Fold as F
+
+treeWidth :: Int
+treeWidth = 8
+
+-- A tree of unboxed, mutable arrays with a pre-defined
+-- fixed width each
+data TreeArray a = Branch {offset :: U.Array Int, children :: B.Array (Maybe (TreeArray a))} | Leaf (U.Array a)
+
+newTreeArray :: MonadIO m => m (TreeArray a)
+newTreeArray = do
+    offset <- U.newArray treeWidth
+    children <- F.finish $ B.writeN treeWidth
+    return $ Branch offset children
+
+insertAtOffset :: a -> Int -> TreeArray a -> TreeArray a
+insertAtOffset = undefined
+
+findAtOffset :: TreeArray a -> Int -> Maybe a
+findAtOffset = undefined
+
+deleteAtOffset :: Int -> Int -> TreeArray a -> TreeArray a
+deleteAtOffset = undefined

--- a/core/streamly-core.cabal
+++ b/core/streamly-core.cabal
@@ -334,6 +334,9 @@ library
                      , Streamly.Data.Fold.Tee
                      , Streamly.Data.Array.Foreign
 
+                     -- temporary
+                     , Streamly.Internal.Data.Array.Tree.Type
+
     build-depends:
                     -- Core libraries shipped with ghc, the min and max
                     -- constraints of these libraries should match with

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -99,6 +99,7 @@ extra-source-files:
     test/Streamly/Test/Data/Array/Prim/Pinned.hs
     test/Streamly/Test/Data/Array/Foreign.hs
     test/Streamly/Test/Data/Array/Stream/Foreign.hs
+    test/Streamly/Test/Data/Array/TreeArray.hs
     test/Streamly/Test/Data/Parser/ParserD.hs
     test/Streamly/Test/FileSystem/Event.hs
     test/Streamly/Test/FileSystem/Event/Common.hs
@@ -650,6 +651,9 @@ library
                      , Streamly.Data.Fold
                      , Streamly.Data.Fold.Tee
                      , Streamly.Data.Array.Foreign
+
+                     -- temporary
+                     , Streamly.Internal.Data.Array.Tree.Type
 
     other-modules:
                        Streamly.Data.Array

--- a/test/Streamly/Test/Data/Array.hs
+++ b/test/Streamly/Test/Data/Array.hs
@@ -10,7 +10,10 @@ module Streamly.Test.Data.Array (main) where
 
 #include "Streamly/Test/Data/Array/CommonImports.hs"
 
+import Streamly.Test.Common (listEquals, checkListEqual)
 import qualified Streamly.Internal.Data.Array as A
+import qualified Streamly.Internal.Data.Array.Tree.Type as T
+import qualified Streamly.Internal.Data.Stream.IsStream.Eliminate as S
 type Array = A.Array
 
 moduleName :: String
@@ -33,6 +36,23 @@ testFromList =
                     xs <- run $ S.toList $ (S.unfold A.read) arr
                     assert (xs == list)
 
+testTreeAppendCount :: Property
+testTreeAppendCount =
+    forAll (choose (0, maxArrLen)) $ \len ->
+      forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
+        monadicIO $ do
+          arr <- S.fold (T.appendN T.newArray $ length list) $ S.fromList list
+          assert (T.count arr == length list)
+
+testTreeAppendRead :: Property
+testTreeAppendRead =
+  forAll (choose (0, 7)) $ \len ->
+    forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
+      monadicIO $ do
+        arr <- S.fold (T.appendN T.newArray $ length list) $ S.fromList list
+        readArr <- S.toList $ S.unfold T.read arr
+        assert (readArr == list)
+
 testLengthFromStream :: Property
 testLengthFromStream = genericTestFrom (const A.fromStream)
 
@@ -48,3 +68,5 @@ main =
             prop "toStream . fromStream === id" testFromStreamToStream
             prop "read . write === id" testFoldUnfold
             prop "fromList" testFromList
+            prop "testTreeAppendCount" testTreeAppendCount
+            prop "testTreeAppendRead" testTreeAppendRead

--- a/test/Streamly/Test/Data/Array.hs
+++ b/test/Streamly/Test/Data/Array.hs
@@ -10,10 +10,7 @@ module Streamly.Test.Data.Array (main) where
 
 #include "Streamly/Test/Data/Array/CommonImports.hs"
 
-import Streamly.Test.Common (listEquals, checkListEqual)
 import qualified Streamly.Internal.Data.Array as A
-import qualified Streamly.Internal.Data.Array.Tree.Type as T
-import qualified Streamly.Internal.Data.Stream.IsStream.Eliminate as S
 type Array = A.Array
 
 moduleName :: String
@@ -36,23 +33,6 @@ testFromList =
                     xs <- run $ S.toList $ (S.unfold A.read) arr
                     assert (xs == list)
 
-testTreeAppendCount :: Property
-testTreeAppendCount =
-    forAll (choose (0, maxArrLen)) $ \len ->
-      forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
-        monadicIO $ do
-          arr <- S.fold (T.appendN T.newArray $ length list) $ S.fromList list
-          assert (T.count arr == length list)
-
-testTreeAppendRead :: Property
-testTreeAppendRead =
-  forAll (choose (0, 7)) $ \len ->
-    forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
-      monadicIO $ do
-        arr <- S.fold (T.appendN T.newArray $ length list) $ S.fromList list
-        readArr <- S.toList $ S.unfold T.read arr
-        assert (readArr == list)
-
 testLengthFromStream :: Property
 testLengthFromStream = genericTestFrom (const A.fromStream)
 
@@ -68,5 +48,3 @@ main =
             prop "toStream . fromStream === id" testFromStreamToStream
             prop "read . write === id" testFoldUnfold
             prop "fromList" testFromList
-            prop "testTreeAppendCount" testTreeAppendCount
-            prop "testTreeAppendRead" testTreeAppendRead

--- a/test/Streamly/Test/Data/Array/TreeArray.hs
+++ b/test/Streamly/Test/Data/Array/TreeArray.hs
@@ -1,0 +1,64 @@
+module Streamly.Test.Data.Array.TreeArray (main) where
+
+import Streamly.Internal.Data.Unboxed (sizeOf)
+
+import Test.Hspec.QuickCheck
+import Test.QuickCheck (Property, forAll, Gen, vectorOf, arbitrary, choose)
+import Test.QuickCheck.Monadic (monadicIO, assert)
+import Test.Hspec as H
+
+import qualified Streamly.Prelude as S
+import qualified Streamly.Internal.Data.Array.Tree.Type as T
+
+-- Coverage build takes too long with default number of tests
+maxTestCount :: Int
+#ifdef DEVBUILD
+maxTestCount = 100
+#else
+maxTestCount = 10
+#endif
+
+-- helper methods
+allocOverhead :: Int
+allocOverhead = 2 * sizeOf (undefined :: Int)
+
+-- XXX this should be in sync with the defaultChunkSize in Array code, or we
+-- should expose that and use that. For fast testing we could reduce the
+-- defaultChunkSize under CPP conditionals.
+--
+defaultChunkSize :: Int
+defaultChunkSize = 32 * k - allocOverhead
+   where k = 1024
+
+maxArrLen :: Int
+maxArrLen = defaultChunkSize * 8
+
+moduleName :: String
+moduleName = "Data.Array.TreeArray"
+
+testAppend :: Property
+testAppend =
+  forAll (choose (0, maxArrLen)) $ \len ->
+    forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
+      monadicIO $ do
+        arr <- S.fold (T.appendN T.newArray $ length list) $ S.fromList list
+        assert (T.count arr == length list)
+
+testRead :: Property
+testRead =
+  forAll (choose (0, 7)) $ \len ->
+    forAll (vectorOf len (arbitrary :: Gen Int)) $ \list ->
+      monadicIO $ do
+        arr <- S.fold (T.appendN T.newArray $ length list) $ S.fromList list
+        readArr <- S.toList $ S.unfold T.read arr
+        assert (readArr == list)
+
+main :: IO ()
+main =
+  hspec $
+    H.parallel $
+      modifyMaxSuccess (const maxTestCount) $ do
+        describe moduleName $ do
+          describe "Construction" $ do
+            prop "testAppend" testAppend
+            prop "testRead" testRead

--- a/test/streamly-tests.cabal
+++ b/test/streamly-tests.cabal
@@ -241,6 +241,12 @@ test-suite Data.Array.Foreign
   main-is: Streamly/Test/Data/Array/Foreign.hs
   ghc-options: -main-is Streamly.Test.Data.Array.Foreign.main
 
+test-suite Data.Array.TreeArray
+  import: test-options
+  type: exitcode-stdio-1.0
+  main-is: Streamly/Test/Data/Array/TreeArray.hs
+  ghc-options: -main-is Streamly.Test.Data.Array.TreeArray.main
+
 test-suite Data.Array.Stream.Foreign
   import: test-options
   type: exitcode-stdio-1.0


### PR DESCRIPTION
A TreeArray grows in fixed size chunks allocated as mutable unboxed arrays. It is useful for cases where are large amount of data of unknown length needs to be written to an array. A typical array after becoming full would have to reallocate double it's original size, increasing peak memory usage. A tree array will allocate new memory in fixed sized chunks keeping peak memory usage closer to actual memory usage.

There is also the concern that for very large data use cases, an array may not find a continuous of memory to allocate. In such case again, tree array with it's smaller fixed size allocation will still be able to operate.

A TreeArray has configurable `branchWidth` i.e. the number of children each branch can have and configurable `leafWidth` i.e. the number of elements a single leaf can store.