### PR TITLE
Rename chunksOf to groupsOf

### DIFF
--- a/core/src/Streamly/Data/Fold.hs
+++ b/core/src/Streamly/Data/Fold.hs
@@ -325,7 +325,7 @@ module Streamly.Data.Fold
 
     -- ** Splitting
     , many
-    , chunksOf
+    , groupsOf
     -- , intervalsOf
 
     -- ** Nesting
@@ -335,6 +335,7 @@ module Streamly.Data.Fold
     , morphInner
 
     -- * Deprecated
+    , chunksOf
     , foldr
     , drainBy
     , last
@@ -362,3 +363,12 @@ import Streamly.Internal.Data.Fold.Container
 -- >>> import Data.Function ((&))
 -- >>> import qualified Streamly.Data.Fold as Fold
 -- >>> import qualified Streamly.Data.Stream as Stream
+
+--------------------------------------------------------------------------------
+-- Deprecated
+--------------------------------------------------------------------------------
+
+{-# DEPRECATED chunksOf "Please use 'groupsOf' instead" #-}
+{-# INLINE chunksOf #-}
+chunksOf :: Monad m => Int -> Fold m a b -> Fold m b c -> Fold m a c
+chunksOf = groupsOf

--- a/core/src/Streamly/Internal/Data/Fold.hs
+++ b/core/src/Streamly/Internal/Data/Fold.hs
@@ -283,7 +283,7 @@ module Streamly.Internal.Data.Fold
     -- ** Splitting
     , many
     , manyPost
-    , chunksOf
+    , groupsOf
     , chunksBetween
     , refoldMany
     , refoldMany1
@@ -461,7 +461,7 @@ breakStreamK strm fl = fmap f $ K.foldBreak fl (Stream.toStreamK strm)
 --
 -- >>> :{
 -- let f :: Fold IO Int (Stream Identity (Array Int))
---     f = Fold.chunksOf 2 (Array.writeN 3) Fold.toStream
+--     f = Fold.groupsOf 2 (Array.writeN 3) Fold.toStream
 -- in pure f
 --     >>= Fold.addOne 1
 --     >>= Fold.addStream (Stream.enumerateFromTo 2 4)

--- a/core/src/Streamly/Internal/Data/Fold/Type.hs
+++ b/core/src/Streamly/Internal/Data/Fold/Type.hs
@@ -382,7 +382,7 @@ module Streamly.Internal.Data.Fold.Type
     , ManyState
     , many
     , manyPost
-    , chunksOf
+    , groupsOf
     , refoldMany
     , refoldMany1
 
@@ -1334,7 +1334,7 @@ catEithers = lmap (either id id)
 -- Parsing
 ------------------------------------------------------------------------------
 
--- Required to fuse "take" with "many" in "chunksOf", for ghc-9.x
+-- Required to fuse "take" with "many" in "groupsOf", for ghc-9.x
 {-# ANN type Tuple'Fused Fuse #-}
 data Tuple'Fused a b = Tuple'Fused !a !b deriving Show
 
@@ -1712,25 +1712,25 @@ manyPost (Fold sstep sinitial sextract) (Fold cstep cinitial cextract) =
             Partial s -> cextract s
             Done b -> return b
 
--- | @chunksOf n split collect@ repeatedly applies the @split@ fold to chunks
+-- | @groupsOf n split collect@ repeatedly applies the @split@ fold to chunks
 -- of @n@ items in the input stream and supplies the result to the @collect@
 -- fold.
 --
 -- Definition:
 --
--- >>> chunksOf n split = Fold.many (Fold.take n split)
+-- >>> groupsOf n split = Fold.many (Fold.take n split)
 --
 -- Example:
 --
--- >>> twos = Fold.chunksOf 2 Fold.toList Fold.toList
+-- >>> twos = Fold.groupsOf 2 Fold.toList Fold.toList
 -- >>> Stream.fold twos $ Stream.fromList [1..10]
 -- [[1,2],[3,4],[5,6],[7,8],[9,10]]
 --
 -- Stops when @collect@ stops.
 --
-{-# INLINE chunksOf #-}
-chunksOf :: Monad m => Int -> Fold m a b -> Fold m b c -> Fold m a c
-chunksOf n split = many (take n split)
+{-# INLINE groupsOf #-}
+groupsOf :: Monad m => Int -> Fold m a b -> Fold m b c -> Fold m a c
+groupsOf n split = many (take n split)
 
 ------------------------------------------------------------------------------
 -- Refold and Fold Combinators

--- a/core/src/Streamly/Internal/Data/Stream/Chunked.hs
+++ b/core/src/Streamly/Internal/Data/Stream/Chunked.hs
@@ -111,7 +111,7 @@ import qualified Streamly.Internal.Data.Stream.StreamK as K
 -- | @arraysOf n stream@ groups the elements in the input stream into arrays of
 -- @n@ elements each.
 --
--- > arraysOf n = Stream.chunksOf n (Array.writeN n)
+-- > arraysOf n = Stream.groupsOf n (Array.writeN n)
 --
 -- /Pre-release/
 {-# INLINE arraysOf #-}
@@ -541,7 +541,7 @@ toArraysInRange low high (Fold step initial extract) =
 {-# INLINE _toArraysOf #-}
 _toArraysOf :: (MonadIO m, Unbox a)
     => Int -> Fold m a (Stream Identity (Array a))
-_toArraysOf n = FL.chunksOf n (A.writeNF n) FL.toStream
+_toArraysOf n = FL.groupsOf n (A.writeNF n) FL.toStream
 -}
 
 -------------------------------------------------------------------------------

--- a/core/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
+++ b/core/src/Streamly/Internal/Data/Stream/StreamD/Nesting.hs
@@ -138,7 +138,7 @@ module Streamly.Internal.Data.Stream.StreamD.Nesting
 
     -- ** Grouping
     -- | Group segments of a stream and fold. Special case of parsing.
-    , chunksOf
+    , groupsOf
     , groupsBy
     , groupsRollingBy
 

--- a/core/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
+++ b/core/src/Streamly/Internal/Data/Stream/StreamD/Type.hs
@@ -120,7 +120,7 @@ module Streamly.Internal.Data.Stream.StreamD.Type
     , FoldManyPost (..)
     , foldMany
     , foldManyPost
-    , chunksOf
+    , groupsOf
     , refoldMany
 
     -- * Fold Iterate
@@ -1860,9 +1860,9 @@ foldMany (Fold fstep initial extract) (Stream step state) =
     step' _ (FoldManyYield b next) = return $ Yield b next
     step' _ FoldManyDone = return Stop
 
-{-# INLINE chunksOf #-}
-chunksOf :: Monad m => Int -> Fold m a b -> Stream m a -> Stream m b
-chunksOf n f = foldMany (FL.take n f)
+{-# INLINE groupsOf #-}
+groupsOf :: Monad m => Int -> Fold m a b -> Stream m a -> Stream m b
+groupsOf n f = foldMany (FL.take n f)
 
 -- Keep the argument order consistent with refoldIterateM.
 

--- a/core/src/Streamly/Internal/FileSystem/Dir.hs
+++ b/core/src/Streamly/Internal/FileSystem/Dir.hs
@@ -448,7 +448,7 @@ writeChunksWithBufferOf n h = lpackArraysChunksOf n (writeChunks h)
 -- @since 0.7.0
 {-# INLINE writeWithBufferOf #-}
 writeWithBufferOf :: MonadIO m => Int -> Handle -> Fold m Word8 ()
-writeWithBufferOf n h = FL.chunksOf n (writeNUnsafe n) (writeChunks h)
+writeWithBufferOf n h = FL.groupsOf n (writeNUnsafe n) (writeChunks h)
 
 -- > write = 'writeWithBufferOf' A.defaultChunkSize
 --

--- a/core/src/Streamly/Internal/FileSystem/File.hs
+++ b/core/src/Streamly/Internal/FileSystem/File.hs
@@ -103,7 +103,7 @@ import Prelude hiding (read)
 import qualified Control.Monad.Catch as MC
 import qualified System.IO as SIO
 
-import Streamly.Data.Fold (chunksOf, drain)
+import Streamly.Data.Fold (groupsOf, drain)
 import Streamly.Internal.Data.Array.Type (Array(..), writeNUnsafe)
 import Streamly.Internal.Data.Fold.Type (Fold(..))
 import Streamly.Data.Stream (Stream)
@@ -464,7 +464,7 @@ writeChunks path = Fold step initial extract
 writeWith :: (MonadIO m, MonadCatch m)
     => Int -> FilePath -> Fold m Word8 ()
 writeWith n path =
-    chunksOf n (writeNUnsafe n) (writeChunks path)
+    groupsOf n (writeNUnsafe n) (writeChunks path)
 
 {-# DEPRECATED writeWithBufferOf "Please use 'writeWith' instead"  #-}
 {-# INLINE writeWithBufferOf #-}

--- a/core/src/Streamly/Internal/FileSystem/Handle.hs
+++ b/core/src/Streamly/Internal/FileSystem/Handle.hs
@@ -500,11 +500,11 @@ writeChunksWithBufferOf = writeChunksWith
 -- Bytes in the input stream are collected into a buffer until we have a chunk
 -- of @reqSize@ and then written to the IO device.
 --
--- >>> writeWith n h = Fold.chunksOf n (Array.writeNUnsafe n) (Handle.writeChunks h)
+-- >>> writeWith n h = Fold.groupsOf n (Array.writeNUnsafe n) (Handle.writeChunks h)
 --
 {-# INLINE writeWith #-}
 writeWith :: MonadIO m => Int -> Handle -> Fold m Word8 ()
-writeWith n h = FL.chunksOf n (writeNUnsafe n) (writeChunks h)
+writeWith n h = FL.groupsOf n (writeNUnsafe n) (writeChunks h)
 
 -- | Same as 'writeWith'
 --

--- a/docs/User/ProjectRelated/Changelog.md
+++ b/docs/User/ProjectRelated/Changelog.md
@@ -49,6 +49,7 @@ higher level operations with additional dependencies.
   * `serialWith` renamed to `splitWith`.
   * `variance`, and `stdDev` deprecated. Please use the
     `streamly-statistics` package instead.
+  * `chunksOf` is renamed to `groupsOf`.
 * In `Streamly.Network.Socket`:
   * `readWithBufferOf` renamed to `readWith`
   * `readChunksWithBufferOf` renamed to `readChunksWith`

--- a/src/Streamly/Internal/Data/Stream/IsStream/Reduce.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Reduce.hs
@@ -193,7 +193,7 @@ import qualified Streamly.Internal.Data.Parser.ParserD as PRD (Parser(..))
 import qualified Streamly.Internal.Data.Stream.IsStream.Type as IsStream
 import qualified Streamly.Internal.Data.Stream.StreamD as D
     ( foldMany
-    , chunksOf
+    , groupsOf
     , refoldMany
     , foldIterateM
     , refoldIterateM
@@ -983,7 +983,7 @@ splitOnSuffixSeqAny _subseq _f _m = undefined
 chunksOf
     :: (IsStream t, Monad m)
     => Int -> Fold m a b -> t m a -> t m b
-chunksOf n f = fromStreamD . D.chunksOf n f . toStreamD
+chunksOf n f = fromStreamD . D.groupsOf n f . toStreamD
 
 -- | @arraysOf n stream@ groups the elements in the input stream into arrays of
 -- @n@ elements each.

--- a/src/Streamly/Internal/Network/Inet/TCP.hs
+++ b/src/Streamly/Internal/Network/Inet/TCP.hs
@@ -399,7 +399,7 @@ writeWithBufferOf
     -> PortNumber
     -> Fold m Word8 ()
 writeWithBufferOf n addr port =
-    FL.chunksOf n (writeNUnsafe n) (writeChunks addr port)
+    FL.groupsOf n (writeNUnsafe n) (writeChunks addr port)
 
 -- | Write a stream to the supplied IPv4 host address and port number.
 --

--- a/src/Streamly/Internal/Network/Socket.hs
+++ b/src/Streamly/Internal/Network/Socket.hs
@@ -502,7 +502,7 @@ putBytesWith n h m = putChunks h $ A.arraysOf n m
 --
 {-# INLINE writeWith #-}
 writeWith :: MonadIO m => Int -> Socket -> Fold m Word8 ()
-writeWith n h = FL.chunksOf n (A.writeNUnsafe n) (writeChunks h)
+writeWith n h = FL.groupsOf n (A.writeNUnsafe n) (writeChunks h)
 
 -- | Same as 'writeWith'
 --


### PR DESCRIPTION
* Deprecate chunksOf in Data.Fold as it is exposed.
* No deprecation is required in Data.Stream as it is a new module.