### PR TITLE
Allow "Continue 0" case in parser extract

### DIFF
--- a/core/src/Streamly/Internal/Data/Array/Unboxed/Stream.hs
+++ b/core/src/Streamly/Internal/Data/Array/Unboxed/Stream.hs
@@ -744,8 +744,8 @@ parseBreakK (PRD.Parser pstep initial extract) stream = do
         pRes <- extract pst
         case pRes of
             PR.Partial _ _ -> error "Bug: parseBreak: Partial in extract"
-            PR.Continue 0 _ ->
-                error "parseBreak: extract, Continue 0 creates infinite loop"
+            PR.Continue 0 s ->
+                goStop s backBuf
             PR.Continue n s -> do
                 assert (n <= Prelude.length backBuf) (return ())
                 let (src0, buf1) = splitAt n backBuf
@@ -897,8 +897,8 @@ runArrayParserDBreak
         pRes <- extract pst
         case pRes of
             PR.Partial _ _ -> error "Bug: runArrayParserDBreak: Partial in extract"
-            PR.Continue 0 _ ->
-                error "runArrayParserDBreak: extract, Continue 0 creates infinite loop"
+            PR.Continue 0 pst1 ->
+                goStop backBuf pst1
             PR.Continue n pst1 -> do
                 assert
                     (n <= sum (map Array.length (getList backBuf)))
@@ -1123,7 +1123,8 @@ runArrayFoldManyD
         pRes <- extract pst
         case pRes of
             PR.Partial _ _ -> error "runArrayFoldManyD: Partial in extract"
-            PR.Continue 0 _ -> error "runArrayFoldManyD: Continue 0 in extract"
+            PR.Continue 0 pst1 ->
+                return $ D.Skip $ ParseChunksStop backBuf pst1
             PR.Continue n pst1 -> do
                 assert (n <= sum (map Array.length backBuf)) (return ())
                 let (src0, buf1) = splitAtArrayListRev n backBuf

--- a/core/src/Streamly/Internal/Data/Parser/ParserK/Type.hs
+++ b/core/src/Streamly/Internal/Data/Parser/ParserK/Type.hs
@@ -84,14 +84,14 @@ instance Functor Parse where
 --
 newtype Parser m a b = MkParser
     { runParser :: forall r.
-           -- The number of elements that were not used by the previous
-           -- consumer and should be carried forward.
+           -- leftover: the number of elements that were not used by the
+           -- previous consumer and should be carried forward.
            Int
-           -- (nesting level, used elem count). Nesting level is increased
-           -- whenever we enter an Alternative composition and decreased when
-           -- it is done. The used element count is a count of elements
-           -- consumed by the Alternative. If the Alternative fails we need to
-           -- backtrack by this amount.
+           -- (alt nesting level, alt used elem count). Nesting level is
+           -- increased whenever we enter an Alternative composition and
+           -- decreased when it is done. The used element count is a count of
+           -- elements consumed by the Alternative. If the Alternative fails we
+           -- need to backtrack by this amount.
            --
            -- The nesting level is used in parseDToK to optimize the case when
            -- we are not in an alternative, in that case we do not need to

--- a/core/src/Streamly/Internal/Data/Producer/Source.hs
+++ b/core/src/Streamly/Internal/Data/Producer/Source.hs
@@ -221,8 +221,8 @@ parseD
         pRes <- extract pst
         case pRes of
             Partial _ _ -> error "Bug: parseD: Partial in extract"
-            Continue 0 _ ->
-                error "parseD: extract, Continue 0 creates infinite loop"
+            Continue 0 pst1 ->
+                goStop buf pst1
             Continue n pst1 -> do
                 assert (n <= length (getList buf)) (return ())
                 let (src0, buf1) = splitAt n (getList buf)

--- a/core/src/Streamly/Internal/Data/Stream/Eliminate.hs
+++ b/core/src/Streamly/Internal/Data/Stream/Eliminate.hs
@@ -221,6 +221,8 @@ foldlT f z s = D.foldlT f z (toStreamD s)
 parseD :: MonadThrow m => PRD.Parser m a b -> Stream m a -> m b
 parseD p = D.parse p . toStreamD
 
+-- XXX Drive directly as parserK rather than converting to parserD first.
+
 -- | Parse a stream using the supplied ParserK 'PRK.Parser'.
 --
 -- /Internal/

--- a/core/src/Streamly/Internal/Data/Stream/StreamD/Eliminate.hs
+++ b/core/src/Streamly/Internal/Data/Stream/StreamD/Eliminate.hs
@@ -253,13 +253,13 @@ parseBreak (PRD.Parser pstep initial extract) stream@(Stream step state) = do
             PR.Error err -> throwM $ ParseError err
 
     -- This is simplified goExtract
+    -- XXX Use SPEC?
     {-# INLINE goStop #-}
     goStop buf pst = do
         pRes <- extract pst
         case pRes of
             PR.Partial _ _ -> error "Bug: parseBreak: Partial in extract"
-            PR.Continue 0 _ ->
-                error "parseBreak: extract, Continue 0 creates infinite loop"
+            PR.Continue 0 pst1 -> goStop buf pst1
             PR.Continue n pst1 -> do
                 assert (n <= length (getList buf)) (return ())
                 let (src0, buf1) = splitAt n (getList buf)

--- a/core/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
+++ b/core/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
@@ -1300,8 +1300,8 @@ parseMany (PRD.Parser pstep initial extract) (Stream step state) =
         pRes <- extract pst
         case pRes of
             PR.Partial _ _ -> error "Bug: parseMany: Partial in extract"
-            PR.Continue 0 _ ->
-                error "parseMany: extract, Continue 0 creates infinite loop"
+            PR.Continue 0 pst1 ->
+                return $ Skip $ ParseChunksStop buf pst1
             PR.Continue n pst1 -> do
                 assert (n <= length buf) (return ())
                 let (src0, buf1) = splitAt n buf
@@ -1480,8 +1480,8 @@ parseIterate func seed (Stream step state) =
         pRes <- extract pst
         case pRes of
             PR.Partial _ _ -> error "Bug: parseIterate: Partial in extract"
-            PR.Continue 0 _ ->
-                error "parseIterate: extract, Continue 0 creates infinite loop"
+            PR.Continue 0 pst1 ->
+                return $ Skip $ ConcatParseStop buf pstep pst1 extract
             PR.Continue n pst1 -> do
                 assert (n <= length buf) (return ())
                 let (src0, buf1) = splitAt n buf

--- a/core/src/Streamly/Internal/Data/Stream/StreamK.hs
+++ b/core/src/Streamly/Internal/Data/Stream/StreamK.hs
@@ -1054,7 +1054,7 @@ parseBreak (PR.Parser pstep initial extract) stream = do
                             src  = Prelude.reverse src0
                         return (b, fromList src)
                     PR.Partial _ _ -> error "Bug: parseBreak: Partial in extract"
-                    PR.Continue 0 _ -> error "parseBreak: extract, Continue 0 creates infinite loop"
+                    PR.Continue 0 s -> goStream nil buf s
                     PR.Continue n s -> do
                         assertM(n <= length buf)
                         let (src0, buf1) = splitAt n buf


### PR DESCRIPTION
It can happen if the first parser in an alternative does not receive sufficient input but the next parser can work even without input.