### PR TITLE
Rename some parsers

### DIFF
--- a/benchmark/Streamly/Benchmark/Data/Parser.hs
+++ b/benchmark/Streamly/Benchmark/Data/Parser.hs
@@ -153,13 +153,13 @@ takeFramedByEsc_ _ = Stream.parse parser
 
     parser = PR.takeFramedByEsc_ isEsc isBegin isEnd Fold.drain
 
+{-# INLINE listEqBy #-}
+listEqBy :: Int -> Stream IO Int -> IO [Int]
+listEqBy len = Stream.parse (PR.listEqBy (==) [1 .. len])
+
 {-# INLINE eqBy #-}
 eqBy :: Int -> Stream IO Int -> IO ()
-eqBy len = Stream.parse (PR.eqBy (==) [1 .. len])
-
-{-# INLINE matchBy #-}
-matchBy :: Int -> Stream IO Int -> IO ()
-matchBy len = Stream.parse (PR.matchBy (==) (Stream.enumerateFromTo 1 len))
+eqBy len = Stream.parse (PR.eqBy (==) (Stream.enumerateFromTo 1 len))
 
 {-# INLINE takeWhile #-}
 takeWhile :: MonadThrow m => Int -> Stream m Int -> m ()
@@ -481,8 +481,8 @@ o_1_space_serial value =
     , benchIOSink value "concatSequence" concatSequence
     , benchIOSink value "parseMany (groupBy (<))" (parseManyGroupBy (<))
     , benchIOSink value "parseMany (groupBy (==))" (parseManyGroupBy (==))
+    , benchIOSink value "listEqBy" (listEqBy value)
     , benchIOSink value "eqBy" (eqBy value)
-    , benchIOSink value "matchBy" (matchBy value)
     ]
 
 o_1_space_filesystem :: BenchEnv -> [Benchmark]

--- a/benchmark/Streamly/Benchmark/Data/Parser/ParserD.hs
+++ b/benchmark/Streamly/Benchmark/Data/Parser/ParserD.hs
@@ -66,13 +66,13 @@ benchIOSink value name f =
 -- Parsers
 -------------------------------------------------------------------------------
 
+{-# INLINE listEqBy #-}
+listEqBy :: Int -> Stream IO Int -> IO [Int]
+listEqBy len = Stream.parseD (PR.listEqBy (==) [1 .. len])
+
 {-# INLINE eqBy #-}
 eqBy :: Int -> Stream IO Int -> IO ()
-eqBy len = Stream.parseD (PR.eqBy (==) [1 .. len])
-
-{-# INLINE matchBy #-}
-matchBy :: Int -> Stream IO Int -> IO ()
-matchBy len = Stream.parseD (PR.matchBy (==) (D.enumerateFromToIntegral 1 len))
+eqBy len = Stream.parseD (PR.eqBy (==) (D.enumerateFromToIntegral 1 len))
 
 {-# INLINE drainWhile #-}
 drainWhile :: MonadThrow m => (a -> Bool) -> PR.Parser m a ()
@@ -359,8 +359,8 @@ o_1_space_serial value =
     , benchIOSink value "longest (all,any)" $ longestAllAny value
     -}
     , benchIOSink value "sequenceParser" sequenceParser
+    , benchIOSink value "listEqBy" (listEqBy value)
     , benchIOSink value "eqBy" (eqBy value)
-    , benchIOSink value "matchBy" (matchBy value)
     ]
 
 o_1_space_serial_spanning :: Int -> [Benchmark]

--- a/core/src/Streamly/Data/Parser.hs
+++ b/core/src/Streamly/Data/Parser.hs
@@ -38,8 +38,8 @@ module Streamly.Data.Parser
 
     -- All of these can be expressed in terms of either
     , one
-    , element
-    , except
+    -- , oneEq
+    -- , oneNotEq
     , oneOf
     , noneOf
     , satisfy
@@ -49,7 +49,8 @@ module Streamly.Data.Parser
 
     -- ** Sequences
     , eqBy
-    , list
+    , listEqBy
+    , listEq
 
     -- * Combinators
     -- Mapping on output

--- a/core/src/Streamly/Internal/Data/Parser.hs
+++ b/core/src/Streamly/Internal/Data/Parser.hs
@@ -248,11 +248,6 @@ module Streamly.Internal.Data.Parser
     )
 where
 
-import Data.Functor (($>))
-import Prelude hiding
-    ( any, all, dropWhile, take, takeWhile, sequence, concatMap, maybe, either
-    , filter )
-
 import Streamly.Internal.Data.Fold.Type (Fold(..))
 import Streamly.Internal.Data.Parser.ParserK.Type (Parser)
 import Streamly.Internal.Data.Stream.Type (Stream)
@@ -261,6 +256,10 @@ import qualified Streamly.Internal.Data.Fold.Type as FL
 import qualified Streamly.Internal.Data.Parser.ParserD as D
 import qualified Streamly.Internal.Data.Parser.ParserK.Type as K
 import qualified Streamly.Internal.Data.Stream.Type as Stream
+
+import Prelude hiding
+    ( any, all, dropWhile, take, takeWhile, sequence, concatMap, maybe, either
+    , filter )
 
 --
 -- $setup

--- a/core/src/Streamly/Internal/Data/Parser.hs
+++ b/core/src/Streamly/Internal/Data/Parser.hs
@@ -76,8 +76,8 @@ module Streamly.Internal.Data.Parser
 
     -- All of these can be expressed in terms of either
     , one
-    , element
-    , except
+    , oneEq
+    , oneNotEq
     , oneOf
     , noneOf
     , eof
@@ -102,9 +102,9 @@ module Streamly.Internal.Data.Parser
 
     -- Grab a sequence of input elements by inspecting them
     -- ** Exact match
+    , listEq
+    , listEqBy
     , eqBy
-    , matchBy
-    , list
 
     -- ** By predicate
     , takeWhileP
@@ -463,19 +463,19 @@ one = satisfy $ const True
 
 -- | Match a specific element.
 --
--- >>> element x = Parser.satisfy (== x)
+-- >>> oneEq x = Parser.satisfy (== x)
 --
-{-# INLINE element #-}
-element :: (Monad m, Eq a) => a -> Parser m a a
-element x = satisfy (== x)
+{-# INLINE oneEq #-}
+oneEq :: (Monad m, Eq a) => a -> Parser m a a
+oneEq x = satisfy (== x)
 
 -- | Match anything other than the supplied element.
 --
--- >>> except x = Parser.satisfy (/= x)
+-- >>> oneNotEq x = Parser.satisfy (/= x)
 --
-{-# INLINE except #-}
-except :: (Monad m, Eq a) => a -> Parser m a a
-except x = satisfy (/= x)
+{-# INLINE oneNotEq #-}
+oneNotEq :: (Monad m, Eq a) => a -> Parser m a a
+oneNotEq x = satisfy (/= x)
 
 -- | Match any one of the elements in the supplied list.
 --
@@ -1026,30 +1026,36 @@ groupByRollingEither :: Monad m =>
 groupByRollingEither eq f1 = D.toParserK . D.groupByRollingEither eq f1
 
 -- | Match the given sequence of elements using the given comparison function.
+-- Returns the original sequence if successful.
 --
--- >>> Stream.parse (Parser.eqBy (==) "string") $ Stream.fromList "string"
+-- >>> Stream.parse (Parser.listEqBy (==) "string") $ Stream.fromList "string"
 --
--- >>> Stream.parse (Parser.eqBy (==) "mismatch") $ Stream.fromList "match"
--- *** Exception: ParseError "eqBy: failed, yet to match 7 elements"
+-- >>> Stream.parse (Parser.listEqBy (==) "mismatch") $ Stream.fromList "match"
+-- *** Exception: ParseError "listEqBy: failed, yet to match 7 elements"
 --
 -- /Pre-release/
 --
-{-# INLINE eqBy #-}
-eqBy :: Monad m => (a -> a -> Bool) -> [a] -> Parser m a ()
-eqBy cmp = D.toParserK . D.eqBy cmp
+{-# INLINE listEqBy #-}
+listEqBy :: Monad m => (a -> a -> Bool) -> [a] -> Parser m a [a]
+listEqBy cmp xs = D.toParserK (D.listEqBy cmp xs)
 
--- | Like eqBy but uses a stream instead of a list
-{-# INLINE matchBy #-}
-matchBy :: Monad m => (a -> a -> Bool) -> Stream m a -> Parser m a ()
-matchBy cmp = D.toParserK . D.matchBy cmp . Stream.toStreamD
+-- | Like 'listEqBy' but uses a stream instead of a list and does not return
+-- the stream.
+--
+-- /Pre-release/
+{-# INLINE eqBy #-}
+eqBy :: Monad m => (a -> a -> Bool) -> Stream m a -> Parser m a ()
+eqBy cmp = D.toParserK . D.eqBy cmp . Stream.toStreamD
 
 -- | Match the input sequence with the supplied list and return it if
 -- successful.
 --
+-- >>> listEq = Parser.listEqBy (==)
+--
 -- /Pre-release/
-{-# INLINE list #-}
-list :: (Monad m, Eq a) => [a] -> Parser m a [a]
-list xs = eqBy (==) xs $> xs
+{-# INLINE listEq #-}
+listEq :: (Monad m, Eq a) => [a] -> Parser m a [a]
+listEq = listEqBy (==)
 
 -------------------------------------------------------------------------------
 -- nested parsers

--- a/core/src/Streamly/Internal/Data/Parser.hs
+++ b/core/src/Streamly/Internal/Data/Parser.hs
@@ -1028,6 +1028,7 @@ groupByRollingEither eq f1 = D.toParserK . D.groupByRollingEither eq f1
 -- Returns the original sequence if successful.
 --
 -- >>> Stream.parse (Parser.listEqBy (==) "string") $ Stream.fromList "string"
+-- "string"
 --
 -- >>> Stream.parse (Parser.listEqBy (==) "mismatch") $ Stream.fromList "match"
 -- *** Exception: ParseError "listEqBy: failed, yet to match 7 elements"

--- a/core/src/Streamly/Internal/Unicode/Char/Parser.hs
+++ b/core/src/Streamly/Internal/Unicode/Char/Parser.hs
@@ -65,7 +65,7 @@ import qualified Streamly.Internal.Data.Parser as Parser
     (
       lmap
     , satisfy
-    , list
+    , listEq
     , takeWhile1
     , dropWhile
     )
@@ -183,12 +183,13 @@ charIgnoreCase c = Parser.lmap Char.toLower (Parser.satisfy (== Char.toLower c))
 
 -- | Match the input with the supplied string and return it if successful.
 string :: MonadCatch m => String -> Parser m Char String
-string = Parser.list
+string = Parser.listEq
 
 -- XXX Not accurate unicode case conversion
 -- | Match the input with the supplied string and return it if successful.
 stringIgnoreCase :: MonadCatch m => String -> Parser m Char String
-stringIgnoreCase s = Parser.lmap Char.toLower (Parser.list (map Char.toLower s))
+stringIgnoreCase s =
+    Parser.lmap Char.toLower (Parser.listEq (map Char.toLower s))
 
 -- | Drop /zero/ or more white space characters.
 dropSpace :: MonadCatch m => Parser m Char ()


### PR DESCRIPTION
Rename:
element -> oneEq
except -> oneNotEq
eqBy -> listEqBy
matchBy -> eqBy

Change the signature of eqBy to return the list.