### PR TITLE
Move IsStream modules to deprecated section

### DIFF
--- a/streamly.cabal
+++ b/streamly.cabal
@@ -332,6 +332,46 @@ library
 
                      -- streamly-concurrent
                      , Streamly.Internal.Data.Atomics
+                     , Streamly.Internal.Data.Stream.Channel.Types
+                     , Streamly.Internal.Data.Stream.Channel.Dispatcher
+                     , Streamly.Internal.Data.Stream.Channel.Worker
+
+                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Type
+                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Dispatcher
+                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Consumer
+                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Append
+                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Interleave
+                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Operations
+                     , Streamly.Internal.Data.Stream.Concurrent.Channel
+                     , Streamly.Internal.Data.Stream.Concurrent
+
+                     -- streamly-unicode
+                     , Streamly.Internal.Unicode.Utf8
+                     , Streamly.Internal.Unicode.Char
+
+                     -- streamly-filesystem
+                     , Streamly.Internal.FileSystem.Dir
+                     , Streamly.Internal.FileSystem.File
+
+                     -- streamly-network
+                     , Streamly.Internal.Network.Socket
+                     , Streamly.Internal.Network.Inet.TCP
+
+                     -- Exposed modules
+                     , Streamly.Data.Stream.Concurrent
+
+                     -- Network/IO
+                     , Streamly.Network.Socket
+                     , Streamly.Network.Inet.TCP
+
+                     -- Deprecated
+                     , Streamly
+                     , Streamly.Data.Unicode.Stream
+                     , Streamly.Memory.Array
+                     , Streamly.Data.Array.Foreign
+                     , Streamly.Prelude
+
+                     -- Deprecated Internal modules
                      , Streamly.Internal.Data.SVar.Worker
                      , Streamly.Internal.Data.SVar.Dispatch
                      , Streamly.Internal.Data.SVar.Pull
@@ -346,18 +386,6 @@ library
                      , Streamly.Internal.Data.Stream.Serial
                      , Streamly.Internal.Data.Stream.Async
                      , Streamly.Internal.Data.Stream.Parallel
-                     , Streamly.Internal.Data.Stream.Channel.Types
-                     , Streamly.Internal.Data.Stream.Channel.Dispatcher
-                     , Streamly.Internal.Data.Stream.Channel.Worker
-
-                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Type
-                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Dispatcher
-                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Consumer
-                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Append
-                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Interleave
-                     , Streamly.Internal.Data.Stream.Concurrent.Channel.Operations
-                     , Streamly.Internal.Data.Stream.Concurrent.Channel
-                     , Streamly.Internal.Data.Stream.Concurrent
                      , Streamly.Internal.Data.Stream.Ahead
                      , Streamly.Internal.Data.Stream.ZipAsync
 
@@ -374,32 +402,6 @@ library
                      , Streamly.Internal.Data.Stream.IsStream.Lift
                      , Streamly.Internal.Data.Stream.IsStream.Top
                      , Streamly.Internal.Data.Stream.IsStream
-
-                     -- streamly-unicode
-                     , Streamly.Internal.Unicode.Utf8
-                     , Streamly.Internal.Unicode.Char
-
-                     -- streamly-filesystem
-                     , Streamly.Internal.FileSystem.Dir
-                     , Streamly.Internal.FileSystem.File
-
-                     -- streamly-network
-                     , Streamly.Internal.Network.Socket
-                     , Streamly.Internal.Network.Inet.TCP
-
-                     -- Exposed modules
-                     , Streamly.Prelude
-                     , Streamly.Data.Stream.Concurrent
-
-                     -- Network/IO
-                     , Streamly.Network.Socket
-                     , Streamly.Network.Inet.TCP
-
-                     -- Deprecated
-                     , Streamly
-                     , Streamly.Data.Unicode.Stream
-                     , Streamly.Memory.Array
-                     , Streamly.Data.Array.Foreign
 
     if !impl(ghcjs) && flag(dev)
         exposed-modules:


### PR DESCRIPTION
All these modules are to be deprecated after ensuring that all equivalent functionality is available in other modules.