### PR TITLE
Refactor Async Channel code for reuse in other stream types

### DIFF
--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -28,6 +28,7 @@ jobs:
         Data.Stream.StreamK:6
         Data.Unfold
         Data.Stream
+        Data.Stream.Async
         FileSystem.Handle
         Prelude.Ahead
         Prelude.Async:12

--- a/src/Streamly/Internal/Data/Stream/Async/Channel.hs
+++ b/src/Streamly/Internal/Data/Stream/Async/Channel.hs
@@ -43,7 +43,7 @@ where
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Streamly.Internal.Control.Concurrent (MonadAsync, askRunInIO)
 import Streamly.Internal.Data.Stream.Async.Channel.Operations
-    (fromChannel, toChannel, toChannelK)
+    (fromChannel, fromChannelK, toChannel, toChannelK)
 import Streamly.Internal.Data.SVar.Type (adaptState)
 
 import qualified Streamly.Internal.Data.Stream as Stream
@@ -53,6 +53,7 @@ import qualified Streamly.Internal.Data.Stream.Async.Channel.Interleave
 import qualified Streamly.Internal.Data.Stream.StreamK.Type as K
 
 import Streamly.Internal.Data.Stream.Async.Channel.Type
+import Streamly.Internal.Data.Stream.Channel.Types
 
 -- | Allocate a channel and evaluate the stream using the channel and the
 -- supplied evaluator function. The evaluator is run in a worker thread.
@@ -69,7 +70,7 @@ withChannelK evaluator modifier input = K.concatEffect action
     action = do
         chan <- Append.newChannel modifier
         toChannelK chan (evaluator chan input)
