### PR TITLE
Add bound config param & expose for concurrent folds

### DIFF
--- a/src/Streamly/Internal/Data/Fold/Concurrent.hs
+++ b/src/Streamly/Internal/Data/Fold/Concurrent.hs
@@ -24,6 +24,7 @@ module Streamly.Internal.Data.Fold.Concurrent
     -- * Configuration
       Config
     , maxBuffer
+    , bound
     , inspect
 
     -- * Combinators

--- a/src/Streamly/Internal/Data/Fold/Concurrent/Channel.hs
+++ b/src/Streamly/Internal/Data/Fold/Concurrent/Channel.hs
@@ -14,6 +14,7 @@ module Streamly.Internal.Data.Fold.Concurrent.Channel
     -- * Configuration
     , Config
     , maxBuffer
+    , bound
     , inspect
 
     -- * Fold operations

--- a/src/Streamly/Internal/Data/Fold/Concurrent/Channel/Type.hs
+++ b/src/Streamly/Internal/Data/Fold/Concurrent/Channel/Type.hs
@@ -28,7 +28,7 @@ import Data.IORef (IORef, newIORef, readIORef)
 import Data.List (intersperse)
 import Streamly.Internal.Control.Concurrent
     (MonadAsync, MonadRunInIO, askRunInIO)
-import Streamly.Internal.Control.ForkLifted (doFork)
+import Streamly.Internal.Control.ForkLifted (doFork')
 import Streamly.Internal.Data.Fold (Fold(..))
 import Streamly.Internal.Data.Stream.Channel.Dispatcher (dumpSVarStats)
 import Streamly.Internal.Data.Stream.Channel.Worker (sendWithDoorBell)
@@ -236,9 +236,10 @@ mkNewChannel cfg = do
 newChannel :: (MonadRunInIO m) =>
     (Config -> Config) -> Fold m a b -> m (Channel m a b)
 newChannel modifier f = do
-    sv <- liftIO $ mkNewChannel (modifier defaultConfig)
+    let config = modifier defaultConfig
+    sv <- liftIO $ mkNewChannel config
     mrun <- askRunInIO
-    void $ doFork (work sv) mrun (sendExceptionToDriver sv)
+    void $ doFork' (getBound config) (work sv) mrun (sendExceptionToDriver sv)
     return sv
 
     where

--- a/src/Streamly/Internal/Data/Stream/Channel/Types.hs
+++ b/src/Streamly/Internal/Data/Stream/Channel/Types.hs
@@ -76,6 +76,7 @@ module Streamly.Internal.Data.Stream.Channel.Types
     , stopWhen
     , ordered
     , interleaved
+    , bound
 
     , rate
     , avgRate
@@ -95,6 +96,7 @@ module Streamly.Internal.Data.Stream.Channel.Types
     , getStopWhen
     , getOrdered
     , getInterleaved
+    , getBound
 
     -- * Cleanup
     , cleanupSVar
@@ -340,6 +342,7 @@ data Config = Config
     , _stopWhen :: StopWhen
     , _ordered :: Bool
     , _interleaved :: Bool
+    , _bound :: Bool
     }
 
 -------------------------------------------------------------------------------
@@ -374,6 +377,7 @@ defaultConfig = Config
     , _stopWhen = AllStop
     , _ordered = False
     , _interleaved = False
+    , _bound = False
     }
 
 -------------------------------------------------------------------------------
@@ -541,6 +545,14 @@ interleaved flag st = st { _interleaved = flag }
 
 getInterleaved :: Config -> Bool
 getInterleaved = _interleaved
+
+-- | Spawn bound threads (i.e., spawn threads using 'forkOS' instead of
+-- 'forkIO'). The default value is 'False'.
+bound :: Bool -> Config -> Config
+bound flag st = st { _bound = flag }
+
+getBound :: Config -> Bool
+getBound = _bound
 
 -------------------------------------------------------------------------------
 -- Initialization


### PR DESCRIPTION
(My use case: Concurrently running multiple folds (put together with `demux`) on bound threads.)

I have tried to make this change unintrusive: The new `bound` flag is only exposed in `*Fold.Concurrent*` and all existing calls to `doFork` (apart from the one in `*Fold.Concurrent*`) look exactly the same as before.

Adding `bound` support everywhere would apparently require more sweeping changes in the codebase (adding an extra `Bool` parameter to all sorts of functions, etc.), so I hesitated to do this for now. If this is something you really would prefer at this time, or if you have any other suggestions for improvements, feel free to let me know.
