### PR TITLE
Fix escape processing in wordWithQuotes

### DIFF
--- a/core/src/Streamly/Data/Parser.hs
+++ b/core/src/Streamly/Data/Parser.hs
@@ -127,7 +127,8 @@ module Streamly.Data.Parser
     -- ** Framing
     -- , wordFramedBy
     , wordWithQuotes
-    , wordStripQuotes
+    -- , wordProcessQuotes
+    -- , wordKeepQuotes
 
     -- * Alternative
     , alt


### PR DESCRIPTION
To escape characters in the same way as shell and to be able to specify escape transliteration, and transliterate based on the type of quote.