-        return $ Stream.toStreamK $ fromChannel chan
+        return $ fromChannelK chan
 
 {-# INLINE withInterleaveChannelK #-}
 withInterleaveChannelK :: MonadAsync m =>

--- a/src/Streamly/Internal/Data/Stream/Async/Channel/Dispatcher.hs
+++ b/src/Streamly/Internal/Data/Stream/Async/Channel/Dispatcher.hs
@@ -9,22 +9,8 @@
 --
 module Streamly.Internal.Data.Stream.Async.Channel.Dispatcher
     (
-    -- * Latency collection
-      collectLatency
-
-    -- * Diagnostics
-    , withDiagMVar
-    , dumpSVar
-    , printSVar
-
-    -- * Thread accounting
-    , delThread
-    , modifyThread
-    , allThreadsDone
-
     -- * Dispatching
-    , recordMaxWorkers
-    , pushWorker
+      pushWorker
     , dispatchWorker
     , dispatchWorkerPaced
     , sendWorkerWait
@@ -35,338 +21,33 @@ module Streamly.Internal.Data.Stream.Async.Channel.Dispatcher
 where
 
 import Control.Monad.Trans.Control (MonadBaseControl)
-import Control.Concurrent (takeMVar, tryReadMVar, ThreadId, threadDelay)
-import Control.Concurrent.MVar (tryPutMVar)
-import Control.Exception
-       (assert, catches, throwIO, Handler(..), BlockedIndefinitelyOnMVar(..),
-        BlockedIndefinitelyOnSTM(..))
+import Control.Concurrent (takeMVar, threadDelay)
+import Control.Exception (assert)
 import Control.Monad (when, void)
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Data.Maybe (fromJust, fromMaybe)
-import Data.IORef (IORef, modifyIORef, newIORef, readIORef, writeIORef)
+import Data.IORef (modifyIORef, newIORef, readIORef, writeIORef)
 import Streamly.Internal.Control.ForkLifted (doFork)
-import Streamly.Internal.Data.Atomics
-       (atomicModifyIORefCAS, atomicModifyIORefCAS_, writeBarrier,
-        storeLoadBarrier)
+import Streamly.Internal.Data.Atomics (atomicModifyIORefCAS_, storeLoadBarrier)
 import Streamly.Internal.Data.Time.Clock (Clock(Monotonic), getTime)
 import Streamly.Internal.Data.Time.Units
-       (AbsTime, NanoSecond64(..), MicroSecond64(..), diffAbsTime64,
-        fromRelTime64, toRelTime64, showNanoSecond64, showRelTime64)
-import System.IO (hPutStrLn, stderr)
-
--- import qualified Data.Heap as H
-import qualified Data.Set as S
+       (MicroSecond64(..), diffAbsTime64, fromRelTime64, toRelTime64)
 
 import Streamly.Internal.Data.Stream.Async.Channel.Type
-import Streamly.Internal.Data.Stream.Async.Channel.Worker
-
--------------------------------------------------------------------------------
--- Worker latency data processing
--------------------------------------------------------------------------------
-
--- Every once in a while workers update the latencies and check the yield rate.
--- They return if we are above the expected yield rate. If we check too often
--- it may impact performance, if we check less often we may have a stale
--- picture. We update every minThreadDelay but we translate that into a yield
--- count based on latency so that the checking overhead is little.
---
--- XXX use a generation count to indicate that the value is updated. If the
--- value is updated an existing worker must check it again on the next yield.
--- Otherwise it is possible that we may keep updating it and because of the mod
--- worker keeps skipping it.
-updateWorkerPollingInterval :: YieldRateInfo -> NanoSecond64 -> IO ()
-updateWorkerPollingInterval yinfo latency = do
-    let periodRef = workerPollingInterval yinfo
-        cnt = max 1 $ minThreadDelay `div` latency
-        period = min cnt (fromIntegral magicMaxBuffer)
-
-    writeIORef periodRef (fromIntegral period)
-
-{-# INLINE recordMinMaxLatency #-}
-recordMinMaxLatency :: Channel m a -> NanoSecond64 -> IO ()
-recordMinMaxLatency sv new = do
-    let ss = svarStats sv
-    minLat <- readIORef (minWorkerLatency ss)
-    when (new < minLat || minLat == 0) $
-        writeIORef (minWorkerLatency ss) new
-
-    maxLat <- readIORef (maxWorkerLatency ss)
-    when (new > maxLat) $ writeIORef (maxWorkerLatency ss) new
-
-recordAvgLatency :: Channel m a -> (Count, NanoSecond64) -> IO ()
-recordAvgLatency sv (count, time) = do
-    let ss = svarStats sv
-    modifyIORef (avgWorkerLatency ss) $
-        \(cnt, t) -> (cnt + count, t + time)
-
--- Pour the pending latency stats into a collection bucket
-{-# INLINE collectWorkerPendingLatency #-}
-collectWorkerPendingLatency
-    :: IORef (Count, Count, NanoSecond64)
-    -> IORef (Count, Count, NanoSecond64)
-    -> IO (Count, Maybe (Count, NanoSecond64))
-collectWorkerPendingLatency cur col = do
-    (fcount, count, time) <- atomicModifyIORefCAS cur $ \v -> ((0,0,0), v)
-
-    (fcnt, cnt, t) <- readIORef col
-    let totalCount = fcnt + fcount
-        latCount   = cnt + count
-        latTime    = t + time
-    writeIORef col (totalCount, latCount, latTime)
-
-    assert (latCount == 0 || latTime /= 0) (return ())
-    let latPair =
-            if latCount > 0 && latTime > 0
-            then Just (latCount, latTime)
-            else Nothing
-    return (totalCount, latPair)
-
-{-# INLINE shouldUseCollectedBatch #-}
-shouldUseCollectedBatch
-    :: Count
-    -> NanoSecond64
-    -> NanoSecond64
-    -> NanoSecond64
-    -> Bool
-shouldUseCollectedBatch collectedYields collectedTime newLat prevLat =
-    let r = fromIntegral newLat / fromIntegral prevLat :: Double
-    in     (collectedYields > fromIntegral magicMaxBuffer)
-        || (collectedTime > minThreadDelay)
-        || (prevLat > 0 && (r > 2 || r < 0.5))
-        || (prevLat == 0)
-
--- Returns a triple, (1) yield count since last collection, (2) the base time
--- when we started counting, (3) average latency in the last measurement
--- period. The former two are used for accurate measurement of the going rate
--- whereas the average is used for future estimates e.g. how many workers
--- should be maintained to maintain the rate.
--- CAUTION! keep it in sync with getWorkerLatency
-collectLatency :: Channel m a
-               -> YieldRateInfo
-               -> Bool
-               -> IO (Count, AbsTime, NanoSecond64)
-collectLatency sv yinfo drain = do
-    let cur      = workerPendingLatency yinfo
-        col      = workerCollectedLatency yinfo
-        longTerm = svarAllTimeLatency yinfo
-        measured = workerMeasuredLatency yinfo
-
-    (newCount, newLatPair) <- collectWorkerPendingLatency cur col
-    (lcount, ltime) <- readIORef longTerm
-    prevLat <- readIORef measured
-
-    let newLcount = lcount + newCount
-        retWith lat = return (newLcount, ltime, lat)
-
-    case newLatPair of
-        Nothing -> retWith prevLat
-        Just (count, time) -> do
-            let newLat = time `div` fromIntegral count
-            when (svarInspectMode sv) $ recordMinMaxLatency sv newLat
-            -- When we have collected a significant sized batch we compute the
-            -- new latency using that batch and return the new latency,
-            -- otherwise we return the previous latency derived from the
-            -- previous batch.
-            if shouldUseCollectedBatch newCount time newLat prevLat || drain
-            then do
-                -- XXX make this NOINLINE?
-                updateWorkerPollingInterval yinfo (max newLat prevLat)
-                when (svarInspectMode sv) $ recordAvgLatency sv (count, time)
-                writeIORef col (0, 0, 0)
-                writeIORef measured ((prevLat + newLat) `div` 2)
-                modifyIORef longTerm $ \(_, t) -> (newLcount, t)
-                retWith newLat
-            else retWith prevLat
-
--------------------------------------------------------------------------------
--- Dumping the SVar for debug/diag
--------------------------------------------------------------------------------
-
-dumpSVarStats :: Channel m a -> SVarStats -> IO String
-dumpSVarStats sv ss = do
-    case yieldRateInfo sv of
-        Nothing -> return ()
-        Just yinfo -> do
-            _ <- liftIO $ collectLatency sv yinfo True
-            return ()
-
-    dispatches <- readIORef $ totalDispatches ss
-    maxWrk <- readIORef $ maxWorkers ss
-    maxOq <- readIORef $ maxOutQSize ss
-    -- maxHp <- readIORef $ maxHeapSize ss
-    minLat <- readIORef $ minWorkerLatency ss
-    maxLat <- readIORef $ maxWorkerLatency ss
-    (avgCnt, avgTime) <- readIORef $ avgWorkerLatency ss
-    (svarCnt, svarGainLossCnt, svarLat) <- case yieldRateInfo sv of
-        Nothing -> return (0, 0, 0)
-        Just yinfo -> do
-            (cnt, startTime) <- readIORef $ svarAllTimeLatency yinfo
-            if cnt > 0
-            then do
-                t <- readIORef (svarStopTime ss)
-                gl <- readIORef (svarGainedLostYields yinfo)
-                case t of
-                    Nothing -> do
-                        now <- getTime Monotonic
-                        let interval = diffAbsTime64 now startTime
-                        return (cnt, gl, interval `div` fromIntegral cnt)
-                    Just stopTime -> do
-                        let interval = diffAbsTime64 stopTime startTime
-                        return (cnt, gl, interval `div` fromIntegral cnt)
-            else return (0, 0, 0)
-
-    return $ unlines
-        [ "total dispatches = " <> show dispatches
-        , "max workers = " <> show maxWrk
-        , "max outQSize = " <> show maxOq
-            <> (if minLat > 0
-               then "\nmin worker latency = " <> showNanoSecond64 minLat
-               else "")
-            <> (if maxLat > 0
-               then "\nmax worker latency = " <> showNanoSecond64 maxLat
-               else "")
-            <> (if avgCnt > 0
-                then let lat = avgTime `div` fromIntegral avgCnt
-                     in "\navg worker latency = " <> showNanoSecond64 lat
-                else "")
-            <> (if svarLat > 0
-               then "\nSVar latency = " <> showRelTime64 svarLat
-               else "")
-            <> (if svarCnt > 0
-               then "\nSVar yield count = " <> show svarCnt
-               else "")
-            <> (if svarGainLossCnt > 0
-               then "\nSVar gain/loss yield count = " <> show svarGainLossCnt
-               else "")
-        ]
-
-{-# NOINLINE dumpSVar #-}
-dumpSVar :: Channel m a -> IO String
-dumpSVar sv = do
-    (oqList, oqLen) <- readIORef $ outputQueue sv
-    db <- tryReadMVar $ outputDoorBell sv
-
-    waiting <- readIORef $ needDoorBell sv
-    rthread <- readIORef $ workerThreads sv
-    workers <- readIORef $ workerCount sv
-    stats <- dumpSVarStats sv (svarStats sv)
-
-    return $ unlines
-        [
-          "Creator tid = " <> show (svarCreator sv)
-        , "---------CURRENT STATE-----------"
-        , "outputQueue length computed  = " <> show (length oqList)
-        , "outputQueue length maintained = " <> show oqLen
-        -- XXX print the types of events in the outputQueue, first 5
-        , "outputDoorBell = " <> show db
-        ]
-        <> unlines
-        [ "needDoorBell = " <> show waiting
-        , "running threads = " <> show rthread
-        -- XXX print the status of first 5 threads
-        , "running thread count = " <> show workers
-        ]
-        <> "---------STATS-----------\n"
-        <> stats
-
--- MVar diagnostics has some overhead - around 5% on AsyncT null benchmark, we
--- can keep it on in production to debug problems quickly if and when they
--- happen, but it may result in unexpected output when threads are left hanging
--- until they are GCed because the consumer went away.
-
-{-# NOINLINE mvarExcHandler #-}
-mvarExcHandler :: Channel m a -> String -> BlockedIndefinitelyOnMVar -> IO ()
-mvarExcHandler sv label e@BlockedIndefinitelyOnMVar = do
-    svInfo <- dumpSVar sv
-    hPutStrLn stderr $ label <> " " <> "BlockedIndefinitelyOnMVar\n" <> svInfo
-    throwIO e
-
-{-# NOINLINE stmExcHandler #-}
-stmExcHandler :: Channel m a -> String -> BlockedIndefinitelyOnSTM -> IO ()
-stmExcHandler sv label e@BlockedIndefinitelyOnSTM = do
-    svInfo <- dumpSVar sv
-    hPutStrLn stderr $ label <> " " <> "BlockedIndefinitelyOnSTM\n" <> svInfo
-    throwIO e
-
-withDiagMVar :: Channel m a -> String -> IO () -> IO ()
-withDiagMVar sv label action =
-    if svarInspectMode sv
-    then
-        action `catches` [ Handler (mvarExcHandler sv label)
-                         , Handler (stmExcHandler sv label)
-                         ]
-    else action
-
-printSVar :: Channel m a -> String -> IO ()
-printSVar sv how = do
-    svInfo <- dumpSVar sv
-    hPutStrLn stderr $ "\n" <> how <> "\n" <> svInfo
-
--------------------------------------------------------------------------------
--- Thread accounting
--------------------------------------------------------------------------------
-
--- Thread tracking is needed for two reasons:
---
--- 1) Killing threads on exceptions. Threads may not be left to go away by
--- themselves because they may run for significant times before going away or
--- worse they may be stuck in IO and never go away.
---
--- 2) To know when all threads are done and the stream has ended.
-
-{-# NOINLINE addThread #-}
-addThread :: MonadIO m => Channel m a -> ThreadId -> m ()
-addThread sv tid =
-    liftIO $ modifyIORef (workerThreads sv) (S.insert tid)
-
--- This is cheaper than modifyThread because we do not have to send a
--- outputDoorBell This can make a difference when more workers are being
--- dispatched.
-{-# INLINE delThread #-}
-delThread :: MonadIO m => Channel m a -> ThreadId -> m ()
-delThread sv tid =
-    liftIO $ modifyIORef (workerThreads sv) (S.delete tid)
-
--- If present then delete else add. This takes care of out of order add and
--- delete i.e. a delete arriving before we even added a thread.
--- This occurs when the forked thread is done even before the 'addThread' right
--- after the fork gets a chance to run.
-{-# INLINE modifyThread #-}
-modifyThread :: MonadIO m => Channel m a -> ThreadId -> m ()
-modifyThread sv tid = do
-    changed <- liftIO $ atomicModifyIORefCAS (workerThreads sv) $ \old ->
-        if S.member tid old
-        then let new = S.delete tid old in (new, new)
-        else let new = S.insert tid old in (new, old)
-    when (null changed) $
-         liftIO $ do
-            writeBarrier
-            void $ tryPutMVar (outputDoorBell sv) ()
-
--- | This is safe even if we are adding more threads concurrently because if
--- a child thread is adding another thread then anyway 'workerThreads' will
--- not be empty.
-{-# INLINE allThreadsDone #-}
-allThreadsDone :: MonadIO m => Channel m a -> m Bool
-allThreadsDone sv = liftIO $ S.null <$> readIORef (workerThreads sv)
+import Streamly.Internal.Data.Stream.Channel.Dispatcher
+import Streamly.Internal.Data.Stream.Channel.Types
+import Streamly.Internal.Data.Stream.Channel.Worker
 
 -------------------------------------------------------------------------------
 -- Dispatching workers
 -------------------------------------------------------------------------------
 
-{-# NOINLINE recordMaxWorkers #-}
-recordMaxWorkers :: MonadIO m => Channel m a -> m ()
-recordMaxWorkers sv = liftIO $ do
-    active <- readIORef (workerCount sv)
-    maxWrk <- readIORef (maxWorkers $ svarStats sv)
-    when (active > maxWrk) $ writeIORef (maxWorkers $ svarStats sv) active
-    modifyIORef (totalDispatches $ svarStats sv) (+1)
-
 {-# NOINLINE pushWorker #-}
 pushWorker :: (MonadIO m, MonadBaseControl IO m) => Count -> Channel m a -> m ()
 pushWorker yieldMax sv = do
     liftIO $ atomicModifyIORefCAS_ (workerCount sv) $ \n -> n + 1
-    when (svarInspectMode sv) $ recordMaxWorkers sv
+    when (svarInspectMode sv)
+        $ recordMaxWorkers (workerCount sv) (svarStats sv)
     -- This allocation matters when significant number of workers are being
     -- sent. We allocate it only when needed.
     winfo <-
@@ -381,8 +62,12 @@ pushWorker yieldMax sv = do
                     , workerYieldCount = cntRef
                     , workerLatencyStart = lat
                     }
-    doFork (workLoop sv winfo) (svarMrun sv) (handleChildException sv)
-        >>= addThread sv
+    doFork (workLoop sv winfo) (svarMrun sv) exception
+        >>= addThread (workerThreads sv)
+
+    where
+
+    exception = handleChildException (outputQueue sv) (outputDoorBell sv)
 
 -- Returns:
 -- True: can dispatch more
@@ -454,7 +139,9 @@ dispatchWorkerPaced sv = do
     (svarYields, svarElapsed, wLatency) <- do
         now <- liftIO $ getTime Monotonic
         (yieldCount, baseTime, lat) <-
-            liftIO $ collectLatency sv yinfo False
+            liftIO
+                $ collectLatency
+                    (svarInspectMode sv) (svarStats sv) yinfo False
         let elapsed = fromRelTime64 $ diffAbsTime64 now baseTime
         let latency =
                 if lat == 0
@@ -492,7 +179,7 @@ dispatchWorkerPaced sv = do
                 -- here as it is not a reliable way to ensure there are
                 -- definitely no active workers. When workerCount is 0 we may
                 -- still have a Stop event waiting in the outputQueue.
-                done <- allThreadsDone sv
+                done <- allThreadsDone (workerThreads sv)
                 when done $ void $ do
                     let us = fromRelTime64 (toRelTime64 s) :: MicroSecond64
                     liftIO $ threadDelay (fromIntegral us)
@@ -502,7 +189,7 @@ dispatchWorkerPaced sv = do
                 assert (yields > 0) (return ())
                 updateGainedLostYields yinfo yields
 
-                done <- allThreadsDone sv
+                done <- allThreadsDone (workerThreads sv)
                 when done $ void $ dispatchWorker yields sv
                 return False
             ManyWorkers netWorkers yields -> do
@@ -627,8 +314,12 @@ sendWorkerWait delay dispatch sv = do
         if canDoMore
         then sendWorkerWait delay dispatch sv
         else do
-            liftIO $ withDiagMVar sv "sendWorkerWait: nothing to do"
-                             $ takeMVar (outputDoorBell sv)
+            liftIO
+                $ withDiagMVar
+                    (svarInspectMode sv)
+                    (dumpSVar sv)
+                    "sendWorkerWait: nothing to do"
+                $ takeMVar (outputDoorBell sv)
             (_, len) <- liftIO $ readIORef (outputQueue sv)
             when (len <= 0) $ sendWorkerWait delay dispatch sv
 

--- a/src/Streamly/Internal/Data/Stream/Async/Channel/Type.hs
+++ b/src/Streamly/Internal/Data/Stream/Async/Channel/Type.hs
@@ -8,222 +8,24 @@
 
 module Streamly.Internal.Data.Stream.Async.Channel.Type
     (
-    -- * Parent child communication
-      ThreadAbort (..)
-    , ChildEvent (..)
-
-    -- * SVar
-    , Count (..)
-    , Limit (..)
-    , SVarStats (..)
-    , WorkerInfo (..)
-    , LatencyRange (..)
-    , YieldRateInfo (..)
-    , Channel(..)
-
-    -- * Channel configuration
-    , Rate (..)
-    , Config
-
-    -- ** Default config
-    , magicMaxBuffer
-    , defaultConfig
-
-    -- ** Type cast
-
-    -- ** State accessors
-    , maxThreads
-    , maxBuffer
-    , maxYields
-    , inspectMode
-
-    , rate
-    , avgRate
-    , minRate
-    , maxRate
-    , constRate
-
-    , getMaxThreads
-    , getMaxBuffer
-    , getStreamRate
-    , getStreamLatency
-    , setStreamLatency
-    , getYieldLimit
-    , getInspectMode
-
-    , getYieldRateInfo
-    , newSVarStats
+      Channel(..)
+    , yield
+    , stop
+    , dumpSVar
     )
 where
 
 import Control.Concurrent (ThreadId)
 import Control.Concurrent.MVar (MVar)
-import Control.Exception (SomeException(..), Exception)
-import Data.Int (Int64)
-import Data.IORef (IORef, newIORef)
+import Data.IORef (IORef)
 import Data.Set (Set)
 
 import Streamly.Internal.Control.Concurrent (RunInIO)
+import Streamly.Internal.Data.Stream.Channel.Dispatcher (dumpSVarStats)
+import Streamly.Internal.Data.Stream.Channel.Worker (sendYield, sendStop)
 import Streamly.Internal.Data.Stream.StreamK.Type (Stream)
-import Streamly.Internal.Data.Time.Clock (Clock(Monotonic), getTime)
-import Streamly.Internal.Data.Time.Units (AbsTime, NanoSecond64(..))
 
-newtype Count = Count Int64
-    deriving ( Eq
-             , Read
-             , Show
-             , Enum
-             , Bounded
-             , Num
-             , Real
-             , Integral
-             , Ord
-             )
-
--- XXX We can use maxBound for unlimited?
-
--- This is essentially a 'Maybe Word' type
-data Limit = Unlimited | Limited Word deriving Show
-
-instance Eq Limit where
-    Unlimited == Unlimited = True
-    Unlimited == Limited _ = False
-    Limited _ == Unlimited = False
-    Limited x == Limited y = x == y
-
-instance Ord Limit where
-    Unlimited <= Unlimited = True
-    Unlimited <= Limited _ = False
-    Limited _ <= Unlimited = True
-    Limited x <= Limited y = x <= y
-
-------------------------------------------------------------------------------
--- Parent child thread communication type
-------------------------------------------------------------------------------
-
-data ThreadAbort = ThreadAbort deriving Show
-
-instance Exception ThreadAbort
-
--- | Events that a child thread may send to a parent thread.
-data ChildEvent a =
-      ChildYield a
-    | ChildStop ThreadId (Maybe SomeException)
-
--- | An SVar or a Stream Var is a conduit to the output from multiple streams
--- running concurrently and asynchronously. An SVar can be thought of as an
--- asynchronous IO handle. We can write any number of streams to an SVar in a
--- non-blocking manner and then read them back at any time at any pace.  The
--- SVar would run the streams asynchronously and accumulate results. An SVar
--- may not really execute the stream completely and accumulate all the results.
--- However, it ensures that the reader can read the results at whatever paces
--- it wants to read. The SVar monitors and adapts to the consumer's pace.
---
--- An SVar is a mini scheduler, it has an associated workLoop that holds the
--- stream tasks to be picked and run by a pool of worker threads. It has an
--- associated output queue where the output stream elements are placed by the
--- worker threads. A outputDoorBell is used by the worker threads to intimate the
--- consumer thread about availability of new results in the output queue. More
--- workers are added to the SVar by 'fromStreamVar' on demand if the output
--- produced is not keeping pace with the consumer. On bounded SVars, workers
--- block on the output queue to provide throttling of the producer  when the
--- consumer is not pulling fast enough.  The number of workers may even get
--- reduced depending on the consuming pace.
---
--- New work is enqueued either at the time of creation of the SVar or as a
--- result of executing the parallel combinators i.e. '<|' and '<|>' when the
--- already enqueued computations get evaluated. See 'joinStreamVarAsync'.
-
--- We measure the individual worker latencies to estimate the number of workers
--- needed or the amount of time we have to sleep between dispatches to achieve
--- a particular rate when controlled pace mode it used.
-data WorkerInfo = WorkerInfo
-    { workerYieldMax   :: Count -- 0 means unlimited
-    -- total number of yields by the worker till now
-    , workerYieldCount    :: IORef Count
-    -- yieldCount at start, timestamp
-    , workerLatencyStart  :: IORef (Count, AbsTime)
-    }
-
-data LatencyRange = LatencyRange
-    { minLatency :: NanoSecond64
-    , maxLatency :: NanoSecond64
-    } deriving Show
-
--- Rate control.
-data YieldRateInfo = YieldRateInfo
-    { svarLatencyTarget    :: NanoSecond64
-    , svarLatencyRange     :: LatencyRange
-    , svarRateBuffer       :: Int
-
-    -- [LOCKING] Unlocked access. Modified by the consumer thread and unsafely
-    -- read by the worker threads
-    , svarGainedLostYields :: IORef Count
-
-    -- Actual latency/througput as seen from the consumer side, we count the
-    -- yields and the time it took to generates those yields. This is used to
-    -- increase or decrease the number of workers needed to achieve the desired
-    -- rate. The idle time of workers is adjusted in this, so that we only
-    -- account for the rate when the consumer actually demands data.
-    -- XXX interval latency is enough, we can move this under diagnostics build
-    -- [LOCKING] Unlocked access. Modified by the consumer thread and unsafely
-    -- read by the worker threads
-    , svarAllTimeLatency :: IORef (Count, AbsTime)
-
-    -- XXX Worker latency specified by the user to be used before the first
-    -- actual measurement arrives. Not yet implemented
-    , workerBootstrapLatency :: Maybe NanoSecond64
-
-    -- After how many yields the worker should update the latency information.
-    -- If the latency is high, this count is kept lower and vice-versa.  XXX If
-    -- the latency suddenly becomes too high this count may remain too high for
-    -- long time, in such cases the consumer can change it.
-    -- 0 means no latency computation
-    -- XXX this is derivable from workerMeasuredLatency, can be removed.
-    -- [LOCKING] Unlocked access. Modified by the consumer thread and unsafely
-    -- read by the worker threads
-    , workerPollingInterval :: IORef Count
-
-    -- This is in progress latency stats maintained by the workers which we
-    -- empty into workerCollectedLatency stats at certain intervals - whenever
-    -- we process the stream elements yielded in this period. The first count
-    -- is all yields, the second count is only those yields for which the
-    -- latency was measured to be non-zero (note that if the timer resolution
-    -- is low the measured latency may be zero e.g. on JS platform).
-    -- [LOCKING] Locked access. Modified by the consumer thread as well as
-    -- worker threads. Workers modify it periodically based on
-    -- workerPollingInterval and not on every yield to reduce the locking
-    -- overhead.
-    -- (allYieldCount, yieldCount, timeTaken)
-    , workerPendingLatency   :: IORef (Count, Count, NanoSecond64)
-
-    -- This is the second level stat which is an accmulation from
-    -- workerPendingLatency stats. We keep accumulating latencies in this
-    -- bucket until we have stats for a sufficient period and then we reset it
-    -- to start collecting for the next period and retain the computed average
-    -- latency for the last period in workerMeasuredLatency.
-    -- [LOCKING] Unlocked access. Modified by the consumer thread and unsafely
-    -- read by the worker threads
-    -- (allYieldCount, yieldCount, timeTaken)
-    , workerCollectedLatency :: IORef (Count, Count, NanoSecond64)
-
-    -- Latency as measured by workers, aggregated for the last period.
-    -- [LOCKING] Unlocked access. Modified by the consumer thread and unsafely
-    -- read by the worker threads
-    , workerMeasuredLatency :: IORef NanoSecond64
-    }
-
-data SVarStats = SVarStats {
-      totalDispatches  :: IORef Int
-    , maxWorkers       :: IORef Int
-    , maxOutQSize      :: IORef Int
-    , maxHeapSize      :: IORef Int
-    , maxWorkQSize     :: IORef Int
-    , avgWorkerLatency :: IORef (Count, NanoSecond64)
-    , minWorkerLatency :: IORef NanoSecond64
-    , maxWorkerLatency :: IORef NanoSecond64
-    , svarStopTime     :: IORef (Maybe AbsTime)
-}
+import Streamly.Internal.Data.Stream.Channel.Types
 
 -- IMPORTANT NOTE: we cannot update the SVar after generating it as we have
 -- references to the original SVar stored in several functions which will keep
@@ -310,303 +112,43 @@ data Channel m a = Channel
     , svarCreator    :: ThreadId
     }
 
--------------------------------------------------------------------------------
--- Overall state threaded around a stream
--------------------------------------------------------------------------------
+{-# INLINE yield #-}
+yield :: Channel m a -> Maybe WorkerInfo -> a -> IO Bool
+yield sv winfo x =
+    sendYield
+        (maxBufferLimit sv)
+        (maxWorkerLimit sv)
+        (workerCount sv)
+        winfo
+        (yieldRateInfo sv)
+        (outputQueue sv)
+        (outputDoorBell sv)
+        (ChildYield x)
 
--- | Specifies the stream yield rate in yields per second (@Hertz@).
--- We keep accumulating yield credits at 'rateGoal'. At any point of time we
--- allow only as many yields as we have accumulated as per 'rateGoal' since the
--- start of time. If the consumer or the producer is slower or faster, the
--- actual rate may fall behind or exceed 'rateGoal'.  We try to recover the gap
--- between the two by increasing or decreasing the pull rate from the producer.
--- However, if the gap becomes more than 'rateBuffer' we try to recover only as
--- much as 'rateBuffer'.
---
--- 'rateLow' puts a bound on how low the instantaneous rate can go when
--- recovering the rate gap.  In other words, it determines the maximum yield
--- latency.  Similarly, 'rateHigh' puts a bound on how high the instantaneous
--- rate can go when recovering the rate gap.  In other words, it determines the
--- minimum yield latency. We reduce the latency by increasing concurrency,
--- therefore we can say that it puts an upper bound on concurrency.
---
--- If the 'rateGoal' is 0 or negative the stream never yields a value.
--- If the 'rateBuffer' is 0 or negative we do not attempt to recover.
---
--- /Since: 0.5.0 ("Streamly")/
---
--- @since 0.8.0
-data Rate = Rate
-    { rateLow    :: Double -- ^ The lower rate limit
-    , rateGoal   :: Double -- ^ The target rate we want to achieve
-    , rateHigh   :: Double -- ^ The upper rate limit
-    , rateBuffer :: Int    -- ^ Maximum slack from the goal
-    }
+{-# INLINE stop #-}
+stop :: Channel m a -> Maybe WorkerInfo -> IO ()
+stop sv winfo =
+    sendStop
+        (workerCount sv)
+        winfo
+        (yieldRateInfo sv)
+        (outputQueue sv)
+        (outputDoorBell sv)
 
--- XXX we can put the resettable fields in a oneShotConfig field and others in
--- a persistentConfig field. That way reset would be fast and scalable
--- irrespective of the number of fields.
---
--- XXX make all these Limited types and use phantom types to distinguish them
-
--- | An abstract type for specifying the configuration parameters of a
--- 'Channel'. Use @Config -> Config@ modifier functions to modify the
--- default configuration. See the modifiers for default values.
---
-data Config = Config
-    { -- one shot configuration, automatically reset for each API call
-      -- streamVar   :: Maybe (SVar t m a)
-      _yieldLimit  :: Maybe Count
-
-    -- persistent configuration, state that remains valid until changed by
-    -- an explicit setting via a combinator.
-    , _threadsHigh    :: Limit
-    , _bufferHigh     :: Limit
-
-    -- XXX these two can be collapsed into a single type
-    , _streamLatency  :: Maybe NanoSecond64 -- bootstrap latency
-    , _maxStreamRate  :: Maybe Rate
-    , _inspectMode    :: Bool
-    }
-
--------------------------------------------------------------------------------
--- State defaults and reset
--------------------------------------------------------------------------------
-
--- A magical value for the buffer size arrived at by running the smallest
--- possible task and measuring the optimal value of the buffer for that.  This
--- is obviously dependent on hardware, this figure is based on a 2.2GHz intel
--- core-i7 processor.
-magicMaxBuffer :: Word
-magicMaxBuffer = 1500
-
-defaultMaxThreads, defaultMaxBuffer :: Limit
-defaultMaxThreads = Limited magicMaxBuffer
-defaultMaxBuffer = Limited magicMaxBuffer
-
--- The fields prefixed by an _ are not to be accessed or updated directly but
--- via smart accessor APIs.
-defaultConfig :: Config
-defaultConfig = Config
-    { -- streamVar = Nothing
-      _yieldLimit = Nothing
-    , _threadsHigh = defaultMaxThreads
-    , _bufferHigh = defaultMaxBuffer
-    , _maxStreamRate = Nothing
-    , _streamLatency = Nothing
-    , _inspectMode = False
-    }
-
--------------------------------------------------------------------------------
--- Smart get/set routines for State
--------------------------------------------------------------------------------
-
--- Use get/set routines instead of directly accessing the State fields
-maxYields :: Maybe Int64 -> Config -> Config
-maxYields lim st =
-    st { _yieldLimit =
-            case lim of
-                Nothing -> Nothing
-                Just n  ->
-                    if n <= 0
-                    then Just 0
-                    else Just (fromIntegral n)
-       }
-
-getYieldLimit :: Config -> Maybe Count
-getYieldLimit = _yieldLimit
-
--- | Specify the maximum number of threads that can be spawned by the channel.
--- A value of 0 resets the thread limit to default, a negative value means
--- there is no limit. The default value is 1500.
---
--- When the actions in a stream are IO bound, having blocking IO calls, this
--- option can be used to control the maximum number of in-flight IO requests.
--- When the actions are CPU bound this option can be used to control the amount
--- of CPU used by the stream.
---
-maxThreads :: Int -> Config -> Config
-maxThreads n st =
-    st { _threadsHigh =
-            if n < 0
-            then Unlimited
-            else if n == 0
-                 then defaultMaxThreads
-                 else Limited (fromIntegral n)
-       }
-
-getMaxThreads :: Config -> Limit
-getMaxThreads = _threadsHigh
-
--- | Specify the maximum size of the buffer for storing the results from
--- concurrent computations. If the buffer becomes full we stop spawning more
--- concurrent tasks until there is space in the buffer.
--- A value of 0 resets the buffer size to default, a negative value means
--- there is no limit. The default value is 1500.
---
--- CAUTION! using an unbounded 'maxBuffer' value (i.e. a negative value)
--- coupled with an unbounded 'maxThreads' value is a recipe for disaster in
--- presence of infinite streams, or very large streams.  Especially, it must
--- not be used when 'pure' is used in 'ZipAsyncM' streams as 'pure' in
--- applicative zip streams generates an infinite stream causing unbounded
--- concurrent generation with no limit on the buffer or threads.
---
-maxBuffer :: Int -> Config -> Config
-maxBuffer n st =
-    st { _bufferHigh =
-            if n < 0
-            then Unlimited
-            else if n == 0
-                 then defaultMaxBuffer
-                 else Limited (fromIntegral n)
-       }
-
-getMaxBuffer :: Config -> Limit
-getMaxBuffer = _bufferHigh
-
--- | Specify the pull rate of a channel.
--- A 'Nothing' value resets the rate to default which is unlimited.  When the
--- rate is specified, concurrent production may be ramped up or down
--- automatically to achieve the specified yield rate. The specific behavior for
--- different styles of 'Rate' specifications is documented under 'Rate'.  The
--- effective maximum production rate achieved by a channel is governed by:
---
--- * The 'maxThreads' limit
--- * The 'maxBuffer' limit
--- * The maximum rate that the stream producer can achieve
--- * The maximum rate that the stream consumer can achieve
---
-rate :: Maybe Rate -> Config -> Config
-rate r st = st { _maxStreamRate = r }
-
-getStreamRate :: Config -> Maybe Rate
-getStreamRate = _maxStreamRate
-
-setStreamLatency :: Int -> Config -> Config
-setStreamLatency n st =
-    st { _streamLatency =
-            if n <= 0
-            then Nothing
-            else Just (fromIntegral n)
-       }
-
-getStreamLatency :: Config -> Maybe NanoSecond64
-getStreamLatency = _streamLatency
-
-inspectMode :: Config -> Config
-inspectMode st = st { _inspectMode = True }
-
-getInspectMode :: Config -> Bool
-getInspectMode = _inspectMode
-
--------------------------------------------------------------------------------
--- Creating an SVar
--------------------------------------------------------------------------------
-
-getYieldRateInfo :: Config -> IO (Maybe YieldRateInfo)
-getYieldRateInfo st = do
-    -- convert rate in Hertz to latency in Nanoseconds
-    let rateToLatency r = if r <= 0 then maxBound else round $ 1.0e9 / r
-    case getStreamRate st of
-        Just (Rate low goal high buf) ->
-            let l    = rateToLatency goal
-                minl = rateToLatency high
-                maxl = rateToLatency low
-            in mkYieldRateInfo l (LatencyRange minl maxl) buf
-        Nothing -> return Nothing
-
-    where
-
-    mkYieldRateInfo latency latRange buf = do
-        measured <- newIORef 0
-        wcur     <- newIORef (0,0,0)
-        wcol     <- newIORef (0,0,0)
-        now      <- getTime Monotonic
-        wlong    <- newIORef (0,now)
-        period   <- newIORef 1
-        gainLoss <- newIORef (Count 0)
-
-        return $ Just YieldRateInfo
-            { svarLatencyTarget      = latency
-            , svarLatencyRange       = latRange
-            , svarRateBuffer         = buf
-            , svarGainedLostYields   = gainLoss
-            , workerBootstrapLatency = getStreamLatency st
-            , workerPollingInterval  = period
-            , workerMeasuredLatency  = measured
-            , workerPendingLatency   = wcur
-            , workerCollectedLatency = wcol
-            , svarAllTimeLatency     = wlong
-            }
-
-newSVarStats :: IO SVarStats
-newSVarStats = do
-    disp   <- newIORef 0
-    maxWrk <- newIORef 0
-    maxOq  <- newIORef 0
-    maxHs  <- newIORef 0
-    maxWq  <- newIORef 0
-    avgLat <- newIORef (0, NanoSecond64 0)
-    maxLat <- newIORef (NanoSecond64 0)
-    minLat <- newIORef (NanoSecond64 0)
-    stpTime <- newIORef Nothing
-
-    return SVarStats
-        { totalDispatches  = disp
-        , maxWorkers       = maxWrk
-        , maxOutQSize      = maxOq
-        , maxHeapSize      = maxHs
-        , maxWorkQSize     = maxWq
-        , avgWorkerLatency = avgLat
-        , minWorkerLatency = minLat
-        , maxWorkerLatency = maxLat
-        , svarStopTime     = stpTime
-        }
-
--------------------------------------------------------------------------------
--- Rate
--------------------------------------------------------------------------------
-
--- | Same as @rate (Just $ Rate (r/2) r (2*r) maxBound)@
---
--- Specifies the average production rate of a stream in number of yields
--- per second (i.e.  @Hertz@).  Concurrent production is ramped up or down
--- automatically to achieve the specified average yield rate. The rate can
--- go down to half of the specified rate on the lower side and double of
--- the specified rate on the higher side.
---
-avgRate :: Double -> Config -> Config
-avgRate r = rate (Just $ Rate (r/2) r (2*r) maxBound)
-
--- | Same as @rate (Just $ Rate r r (2*r) maxBound)@
---
--- Specifies the minimum rate at which the stream should yield values. As
--- far as possible the yield rate would never be allowed to go below the
--- specified rate, even though it may possibly go above it at times, the
--- upper limit is double of the specified rate.
---
-minRate :: Double -> Config -> Config
-minRate r = rate (Just $ Rate r r (2*r) maxBound)
-
--- | Same as @rate (Just $ Rate (r/2) r r maxBound)@
---
--- Specifies the maximum rate at which the stream should yield values. As
--- far as possible the yield rate would never be allowed to go above the
--- specified rate, even though it may possibly go below it at times, the
--- lower limit is half of the specified rate. This can be useful in
--- applications where certain resource usage must not be allowed to go
--- beyond certain limits.
---
-maxRate :: Double -> Config -> Config
-maxRate r = rate (Just $ Rate (r/2) r r maxBound)
-
--- | Same as @rate (Just $ Rate r r r 0)@
---
--- Specifies a constant yield rate. If for some reason the actual rate
--- goes above or below the specified rate we do not try to recover it by
--- increasing or decreasing the rate in future.  This can be useful in
--- applications like graphics frame refresh where we need to maintain a
--- constant refresh rate.
---
-constRate :: Double -> Config -> Config
-constRate r = rate (Just $ Rate r r r 0)
+{-# NOINLINE dumpSVar #-}
+dumpSVar :: Channel m a -> IO String
+dumpSVar sv = do
+    xs <- sequence
+        [ return (dumpCreator (svarCreator sv))
+        , return "---------CURRENT STATE-----------"
+        , dumpOutputQ (outputQueue sv)
+        -- XXX print the types of events in the outputQueue, first 5
+        , dumpDoorBell (outputDoorBell sv)
+        , dumpNeedDoorBell (needDoorBell sv)
+        , dumpRunningThreads (workerThreads sv)
+        -- XXX print the status of first 5 threads
+        , dumpWorkerCount (workerCount sv)
+        , return "---------STATS-----------\n"
+        , dumpSVarStats (svarInspectMode sv) (yieldRateInfo sv) (svarStats sv)
+        ]
+    return $ concat xs

--- a/src/Streamly/Internal/Data/Stream/Channel/Dispatcher.hs
+++ b/src/Streamly/Internal/Data/Stream/Channel/Dispatcher.hs
@@ -1,0 +1,297 @@
+-- |
+-- Module      : Streamly.Internal.Data.Stream.Channel.Dispatcher
+-- Copyright   : (c) 2017 Composewell Technologies
+-- License     : BSD-3-Clause
+-- Maintainer  : streamly@composewell.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+--
+module Streamly.Internal.Data.Stream.Channel.Dispatcher
+    (
+    -- * Latency collection
+      minThreadDelay
+    , collectLatency
+
+    -- * Thread accounting
+    , addThread
+    , delThread
+    , modifyThread
+    , allThreadsDone
+    , recordMaxWorkers
+
+    -- * Diagnostics
+    , dumpSVarStats
+    )
+where
+
+import Data.Set (Set)
+import Control.Concurrent (MVar, ThreadId)
+import Control.Concurrent.MVar (tryPutMVar)
+import Control.Exception (assert)
+import Control.Monad (when, void)
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Data.IORef (IORef, modifyIORef, readIORef, writeIORef)
+#if __GLASGOW_HASKELL__ < 804
+import Data.Semigroup ((<>))
+#endif
+import Streamly.Internal.Data.Atomics (atomicModifyIORefCAS, writeBarrier)
+import Streamly.Internal.Data.Time.Clock (Clock(Monotonic), getTime)
+import Streamly.Internal.Data.Time.Units
+       ( AbsTime, NanoSecond64(..), diffAbsTime64, showNanoSecond64
+       , showRelTime64)
+
+import qualified Data.Set as S
+
+import Streamly.Internal.Data.Stream.Channel.Types
+
+-------------------------------------------------------------------------------
+-- Worker latency data processing
+-------------------------------------------------------------------------------
+
+-- | This is a magic number and it is overloaded, and used at several places to
+-- achieve batching:
+--
+-- 1. If we have to sleep to slowdown this is the minimum period that we
+--    accumulate before we sleep. Also, workers do not stop until this much
+--    sleep time is accumulated.
+-- 3. Collected latencies are computed and transferred to measured latency
+--    after a minimum of this period.
+minThreadDelay :: NanoSecond64
+minThreadDelay = 1000000
+
+-- Every once in a while workers update the latencies and check the yield rate.
+-- They return if we are above the expected yield rate. If we check too often
+-- it may impact performance, if we check less often we may have a stale
+-- picture. We update every minThreadDelay but we translate that into a yield
+-- count based on latency so that the checking overhead is little.
+--
+-- XXX use a generation count to indicate that the value is updated. If the
+-- value is updated an existing worker must check it again on the next yield.
+-- Otherwise it is possible that we may keep updating it and because of the mod
+-- worker keeps skipping it.
+updateWorkerPollingInterval :: YieldRateInfo -> NanoSecond64 -> IO ()
+updateWorkerPollingInterval yinfo latency = do
+    let periodRef = workerPollingInterval yinfo
+        cnt = max 1 $ minThreadDelay `div` latency
+        period = min cnt (fromIntegral magicMaxBuffer)
+
+    writeIORef periodRef (fromIntegral period)
+
+{-# INLINE recordMinMaxLatency #-}
+recordMinMaxLatency :: SVarStats -> NanoSecond64 -> IO ()
+recordMinMaxLatency ss new = do
+    minLat <- readIORef (minWorkerLatency ss)
+    when (new < minLat || minLat == 0) $
+        writeIORef (minWorkerLatency ss) new
+
+    maxLat <- readIORef (maxWorkerLatency ss)
+    when (new > maxLat) $ writeIORef (maxWorkerLatency ss) new
+
+recordAvgLatency :: SVarStats -> (Count, NanoSecond64) -> IO ()
+recordAvgLatency ss (count, time) = do
+    modifyIORef (avgWorkerLatency ss) $
+        \(cnt, t) -> (cnt + count, t + time)
+
+-- Pour the pending latency stats into a collection bucket
+{-# INLINE collectWorkerPendingLatency #-}
+collectWorkerPendingLatency
+    :: IORef (Count, Count, NanoSecond64)
+    -> IORef (Count, Count, NanoSecond64)
+    -> IO (Count, Maybe (Count, NanoSecond64))
+collectWorkerPendingLatency cur col = do
+    (fcount, count, time) <- atomicModifyIORefCAS cur $ \v -> ((0,0,0), v)
+
+    (fcnt, cnt, t) <- readIORef col
+    let totalCount = fcnt + fcount
+        latCount   = cnt + count
+        latTime    = t + time
+    writeIORef col (totalCount, latCount, latTime)
+
+    assert (latCount == 0 || latTime /= 0) (return ())
+    let latPair =
+            if latCount > 0 && latTime > 0
+            then Just (latCount, latTime)
+            else Nothing
+    return (totalCount, latPair)
+
+{-# INLINE shouldUseCollectedBatch #-}
+shouldUseCollectedBatch
+    :: Count
+    -> NanoSecond64
+    -> NanoSecond64
+    -> NanoSecond64
+    -> Bool
+shouldUseCollectedBatch collectedYields collectedTime newLat prevLat =
+    let r = fromIntegral newLat / fromIntegral prevLat :: Double
+    in     (collectedYields > fromIntegral magicMaxBuffer)
+        || (collectedTime > minThreadDelay)
+        || (prevLat > 0 && (r > 2 || r < 0.5))
+        || (prevLat == 0)
+
+-- Returns a triple, (1) yield count since last collection, (2) the base time
+-- when we started counting, (3) average latency in the last measurement
+-- period. The former two are used for accurate measurement of the going rate
+-- whereas the average is used for future estimates e.g. how many workers
+-- should be maintained to maintain the rate.
+-- CAUTION! keep it in sync with getWorkerLatency
+collectLatency ::
+       Bool
+    -> SVarStats
+    -> YieldRateInfo
+    -> Bool
+    -> IO (Count, AbsTime, NanoSecond64)
+collectLatency inspect ss yinfo drain = do
+    let cur      = workerPendingLatency yinfo
+        col      = workerCollectedLatency yinfo
+        longTerm = svarAllTimeLatency yinfo
+        measured = workerMeasuredLatency yinfo
+
+    (newCount, newLatPair) <- collectWorkerPendingLatency cur col
+    (lcount, ltime) <- readIORef longTerm
+    prevLat <- readIORef measured
+
+    let newLcount = lcount + newCount
+        retWith lat = return (newLcount, ltime, lat)
+
+    case newLatPair of
+        Nothing -> retWith prevLat
+        Just (count, time) -> do
+            let newLat = time `div` fromIntegral count
+            when inspect $ recordMinMaxLatency ss newLat
+            -- When we have collected a significant sized batch we compute the
+            -- new latency using that batch and return the new latency,
+            -- otherwise we return the previous latency derived from the
+            -- previous batch.
+            if shouldUseCollectedBatch newCount time newLat prevLat || drain
+            then do
+                -- XXX make this NOINLINE?
+                updateWorkerPollingInterval yinfo (max newLat prevLat)
+                when inspect $ recordAvgLatency ss (count, time)
+                writeIORef col (0, 0, 0)
+                writeIORef measured ((prevLat + newLat) `div` 2)
+                modifyIORef longTerm $ \(_, t) -> (newLcount, t)
+                retWith newLat
+            else retWith prevLat
+
+-------------------------------------------------------------------------------
+-- Dumping the SVar for debug/diag
+-------------------------------------------------------------------------------
+
+dumpSVarStats :: Bool -> Maybe YieldRateInfo -> SVarStats -> IO String
+dumpSVarStats inspect rateInfo ss = do
+    case rateInfo of
+        Nothing -> return ()
+        Just yinfo -> do
+            _ <- liftIO $ collectLatency inspect ss yinfo True
+            return ()
+
+    dispatches <- readIORef $ totalDispatches ss
+    maxWrk <- readIORef $ maxWorkers ss
+    maxOq <- readIORef $ maxOutQSize ss
+    -- maxHp <- readIORef $ maxHeapSize ss
+    minLat <- readIORef $ minWorkerLatency ss
+    maxLat <- readIORef $ maxWorkerLatency ss
+    (avgCnt, avgTime) <- readIORef $ avgWorkerLatency ss
+    (svarCnt, svarGainLossCnt, svarLat) <- case rateInfo of
+        Nothing -> return (0, 0, 0)
+        Just yinfo -> do
+            (cnt, startTime) <- readIORef $ svarAllTimeLatency yinfo
+            if cnt > 0
+            then do
+                t <- readIORef (svarStopTime ss)
+                gl <- readIORef (svarGainedLostYields yinfo)
+                case t of
+                    Nothing -> do
+                        now <- getTime Monotonic
+                        let interval = diffAbsTime64 now startTime
+                        return (cnt, gl, interval `div` fromIntegral cnt)
+                    Just stopTime -> do
+                        let interval = diffAbsTime64 stopTime startTime
+                        return (cnt, gl, interval `div` fromIntegral cnt)
+            else return (0, 0, 0)
+
+    return $ unlines
+        [ "total dispatches = " <> show dispatches
+        , "max workers = " <> show maxWrk
+        , "max outQSize = " <> show maxOq
+            <> (if minLat > 0
+               then "\nmin worker latency = " <> showNanoSecond64 minLat
+               else "")
+            <> (if maxLat > 0
+               then "\nmax worker latency = " <> showNanoSecond64 maxLat
+               else "")
+            <> (if avgCnt > 0
+                then let lat = avgTime `div` fromIntegral avgCnt
+                     in "\navg worker latency = " <> showNanoSecond64 lat
+                else "")
+            <> (if svarLat > 0
+               then "\nSVar latency = " <> showRelTime64 svarLat
+               else "")
+            <> (if svarCnt > 0
+               then "\nSVar yield count = " <> show svarCnt
+               else "")
+            <> (if svarGainLossCnt > 0
+               then "\nSVar gain/loss yield count = " <> show svarGainLossCnt
+               else "")
+        ]
+
+-------------------------------------------------------------------------------
+-- Thread accounting
+-------------------------------------------------------------------------------
+
+-- Thread tracking is needed for two reasons:
+--
+-- 1) Killing threads on exceptions. Threads may not be left to go away by
+-- themselves because they may run for significant times before going away or
+-- worse they may be stuck in IO and never go away.
+--
+-- 2) To know when all threads are done and the stream has ended.
+
+{-# NOINLINE addThread #-}
+addThread :: MonadIO m => IORef (Set ThreadId) -> ThreadId -> m ()
+addThread workerSet tid =
+    liftIO $ modifyIORef workerSet (S.insert tid)
+
+-- This is cheaper than modifyThread because we do not have to send a
+-- outputDoorBell This can make a difference when more workers are being
+-- dispatched.
+{-# INLINE delThread #-}
+delThread :: MonadIO m => IORef (Set ThreadId) -> ThreadId -> m ()
+delThread workerSet tid =
+    liftIO $ modifyIORef workerSet (S.delete tid)
+
+-- If present then delete else add. This takes care of out of order add and
+-- delete i.e. a delete arriving before we even added a thread.
+-- This occurs when the forked thRead is done even before the 'addThread' right
+-- after the fork gets a chance to run.
+{-# INLINE modifyThread #-}
+modifyThread :: MonadIO m => IORef (Set ThreadId) -> MVar () -> ThreadId -> m ()
+modifyThread workerSet bell tid = do
+    changed <- liftIO $ atomicModifyIORefCAS workerSet $ \old ->
+        if S.member tid old
+        then let new = S.delete tid old in (new, new)
+        else let new = S.insert tid old in (new, old)
+    when (null changed) $
+         liftIO $ do
+            writeBarrier
+            void $ tryPutMVar bell ()
+
+-- | This is safe even if we are adding more threads concurrently because if
+-- a child thread is adding another thread then anyway 'workerThreads' will
+-- not be empty.
+{-# INLINE allThreadsDone #-}
+allThreadsDone :: MonadIO m => IORef (Set ThreadId) -> m Bool
+allThreadsDone ref = liftIO $ S.null <$> readIORef ref
+
+-------------------------------------------------------------------------------
+-- Dispatching workers
+-------------------------------------------------------------------------------
+
+{-# NOINLINE recordMaxWorkers #-}
+recordMaxWorkers :: MonadIO m => IORef Int -> SVarStats -> m ()
+recordMaxWorkers countRef ss = liftIO $ do
+    active <- readIORef countRef
+    maxWrk <- readIORef (maxWorkers ss)
+    when (active > maxWrk) $ writeIORef (maxWorkers ss) active
+    modifyIORef (totalDispatches ss) (+1)

--- a/src/Streamly/Internal/Data/Stream/Channel/Types.hs
+++ b/src/Streamly/Internal/Data/Stream/Channel/Types.hs
@@ -1,0 +1,710 @@
+-- |
+-- Module      : Streamly.Internal.Data.Stream.Channel.Types
+-- Copyright   : (c) 2017 Composewell Technologies
+-- License     : BSD-3-Clause
+-- Maintainer  : streamly@composewell.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- A Channel is a place where streams join and new streams start. This module
+-- defines low level data structures and functions to build channels. For
+-- concrete Channels see the Channel modules of specific stream types.
+--
+-- A Channel is a conduit to the output from multiple streams running
+-- concurrently and asynchronously. A channel can be thought of as an
+-- asynchronous IO handle. We can write any number of streams to a channel in a
+-- non-blocking manner and then read them back at any time at any pace.  The
+-- channel would run the streams asynchronously and accumulate results. A
+-- channel may not really execute the stream completely and accumulate all the
+-- results. However, it ensures that the reader can read the results at
+-- whatever pace it wants to read. The channel monitors and adapts to the
+-- consumer's pace.
+--
+-- A channel is a mini scheduler, it has an associated workLoop that holds the
+-- stream tasks to be picked and run by a pool of worker threads. It has an
+-- associated output queue where the output stream elements are placed by the
+-- worker threads. An outputDoorBell is used by the worker threads to intimate the
+-- consumer thread about availability of new results in the output queue. More
+-- workers are added to the channel by 'fromChannel' on demand if the output
+-- produced is not keeping pace with the consumer. On bounded channels, workers
+-- block on the output queue to provide throttling of the producer  when the
+-- consumer is not pulling fast enough.  The number of workers may even get
+-- reduced depending on the consuming pace.
+--
+module Streamly.Internal.Data.Stream.Channel.Types
+    (
+    -- * Types
+      Count (..)
+    , Limit (..)
+    , ThreadAbort (..)
+    , ChildEvent (..)
+
+    -- * Stats
+    , SVarStats (..)
+    , newSVarStats
+
+    -- * Rate Control
+    , WorkerInfo (..)
+    , LatencyRange (..)
+    , YieldRateInfo (..)
+    , newRateInfo
+
+    -- * Output queue
+    , readOutputQRaw
+    , readOutputQBasic
+    , ringDoorBell
+
+    -- * Yield Limit
+    , decrementYieldLimit
+    , incrementYieldLimit
+
+    -- * Configuration
+    , Rate (..)
+    , Config
+
+    -- ** Default config
+    , magicMaxBuffer
+    , defaultConfig
+
+    -- ** Set config
+    , maxThreads
+    , maxBuffer
+    , maxYields
+    , inspectMode
+
+    , rate
+    , avgRate
+    , minRate
+    , maxRate
+    , constRate
+
+    -- ** Get config
+    , getMaxThreads
+    , getMaxBuffer
+    , getStreamRate
+    , getStreamLatency
+    , setStreamLatency
+    , getYieldLimit
+    , getInspectMode
+
+    -- * Cleanup
+    , cleanupSVar
+
+    -- * Diagnostics
+    , dumpCreator
+    , dumpOutputQ
+    , dumpDoorBell
+    , dumpNeedDoorBell
+    , dumpRunningThreads
+    , dumpWorkerCount
+
+    , withDiagMVar
+    , printSVar
+    )
+where
+
+import Control.Concurrent (ThreadId, myThreadId, throwTo, MVar, tryReadMVar)
+import Control.Concurrent.MVar (tryPutMVar)
+import Control.Exception
+    ( SomeException(..), Exception, catches, throwIO, Handler(..)
+    , BlockedIndefinitelyOnMVar(..), BlockedIndefinitelyOnSTM(..))
+import Control.Monad (void, when)
+import Data.Int (Int64)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Set (Set)
+import Streamly.Internal.Data.Atomics
+    (atomicModifyIORefCAS, atomicModifyIORefCAS_, storeLoadBarrier)
+import Streamly.Internal.Data.Time.Clock (Clock(Monotonic), getTime)
+import Streamly.Internal.Data.Time.Units (AbsTime, NanoSecond64(..))
+import System.IO (hPutStrLn, stderr)
+
+import qualified Data.Set as Set
+
+------------------------------------------------------------------------------
+-- Common types
+------------------------------------------------------------------------------
+
+newtype Count = Count Int64
+    deriving ( Eq
+             , Read
+             , Show
+             , Enum
+             , Bounded
+             , Num
+             , Real
+             , Integral
+             , Ord
+             )
+
+-- XXX We can use maxBound for unlimited?
+
+-- This is essentially a 'Maybe Word' type
+data Limit = Unlimited | Limited Word deriving Show
+
+instance Eq Limit where
+    Unlimited == Unlimited = True
+    Unlimited == Limited _ = False
+    Limited _ == Unlimited = False
+    Limited x == Limited y = x == y
+
+instance Ord Limit where
+    Unlimited <= Unlimited = True
+    Unlimited <= Limited _ = False
+    Limited _ <= Unlimited = True
+    Limited x <= Limited y = x <= y
+
+------------------------------------------------------------------------------
+-- Parent child thread communication type
+------------------------------------------------------------------------------
+
+data ThreadAbort = ThreadAbort deriving Show
+
+instance Exception ThreadAbort
+
+-- | Events that a child thread may send to a parent thread.
+data ChildEvent a =
+      ChildYield a
+    | ChildStop ThreadId (Maybe SomeException)
+
+-- | We measure the individual worker latencies to estimate the number of workers
+-- needed or the amount of time we have to sleep between dispatches to achieve
+-- a particular rate when controlled pace mode it used.
+data WorkerInfo = WorkerInfo
+    {
+    -- | 0 means unlimited
+      workerYieldMax   :: Count
+    -- | total number of yields by the worker till now
+    , workerYieldCount    :: IORef Count
+    -- | yieldCount at start, timestamp
+    , workerLatencyStart  :: IORef (Count, AbsTime)
+    }
+
+data LatencyRange = LatencyRange
+    { minLatency :: NanoSecond64
+    , maxLatency :: NanoSecond64
+    } deriving Show
+
+-- | Rate control.
+data YieldRateInfo = YieldRateInfo
+    { svarLatencyTarget    :: NanoSecond64
+    , svarLatencyRange     :: LatencyRange
+    , svarRateBuffer       :: Int
+
+    -- | [LOCKING] Unlocked access. Modified by the consumer thread and unsafely
+    -- read by the worker threads
+    , svarGainedLostYields :: IORef Count
+
+    -- | Actual latency/througput as seen from the consumer side, we count the
+    -- yields and the time it took to generates those yields. This is used to
+    -- increase or decrease the number of workers needed to achieve the desired
+    -- rate. The idle time of workers is adjusted in this, so that we only
+    -- account for the rate when the consumer actually demands data.
+    -- XXX interval latency is enough, we can move this under diagnostics build
+    -- [LOCKING] Unlocked access. Modified by the consumer thread and unsafely
+    -- read by the worker threads
+    , svarAllTimeLatency :: IORef (Count, AbsTime)
+
+    -- XXX Worker latency specified by the user to be used before the first
+    -- actual measurement arrives. Not yet implemented
+    , workerBootstrapLatency :: Maybe NanoSecond64
+
+    -- | After how many yields the worker should update the latency information.
+    -- If the latency is high, this count is kept lower and vice-versa.  XXX If
+    -- the latency suddenly becomes too high this count may remain too high for
+    -- long time, in such cases the consumer can change it.
+    -- 0 means no latency computation
+    -- XXX this is derivable from workerMeasuredLatency, can be removed.
+    -- [LOCKING] Unlocked access. Modified by the consumer thread and unsafely
+    -- read by the worker threads
+    , workerPollingInterval :: IORef Count
+
+    -- | This is in progress latency stats maintained by the workers which we
+    -- empty into workerCollectedLatency stats at certain intervals - whenever
+    -- we process the stream elements yielded in this period. The first count
+    -- is all yields, the second count is only those yields for which the
+    -- latency was measured to be non-zero (note that if the timer resolution
+    -- is low the measured latency may be zero e.g. on JS platform).
+    -- [LOCKING] Locked access. Modified by the consumer thread as well as
+    -- worker threads. Workers modify it periodically based on
+    -- workerPollingInterval and not on every yield to reduce the locking
+    -- overhead.
+    -- (allYieldCount, yieldCount, timeTaken)
+    , workerPendingLatency   :: IORef (Count, Count, NanoSecond64)
+
+    -- | This is the second level stat which is an accmulation from
+    -- workerPendingLatency stats. We keep accumulating latencies in this
+    -- bucket until we have stats for a sufficient period and then we reset it
+    -- to start collecting for the next period and retain the computed average
+    -- latency for the last period in workerMeasuredLatency.
+    -- [LOCKING] Unlocked access. Modified by the consumer thread and unsafely
+    -- read by the worker threads
+    -- (allYieldCount, yieldCount, timeTaken)
+    , workerCollectedLatency :: IORef (Count, Count, NanoSecond64)
+
+    -- | Latency as measured by workers, aggregated for the last period.
+    -- [LOCKING] Unlocked access. Modified by the consumer thread and unsafely
+    -- read by the worker threads
+    , workerMeasuredLatency :: IORef NanoSecond64
+    }
+
+data SVarStats = SVarStats {
+      totalDispatches  :: IORef Int
+    , maxWorkers       :: IORef Int
+    , maxOutQSize      :: IORef Int
+    , maxHeapSize      :: IORef Int
+    , maxWorkQSize     :: IORef Int
+    , avgWorkerLatency :: IORef (Count, NanoSecond64)
+    , minWorkerLatency :: IORef NanoSecond64
+    , maxWorkerLatency :: IORef NanoSecond64
+    , svarStopTime     :: IORef (Maybe AbsTime)
+}
+
+-------------------------------------------------------------------------------
+-- Config
+-------------------------------------------------------------------------------
+
+-- | Specifies the stream yield rate in yields per second (@Hertz@).
+-- We keep accumulating yield credits at 'rateGoal'. At any point of time we
+-- allow only as many yields as we have accumulated as per 'rateGoal' since the
+-- start of time. If the consumer or the producer is slower or faster, the
+-- actual rate may fall behind or exceed 'rateGoal'.  We try to recover the gap
+-- between the two by increasing or decreasing the pull rate from the producer.
+-- However, if the gap becomes more than 'rateBuffer' we try to recover only as
+-- much as 'rateBuffer'.
+--
+-- 'rateLow' puts a bound on how low the instantaneous rate can go when
+-- recovering the rate gap.  In other words, it determines the maximum yield
+-- latency.  Similarly, 'rateHigh' puts a bound on how high the instantaneous
+-- rate can go when recovering the rate gap.  In other words, it determines the
+-- minimum yield latency. We reduce the latency by increasing concurrency,
+-- therefore we can say that it puts an upper bound on concurrency.
+--
+-- If the 'rateGoal' is 0 or negative the stream never yields a value.
+-- If the 'rateBuffer' is 0 or negative we do not attempt to recover.
+--
+-- /Since: 0.5.0 ("Streamly")/
+--
+-- @since 0.8.0
+data Rate = Rate
+    { rateLow    :: Double -- ^ The lower rate limit
+    , rateGoal   :: Double -- ^ The target rate we want to achieve
+    , rateHigh   :: Double -- ^ The upper rate limit
+    , rateBuffer :: Int    -- ^ Maximum slack from the goal
+    }
+
+-- XXX we can put the resettable fields in a oneShotConfig field and others in
+-- a persistentConfig field. That way reset would be fast and scalable
+-- irrespective of the number of fields.
+--
+-- XXX make all these Limited types and use phantom types to distinguish them
+
+-- | An abstract type for specifying the configuration parameters of a
+-- 'Channel'. Use @Config -> Config@ modifier functions to modify the
+-- default configuration. See the modifiers for default values.
+--
+data Config = Config
+    { -- one shot configuration, automatically reset for each API call
+      -- streamVar   :: Maybe (SVar t m a)
+      _yieldLimit  :: Maybe Count
+
+    -- persistent configuration, state that remains valid until changed by
+    -- an explicit setting via a combinator.
+    , _threadsHigh    :: Limit
+    , _bufferHigh     :: Limit
+
+    -- XXX these two can be collapsed into a single type
+    , _streamLatency  :: Maybe NanoSecond64 -- bootstrap latency
+    , _maxStreamRate  :: Maybe Rate
+    , _inspectMode    :: Bool
+    }
+
+-------------------------------------------------------------------------------
+-- State defaults and reset
+-------------------------------------------------------------------------------
+
+-- | A magical value for the buffer size arrived at by running the smallest
+-- possible task and measuring the optimal value of the buffer for that.  This
+-- is obviously dependent on hardware, this figure is based on a 2.2GHz intel
+-- core-i7 processor.
+magicMaxBuffer :: Word
+magicMaxBuffer = 1500
+
+defaultMaxThreads, defaultMaxBuffer :: Limit
+defaultMaxThreads = Limited magicMaxBuffer
+defaultMaxBuffer = Limited magicMaxBuffer
+
+-- | The fields prefixed by an _ are not to be accessed or updated directly but
+-- via smart accessor APIs. Use get/set routines instead of directly accessing
+-- the Config fields
+defaultConfig :: Config
+defaultConfig = Config
+    { -- streamVar = Nothing
+      _yieldLimit = Nothing
+    , _threadsHigh = defaultMaxThreads
+    , _bufferHigh = defaultMaxBuffer
+    , _maxStreamRate = Nothing
+    , _streamLatency = Nothing
+    , _inspectMode = False
+    }
+
+-------------------------------------------------------------------------------
+-- Smart get/set routines for State
+-------------------------------------------------------------------------------
+
+maxYields :: Maybe Int64 -> Config -> Config
+maxYields lim st =
+    st { _yieldLimit =
+            case lim of
+                Nothing -> Nothing
+                Just n  ->
+                    if n <= 0
+                    then Just 0
+                    else Just (fromIntegral n)
+       }
+
+getYieldLimit :: Config -> Maybe Count
+getYieldLimit = _yieldLimit
+
+-- | Specify the maximum number of threads that can be spawned by the channel.
+-- A value of 0 resets the thread limit to default, a negative value means
+-- there is no limit. The default value is 1500.
+--
+-- When the actions in a stream are IO bound, having blocking IO calls, this
+-- option can be used to control the maximum number of in-flight IO requests.
+-- When the actions are CPU bound this option can be used to control the amount
+-- of CPU used by the stream.
+--
+maxThreads :: Int -> Config -> Config
+maxThreads n st =
+    st { _threadsHigh =
+            if n < 0
+            then Unlimited
+            else if n == 0
+                 then defaultMaxThreads
+                 else Limited (fromIntegral n)
+       }
+
+getMaxThreads :: Config -> Limit
+getMaxThreads = _threadsHigh
+
+-- | Specify the maximum size of the buffer for storing the results from
+-- concurrent computations. If the buffer becomes full we stop spawning more
+-- concurrent tasks until there is space in the buffer.
+-- A value of 0 resets the buffer size to default, a negative value means
+-- there is no limit. The default value is 1500.
+--
+-- CAUTION! using an unbounded 'maxBuffer' value (i.e. a negative value)
+-- coupled with an unbounded 'maxThreads' value is a recipe for disaster in
+-- presence of infinite streams, or very large streams.  Especially, it must
+-- not be used when 'pure' is used in 'ZipAsyncM' streams as 'pure' in
+-- applicative zip streams generates an infinite stream causing unbounded
+-- concurrent generation with no limit on the buffer or threads.
+--
+maxBuffer :: Int -> Config -> Config
+maxBuffer n st =
+    st { _bufferHigh =
+            if n < 0
+            then Unlimited
+            else if n == 0
+                 then defaultMaxBuffer
+                 else Limited (fromIntegral n)
+       }
+
+getMaxBuffer :: Config -> Limit
+getMaxBuffer = _bufferHigh
+
+-- | Specify the pull rate of a channel.
+-- A 'Nothing' value resets the rate to default which is unlimited.  When the
+-- rate is specified, concurrent production may be ramped up or down
+-- automatically to achieve the specified yield rate. The specific behavior for
+-- different styles of 'Rate' specifications is documented under 'Rate'.  The
+-- effective maximum production rate achieved by a channel is governed by:
+--
+-- * The 'maxThreads' limit
+-- * The 'maxBuffer' limit
+-- * The maximum rate that the stream producer can achieve
+-- * The maximum rate that the stream consumer can achieve
+--
+rate :: Maybe Rate -> Config -> Config
+rate r st = st { _maxStreamRate = r }
+
+getStreamRate :: Config -> Maybe Rate
+getStreamRate = _maxStreamRate
+
+setStreamLatency :: Int -> Config -> Config
+setStreamLatency n st =
+    st { _streamLatency =
+            if n <= 0
+            then Nothing
+            else Just (fromIntegral n)
+       }
+
+getStreamLatency :: Config -> Maybe NanoSecond64
+getStreamLatency = _streamLatency
+
+inspectMode :: Config -> Config
+inspectMode st = st { _inspectMode = True }
+
+getInspectMode :: Config -> Bool
+getInspectMode = _inspectMode
+
+-------------------------------------------------------------------------------
+-- Initialization
+-------------------------------------------------------------------------------
+
+newRateInfo :: Config -> IO (Maybe YieldRateInfo)
+newRateInfo st = do
+    -- convert rate in Hertz to latency in Nanoseconds
+    let rateToLatency r = if r <= 0 then maxBound else round $ 1.0e9 / r
+    case getStreamRate st of
+        Just (Rate low goal high buf) ->
+            let l    = rateToLatency goal
+                minl = rateToLatency high
+                maxl = rateToLatency low
+            in mkYieldRateInfo l (LatencyRange minl maxl) buf
+        Nothing -> return Nothing
+
+    where
+
+    mkYieldRateInfo latency latRange buf = do
+        measured <- newIORef 0
+        wcur     <- newIORef (0,0,0)
+        wcol     <- newIORef (0,0,0)
+        now      <- getTime Monotonic
+        wlong    <- newIORef (0,now)
+        period   <- newIORef 1
+        gainLoss <- newIORef (Count 0)
+
+        return $ Just YieldRateInfo
+            { svarLatencyTarget      = latency
+            , svarLatencyRange       = latRange
+            , svarRateBuffer         = buf
+            , svarGainedLostYields   = gainLoss
+            , workerBootstrapLatency = getStreamLatency st
+            , workerPollingInterval  = period
+            , workerMeasuredLatency  = measured
+            , workerPendingLatency   = wcur
+            , workerCollectedLatency = wcol
+            , svarAllTimeLatency     = wlong
+            }
+
+newSVarStats :: IO SVarStats
+newSVarStats = do
+    disp   <- newIORef 0
+    maxWrk <- newIORef 0
+    maxOq  <- newIORef 0
+    maxHs  <- newIORef 0
+    maxWq  <- newIORef 0
+    avgLat <- newIORef (0, NanoSecond64 0)
+    maxLat <- newIORef (NanoSecond64 0)
+    minLat <- newIORef (NanoSecond64 0)
+    stpTime <- newIORef Nothing
+
+    return SVarStats
+        { totalDispatches  = disp
+        , maxWorkers       = maxWrk
+        , maxOutQSize      = maxOq
+        , maxHeapSize      = maxHs
+        , maxWorkQSize     = maxWq
+        , avgWorkerLatency = avgLat
+        , minWorkerLatency = minLat
+        , maxWorkerLatency = maxLat
+        , svarStopTime     = stpTime
+        }
+
+-------------------------------------------------------------------------------
+-- Rate
+-------------------------------------------------------------------------------
+
+-- | Same as @rate (Just $ Rate (r/2) r (2*r) maxBound)@
+--
+-- Specifies the average production rate of a stream in number of yields
+-- per second (i.e.  @Hertz@).  Concurrent production is ramped up or down
+-- automatically to achieve the specified average yield rate. The rate can
+-- go down to half of the specified rate on the lower side and double of
+-- the specified rate on the higher side.
+--
+avgRate :: Double -> Config -> Config
+avgRate r = rate (Just $ Rate (r/2) r (2*r) maxBound)
+
+-- | Same as @rate (Just $ Rate r r (2*r) maxBound)@
+--
+-- Specifies the minimum rate at which the stream should yield values. As
+-- far as possible the yield rate would never be allowed to go below the
+-- specified rate, even though it may possibly go above it at times, the
+-- upper limit is double of the specified rate.
+--
+minRate :: Double -> Config -> Config
+minRate r = rate (Just $ Rate r r (2*r) maxBound)
+
+-- | Same as @rate (Just $ Rate (r/2) r r maxBound)@
+--
+-- Specifies the maximum rate at which the stream should yield values. As
+-- far as possible the yield rate would never be allowed to go above the
+-- specified rate, even though it may possibly go below it at times, the
+-- lower limit is half of the specified rate. This can be useful in
+-- applications where certain resource usage must not be allowed to go
+-- beyond certain limits.
+--
+maxRate :: Double -> Config -> Config
+maxRate r = rate (Just $ Rate (r/2) r r maxBound)
+
+-- | Same as @rate (Just $ Rate r r r 0)@
+--
+-- Specifies a constant yield rate. If for some reason the actual rate
+-- goes above or below the specified rate we do not try to recover it by
+-- increasing or decreasing the rate in future.  This can be useful in
+-- applications like graphics frame refresh where we need to maintain a
+-- constant refresh rate.
+--
+constRate :: Double -> Config -> Config
+constRate r = rate (Just $ Rate r r r 0)
+
+-------------------------------------------------------------------------------
+-- Channel yield count
+-------------------------------------------------------------------------------
+
+-- XXX Can we make access to remainingWork and yieldRateInfo fields in sv
+-- faster, along with the fields in sv required by send?
+-- XXX make it noinline
+--
+-- XXX we may want to employ an increment and decrement in batches when the
+-- througput is high or when the cost of synchronization is high. For example
+-- if the application is distributed then inc/dec of a shared variable may be
+-- very costly.
+
+-- | A worker decrements the yield limit before it executes an action. However,
+-- the action may not result in an element being yielded, in that case we have
+-- to increment the yield limit.
+--
+-- Note that we need it to be an Int type so that we have the ability to undo a
+-- decrement that takes it below zero.
+{-# INLINE decrementYieldLimit #-}
+decrementYieldLimit :: Maybe (IORef Count) -> IO Bool
+decrementYieldLimit remaining =
+    case remaining of
+        Nothing -> return True
+        Just ref -> do
+            r <- atomicModifyIORefCAS ref $ \x -> (x - 1, x)
+            return $ r >= 1
+
+{-# INLINE incrementYieldLimit #-}
+incrementYieldLimit :: Maybe (IORef Count) -> IO ()
+incrementYieldLimit remaining =
+    case remaining of
+        Nothing -> return ()
+        Just ref -> atomicModifyIORefCAS_ ref (+ 1)
+
+-------------------------------------------------------------------------------
+-- Output queue
+-------------------------------------------------------------------------------
+
+{-# INLINE readOutputQBasic #-}
+readOutputQBasic :: IORef ([ChildEvent a], Int) -> IO ([ChildEvent a], Int)
+readOutputQBasic q = atomicModifyIORefCAS q $ \x -> (([],0), x)
+
+{-# INLINE readOutputQRaw #-}
+readOutputQRaw ::
+    IORef ([ChildEvent a], Int) -> Maybe SVarStats -> IO ([ChildEvent a], Int)
+readOutputQRaw q stats = do
+    (list, len) <- readOutputQBasic q
+    case stats of
+        Just ss -> do
+            let ref = maxOutQSize ss
+            oqLen <- readIORef ref
+            when (len > oqLen) $ writeIORef ref len
+        Nothing -> return ()
+    return (list, len)
+
+{-# INLINE ringDoorBell #-}
+ringDoorBell :: IORef Bool -> MVar () -> IO ()
+ringDoorBell needBell bell = do
+    storeLoadBarrier
+    w <- readIORef needBell
+    when w $ do
+        -- Note: the sequence of operations is important for correctness here.
+        -- We need to set the flag to false strictly before sending the
+        -- outputDoorBell, otherwise the outputDoorBell may get processed too
+        -- early and then we may set the flag to False to later making the
+        -- consumer lose the flag, even without receiving a outputDoorBell.
+        atomicModifyIORefCAS_ needBell (const False)
+        void $ tryPutMVar bell ()
+
+-------------------------------------------------------------------------------
+-- Diagnostics
+-------------------------------------------------------------------------------
+
+dumpCreator :: Show a => a -> String
+dumpCreator tid = "Creator tid = " <> show tid
+
+dumpOutputQ :: (Foldable t, Show a1) => IORef (t a2, a1) -> IO String
+dumpOutputQ q = do
+    (oqList, oqLen) <- readIORef q
+    return $ unlines
+        [ "outputQueue length computed  = " <> show (length oqList)
+        , "outputQueue length maintained = " <> show oqLen
+        ]
+
+dumpDoorBell :: Show a => MVar a -> IO String
+dumpDoorBell mvar =  do
+    db <- tryReadMVar mvar
+    return $ "outputDoorBell = " <> show db
+
+dumpNeedDoorBell :: Show a => IORef a -> IO String
+dumpNeedDoorBell ref = do
+    waiting <- readIORef ref
+    return $ "needDoorBell = " <> show waiting
+
+dumpRunningThreads :: Show a => IORef a -> IO String
+dumpRunningThreads ref = do
+    rthread <- readIORef ref
+    return $ "running threads = " <> show rthread
+
+dumpWorkerCount :: Show a => IORef a -> IO String
+dumpWorkerCount ref = do
+    workers <- readIORef ref
+    return $ "running thread count = " <> show workers
+
+{-# NOINLINE mvarExcHandler #-}
+mvarExcHandler :: IO String -> String -> BlockedIndefinitelyOnMVar -> IO ()
+mvarExcHandler dump label e@BlockedIndefinitelyOnMVar = do
+    svInfo <- dump
+    hPutStrLn stderr $ label <> " " <> "BlockedIndefinitelyOnMVar\n" <> svInfo
+    throwIO e
+
+{-# NOINLINE stmExcHandler #-}
+stmExcHandler :: IO String -> String -> BlockedIndefinitelyOnSTM -> IO ()
+stmExcHandler dump label e@BlockedIndefinitelyOnSTM = do
+    svInfo <- dump
+    hPutStrLn stderr $ label <> " " <> "BlockedIndefinitelyOnSTM\n" <> svInfo
+    throwIO e
+
+-- | MVar diagnostics has some overhead - around 5% on AsyncT null benchmark, we
+-- can keep it on in production to debug problems quickly if and when they
+-- happen, but it may result in unexpected output when threads are left hanging
+-- until they are GCed because the consumer went away.
+withDiagMVar :: Bool -> IO String -> String -> IO () -> IO ()
+withDiagMVar inspect dump label action =
+    if inspect
+    then
+        action `catches` [ Handler (mvarExcHandler dump label)
+                         , Handler (stmExcHandler dump label)
+                         ]
+    else action
+
+printSVar :: IO String -> String -> IO ()
+printSVar dump how = do
+    svInfo <- dump
+    hPutStrLn stderr $ "\n" <> how <> "\n" <> svInfo
+
+-------------------------------------------------------------------------------
+-- Cleanup
+-------------------------------------------------------------------------------
+
+-- Can be called from a worker as well, avoids throwing to itself
+cleanupSVar :: IORef (Set ThreadId) -> IO ()
+cleanupSVar workerSet = do
+    workers <- readIORef workerSet
+    self <- myThreadId
+    Prelude.mapM_ (`throwTo` ThreadAbort)
+          (Prelude.filter (/= self) $ Set.toList workers)

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -447,8 +447,11 @@ library
 
                      , Streamly.Internal.Data.Stream.Serial
                      , Streamly.Internal.Data.Stream.WSerial
+                     , Streamly.Internal.Data.Stream.Channel.Types
+                     , Streamly.Internal.Data.Stream.Channel.Dispatcher
+                     , Streamly.Internal.Data.Stream.Channel.Worker
+
                      , Streamly.Internal.Data.Stream.Async.Channel.Type
-                     , Streamly.Internal.Data.Stream.Async.Channel.Worker
                      , Streamly.Internal.Data.Stream.Async.Channel.Dispatcher
                      , Streamly.Internal.Data.Stream.Async.Channel.Consumer
                      , Streamly.Internal.Data.Stream.Async.Channel.Append


### PR DESCRIPTION
Move out the common data structures and functions from Async module to Data.Stream.Channel module. The common code will be used in Parallel module.

Concrete channel type remains in the Async module, but the parts that are used to make it up are in the common module.