### PR TITLE
Add warning to demux documentation

### DIFF
--- a/core/src/Streamly/Internal/Data/Fold/Container.hs
+++ b/core/src/Streamly/Internal/Data/Fold/Container.hs
@@ -326,6 +326,10 @@ demuxGeneric getKey getFold = fmap extract $ foldlM' step initial
 -- This can be used to scan a stream and collect the results from the scan
 -- output.
 --
+-- /Warning/: One should call the returned monadic action to make sure the
+-- folds fully complete—even if the action returns nothing useful (e.g., a map
+-- of @()@ values).
+--
 -- /Pre-release/
 --
 {-# INLINE demux #-}


### PR DESCRIPTION
I apparently need to do this at one point for things to go smoothly. (However, if this makes no sense (based on the way `demux` is known to work), feel free to reject.)