### PR TITLE
core: add assert.hs to extra-source-files

### DIFF
--- a/core/streamly-core.cabal
+++ b/core/streamly-core.cabal
@@ -22,6 +22,7 @@ extra-source-files:
     -- This is duplicated
     src/Streamly/Internal/Data/Stream/Instances.hs
     src/Streamly/Internal/Data/Array/ArrayMacros.h
+    src/assert.hs
     src/inline.hs
 
     src/Streamly/Internal/Data/Time/Clock/config-clock.h


### PR DESCRIPTION
See https://github.com/haskell/cabal/issues/8406

The issue is easily reproduced by running `cabal install --lib --env=/dev/null core/`. `cabal install` first does a sdist, then installs it, so it catches missing `extra-source-files` etc

