### PR TITLE
Rename and move unboxed array APIs

### DIFF
--- a/core/src/Streamly/Data/Array/Unboxed/Mut.hs
+++ b/core/src/Streamly/Data/Array/Unboxed/Mut.hs
@@ -19,7 +19,8 @@ module Streamly.Data.Array.Unboxed.Mut
     -- ** Construction
 
     -- Uninitialized Arrays
-    , newArray
+    , new
+    , newPinned
 
     -- From containers
     , fromListN

--- a/core/src/Streamly/Internal/Data/Array/Unboxed.hs
+++ b/core/src/Streamly/Internal/Data/Array/Unboxed.hs
@@ -284,7 +284,7 @@ writeLastN n
          in fmap f $ liftIO $ RB.new n
 
     done (Tuple3Fused' rb rh i) = do
-        arr <- liftIO $ MA.newArray n
+        arr <- liftIO $ MA.newPinned n
         foldFunc i rh snoc' arr rb
 
     -- XXX We should write a read unfold for ring.

--- a/core/src/Streamly/Internal/Data/Array/Unboxed/Type.hs
+++ b/core/src/Streamly/Internal/Data/Array/Unboxed/Type.hs
@@ -94,12 +94,13 @@ import Text.Read (readPrec, readListPrec, readListPrecDefault)
 
 import Prelude hiding (length, foldr, read, unlines, splitAt)
 
+import qualified GHC.Exts as Exts
 import qualified Streamly.Internal.Data.Array.Unboxed.Mut.Type as MA
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
 import qualified Streamly.Internal.Data.Stream.StreamK.Type as K
 import qualified Streamly.Internal.Data.Stream.Type as Stream
+import qualified Streamly.Internal.Data.Unboxed as Unboxed
 import qualified Streamly.Internal.Data.Unfold.Type as Unfold
-import qualified GHC.Exts as Exts
 
 import Streamly.Internal.System.IO (unsafeInlineIO, defaultChunkSize)
 
@@ -595,7 +596,7 @@ nil ::
     Unboxed a =>
 #endif
     Array a
-nil = Array MA.nilArrayContents 0 0
+nil = Array Unboxed.nil 0 0
 
 instance Unboxed a => Monoid (Array a) where
     mempty = nil

--- a/core/src/Streamly/Internal/Data/Fold.hs
+++ b/core/src/Streamly/Internal/Data/Fold.hs
@@ -2812,7 +2812,7 @@ topBy cmp n = Fold step initial extract
     where
 
     initial = do
-        arr <- MA.newArray n
+        arr <- MA.newPinned n
         if n <= 0
         then return $ Done arr
         else return $ Partial (arr, 0)

--- a/core/src/Streamly/Internal/Data/IORef/Unboxed.hs
+++ b/core/src/Streamly/Internal/Data/IORef/Unboxed.hs
@@ -45,7 +45,7 @@ import Streamly.Internal.Data.Unboxed
     , sizeOf
     , peekWith
     , pokeWith
-    , newUnpinnedArrayContents
+    , newUnpinnedBytes
     )
 
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
@@ -59,7 +59,7 @@ newtype IORef a = IORef (MutableByteArray a)
 {-# INLINE newIORef #-}
 newIORef :: forall a. Unboxed a => a -> IO (IORef a)
 newIORef x = do
-    var <- newUnpinnedArrayContents (sizeOf (undefined :: a))
+    var <- newUnpinnedBytes (sizeOf (undefined :: a))
     pokeWith var 0 x
     return $ IORef var
 

--- a/core/src/Streamly/Internal/Data/Ring/Unboxed.hs
+++ b/core/src/Streamly/Internal/Data/Ring/Unboxed.hs
@@ -579,7 +579,7 @@ slidingWindowWith n (Fold step1 initial1 extract1) = Fold step initial extract
                     Done b -> Done b
 
     toArray foldRing rb rh = do
-        arr <- liftIO $ MA.newArray n
+        arr <- liftIO $ MA.newPinned n
         let snoc' b a = liftIO $ MA.snocUnsafe b a
         foldRing rh snoc' arr rb
 

--- a/core/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/core/src/Streamly/Internal/FileSystem/Handle.hs
@@ -180,7 +180,7 @@ import qualified Streamly.Internal.Data.Stream.StreamK.Type as K (mkStream)
 {-# INLINABLE getChunk #-}
 getChunk :: MonadIO m => Int -> Handle -> m (Array Word8)
 getChunk size h = liftIO $ do
-    arr <- MArray.newPinnedArrayBytes size
+    arr <- MArray.newPinnedBytes size
     -- ptr <- mallocPlainForeignPtrAlignedBytes size (alignment (undefined :: Word8))
     MArray.asPtrUnsafe arr $ \p -> do
         n <- hGetBufSome h p size

--- a/src/Streamly/Internal/FileSystem/FD.hs
+++ b/src/Streamly/Internal/FileSystem/FD.hs
@@ -146,7 +146,7 @@ import qualified Streamly.Internal.System.IOVec.Type as RawIO
 import qualified Streamly.Data.Array.Unboxed as A
 import qualified Streamly.Data.Fold as FL
 import qualified Streamly.Internal.Data.Array.Unboxed.Mut as MArray
-    (Array(..), newPinnedArrayBytes, asPtrUnsafe)
+    (Array(..), newPinnedBytes, asPtrUnsafe)
 import qualified Streamly.Internal.Data.Array.Unboxed.Stream as AS
 import qualified Streamly.Internal.Data.Stream as S
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
@@ -217,7 +217,7 @@ openFile path mode = Handle . fst <$> FD.openFile path mode True
 {-# INLINABLE readArrayUpto #-}
 readArrayUpto :: Int -> Handle -> IO (Array Word8)
 readArrayUpto size (Handle fd) = do
-    arr <- MArray.newPinnedArrayBytes size
+    arr <- MArray.newPinnedBytes size
     -- ptr <- mallocPlainForeignPtrAlignedBytes size (alignment (undefined :: Word8))
     MArray.asPtrUnsafe arr $ \p -> do
         -- n <- hGetBufSome h p size

--- a/src/Streamly/Internal/Network/Socket.hs
+++ b/src/Streamly/Internal/Network/Socket.hs
@@ -104,7 +104,7 @@ import qualified Streamly.Data.Fold as FL
 import qualified Streamly.Internal.Data.Array.Unboxed.Type as A
     (unsafeFreeze, asPtrUnsafe, byteLength, writeNUnsafe)
 import qualified Streamly.Internal.Data.Array.Unboxed.Mut as MArray
-    (Array(..), newPinnedArrayBytes, asPtrUnsafe)
+    (Array(..), newPinnedBytes, asPtrUnsafe)
 import qualified Streamly.Internal.Data.Array.Unboxed.Stream as AS
 import qualified Streamly.Internal.Data.Stream as S
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
@@ -261,7 +261,7 @@ readArrayUptoWith
     -> h
     -> IO (Array Word8)
 readArrayUptoWith f size h = do
-    arr <- MArray.newPinnedArrayBytes size
+    arr <- MArray.newPinnedBytes size
     -- ptr <- mallocPlainForeignPtrAlignedBytes size (alignment (undefined :: Word8))
     MArray.asPtrUnsafe arr $ \p -> do
         n <- f h p size

--- a/test/Streamly/Test/Data/Array/Unboxed.hs
+++ b/test/Streamly/Test/Data/Array/Unboxed.hs
@@ -155,7 +155,7 @@ testBubbleWith asc =
                     else MA.bubble (flip compare) arr
                     return arr
                 )
-                (MA.newArray $ length ls)
+                (MA.newPinned $ length ls)
 
 testBubbleAsc ::  Property
 testBubbleAsc = testBubbleWith True
@@ -165,7 +165,7 @@ testBubbleDesc = testBubbleWith False
 
 testByteLengthWithMA :: forall a. Unboxed a => a -> IO ()
 testByteLengthWithMA _ = do
-     arrA <- MA.newArray 100 :: IO (MA.Array a)
+     arrA <- MA.newPinned 100 :: IO (MA.Array a)
      let arrW8 = MA.castUnsafe arrA :: MA.Array Word8
      MA.byteLength arrA `shouldBe` MA.length arrW8
 

--- a/test/Streamly/Test/Data/Array/Unboxed/Mut.hs
+++ b/test/Streamly/Test/Data/Array/Unboxed/Mut.hs
@@ -42,7 +42,7 @@ testAppend =
 
         action ls = do
             x <- Stream.fold
-                    (MArray.append (MArray.newArray 0))
+                    (MArray.append (MArray.newPinned 0))
                     (Stream.fromList (ls::[Int]))
             lst <- MArray.toList x
             assert (ls == lst)


### PR DESCRIPTION
Added Unboxed.newUnpinnedBytes and Mut.Type.newUnpinnedArray

Array.Unboxed.Mut.Type.nilArrayContents -> Unboxed.nil Array.Unboxed.Mut.Type.newAlignedArrayContents -> Unboxed.newAlignedPinnedBytes

Mut.Type:
newArray -> newPinnedArray
newArrayAligned -> newAlignedPinnedArray

Unboxed:
newUnpinnedArrayContents -> newUnpinnedBytes