### PR TITLE
Add stream ops and rename fold ops in the network module

### DIFF
--- a/src/Streamly/Internal/Network/Inet/TCP.hs
+++ b/src/Streamly/Internal/Network/Inet/TCP.hs
@@ -68,7 +68,7 @@ module Streamly.Internal.Network.Inet.TCP
     , putChunks
 
     -- ** Transformation
-    , processBytes
+    , pipeBytes
     {-
     -- ** Sink Servers
 
@@ -452,11 +452,11 @@ withInputConnect addr port input f = S.bracket pre post handler
 --
 -- /Pre-release/
 --
-{-# INLINE processBytes #-}
-processBytes
+{-# INLINE pipeBytes #-}
+pipeBytes
     :: (MonadAsync m, MonadCatch m)
     => (Word8, Word8, Word8, Word8)
     -> PortNumber
     -> Stream m Word8
     -> Stream m Word8
-processBytes addr port input = withInputConnect addr port input ISK.toBytes
+pipeBytes addr port input = withInputConnect addr port input ISK.toBytes

--- a/src/Streamly/Network/Inet/TCP.hs
+++ b/src/Streamly/Network/Inet/TCP.hs
@@ -15,9 +15,10 @@
 module Streamly.Network.Inet.TCP
     (
     -- * Accept Connections
-      acceptOnAddr
-    , acceptOnPort
-    , acceptOnPortLocal
+    -- ** Unfolds
+      acceptorOnAddr
+    , acceptorOnPort
+    , acceptorOnPortLocal
 
     -- * Connect to Servers
     , connect
@@ -25,7 +26,7 @@ module Streamly.Network.Inet.TCP
     {-
     -- XXX Expose this as a pipe when we have pipes.
     -- * Transformation
-    -- , processBytes
+    -- , pipeBytes
 
     -- ** Sink Servers
 
@@ -47,7 +48,34 @@ module Streamly.Network.Inet.TCP
     , datagrams
     , datagramsOn
     -}
+    -- * Deprecated
+    , acceptOnAddr
+    , acceptOnPort
+    , acceptOnPortLocal
     )
 where
 
+import Control.Monad.IO.Class (MonadIO(..))
+import Data.Word (Word8)
+import Network.Socket (Socket, PortNumber)
+import Streamly.Internal.Data.Unfold.Type (Unfold(..))
+
 import Streamly.Internal.Network.Inet.TCP
+    hiding (acceptOnAddr, acceptOnPort, acceptOnPortLocal)
+
+{-# DEPRECATED acceptOnAddr "Please use 'acceptorOnAddr' instead" #-}
+{-# INLINE acceptOnAddr #-}
+acceptOnAddr
+    :: MonadIO m
+    => Unfold m ((Word8, Word8, Word8, Word8), PortNumber) Socket
+acceptOnAddr = acceptorOnAddr
+
+{-# DEPRECATED acceptOnPort "Please use 'acceptorOnPort' instead" #-}
+{-# INLINE acceptOnPort #-}
+acceptOnPort :: MonadIO m => Unfold m PortNumber Socket
+acceptOnPort = acceptorOnPort
+
+{-# DEPRECATED acceptOnPortLocal "Please use 'acceptorOnPortLocal' instead" #-}
+{-# INLINE acceptOnPortLocal #-}
+acceptOnPortLocal :: MonadIO m => Unfold m PortNumber Socket
+acceptOnPortLocal = acceptorOnPortLocal

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -101,7 +101,7 @@ module Streamly.Network.Socket
 
     -- * Reads
     -- ** Singleton
-    , readChunk
+    , getChunk
 
     -- ** Unfolds
     , reader
@@ -111,7 +111,7 @@ module Streamly.Network.Socket
 
     -- * Writes
     -- ** Singleton
-    , writeChunk
+    , putChunk
 
     -- ** Folds
     , write
@@ -124,6 +124,8 @@ module Streamly.Network.Socket
 
     -- * Deprecated
     , accept
+    , readChunk
+    , writeChunk
     , read
     , readWithBufferOf
     , readChunks
@@ -138,6 +140,7 @@ import Data.Word (Word8)
 import Network.Socket (Socket, SockAddr)
 import Streamly.Internal.Data.Unfold.Type (Unfold(..))
 import Streamly.Internal.Data.Array.Unboxed.Type (Array(..))
+import Streamly.Internal.Data.Unboxed (Unbox)
 
 import Streamly.Internal.Network.Socket hiding (accept, read, readChunks)
 import Prelude hiding (read)
@@ -146,6 +149,16 @@ import Prelude hiding (read)
 {-# INLINE accept #-}
 accept :: MonadIO m => Unfold m (Int, SockSpec, SockAddr) Socket
 accept = acceptor
+
+{-# DEPRECATED readChunk "Please use 'getChunk' instead" #-}
+{-# INLINABLE readChunk #-}
+readChunk :: Int -> Socket -> IO (Array Word8)
+readChunk = getChunk
+
+{-# DEPRECATED writeChunk "Please use 'putChunk' instead" #-}
+{-# INLINABLE writeChunk #-}
+writeChunk :: Unbox a => Socket -> Array a -> IO ()
+writeChunk = putChunk
 
 {-# DEPRECATED read "Please use 'reader' instead" #-}
 {-# INLINE read #-}

--- a/src/Streamly/Network/Socket.hs
+++ b/src/Streamly/Network/Socket.hs
@@ -97,32 +97,62 @@ module Streamly.Network.Socket
       SockSpec(..)
 
     -- * Accept Connections
-    , accept
+    , acceptor
 
-    -- * Read
-    , read
-    , readWith
-    , readChunks
-    , readChunksWith
+    -- * Reads
+    -- ** Singleton
     , readChunk
 
-    -- * Write
+    -- ** Unfolds
+    , reader
+    , readerWith
+    , chunkReader
+    , chunkReaderWith
+
+    -- * Writes
+    -- ** Singleton
+    , writeChunk
+
+    -- ** Folds
     , write
     , writeWith
     , writeChunks
     , writeChunksWith
-    , writeChunk
 
     -- * Exceptions
     , forSocketM
 
     -- * Deprecated
+    , accept
+    , read
     , readWithBufferOf
+    , readChunks
     , readChunksWithBufferOf
     , writeWithBufferOf
     , writeChunksWithBufferOf
     )
 where
 
-import Streamly.Internal.Network.Socket
+import Control.Monad.IO.Class (MonadIO(..))
+import Data.Word (Word8)
+import Network.Socket (Socket, SockAddr)
+import Streamly.Internal.Data.Unfold.Type (Unfold(..))
+import Streamly.Internal.Data.Array.Unboxed.Type (Array(..))
+
+import Streamly.Internal.Network.Socket hiding (accept, read, readChunks)
 import Prelude hiding (read)
+
+{-# DEPRECATED accept "Please use 'acceptor' instead" #-}
+{-# INLINE accept #-}
+accept :: MonadIO m => Unfold m (Int, SockSpec, SockAddr) Socket
+accept = acceptor
+
+{-# DEPRECATED read "Please use 'reader' instead" #-}
+{-# INLINE read #-}
+read :: MonadIO m => Unfold m Socket Word8
+read = reader
+
+{-# DEPRECATED readChunks "Please use 'chunkReader' instead" #-}
+{-# INLINE readChunks #-}
+readChunks :: MonadIO m => Unfold m Socket (Array Word8)
+readChunks = chunkReader


### PR DESCRIPTION
Add stream generating operations as alternatives to unfolds. Stream
opertions are for common use. Unfolds are for optimizations in nested
use.

Rename the fold operations from "write*" to "put*". The "write*"
operations can be used for "Refold"s in future.