### PR TITLE
Future-proof against potential Prelude.foldl'

### DIFF
--- a/core/src/Streamly/Data/Fold.hs
+++ b/core/src/Streamly/Data/Fold.hs
@@ -247,11 +247,11 @@ module Streamly.Data.Fold
 where
 
 import Prelude
-       hiding (filter, drop, dropWhile, take, takeWhile, zipWith, foldr,
-               foldl, map, mapM_, sequence, all, any, sum, product, elem,
-               notElem, maximum, minimum, head, last, tail, length, null,
-               reverse, iterate, init, and, or, lookup, foldr1, (!!),
-               scanl, scanl1, replicate, concatMap, mconcat, foldMap, unzip,
+       hiding (Foldable(..), filter, drop, dropWhile, take, takeWhile, zipWith,
+               map, mapM_, sequence, all, any,
+               notElem, head, last, tail,
+               reverse, iterate, init, and, or, lookup, (!!),
+               scanl, scanl1, replicate, concatMap, mconcat, unzip,
                span, splitAt, break, mapM, maybe)
 
 import Streamly.Internal.Data.Fold

--- a/core/src/Streamly/Internal/Data/Array/Generic.hs
+++ b/core/src/Streamly/Internal/Data/Array/Generic.hs
@@ -65,7 +65,7 @@ import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
 import qualified Streamly.Internal.Data.Stream.StreamD.Generate as D
 import qualified Text.ParserCombinators.ReadPrec as ReadPrec
 
-import Prelude hiding (foldr, length, read)
+import Prelude hiding (Foldable(..), read)
 
 -------------------------------------------------------------------------------
 -- Array Data Type

--- a/core/src/Streamly/Internal/Data/Array/Mut/Type.hs
+++ b/core/src/Streamly/Internal/Data/Array/Mut/Type.hs
@@ -267,7 +267,7 @@ import qualified Streamly.Internal.Data.Unboxed as Unboxed
 import qualified Prelude
 
 import Prelude hiding
-    (length, foldr, read, unlines, splitAt, reverse, truncate)
+    (Foldable(..), read, unlines, splitAt, reverse, truncate)
 
 #include "DocTestDataMutArray.hs"
 

--- a/core/src/Streamly/Internal/Data/Array/Type.hs
+++ b/core/src/Streamly/Internal/Data/Array/Type.hs
@@ -96,7 +96,7 @@ import Streamly.Internal.Data.Unboxed (Unbox, peekWith, sizeOf)
 import Streamly.Internal.Data.Unfold.Type (Unfold(..))
 import Text.Read (readPrec)
 
-import Prelude hiding (length, foldr, read, unlines, splitAt)
+import Prelude hiding (Foldable(..), read, unlines, splitAt)
 
 import qualified GHC.Exts as Exts
 import qualified Streamly.Internal.Data.Array.Mut.Type as MA

--- a/core/src/Streamly/Internal/Data/Fold.hs
+++ b/core/src/Streamly/Internal/Data/Fold.hs
@@ -340,11 +340,11 @@ import qualified Streamly.Internal.Data.Ring.Unboxed as Ring
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as StreamD
 
 import Prelude hiding
-       ( filter, foldl1, drop, dropWhile, take, takeWhile, zipWith
-       , foldl, foldr, map, mapM_, sequence, all, any, sum, product, elem
-       , notElem, maximum, minimum, head, last, tail, length, null
+       ( Foldable(..), filter, drop, dropWhile, take, takeWhile, zipWith
+       , map, mapM_, sequence, all, any
+       , notElem, head, last, tail
        , reverse, iterate, init, and, or, lookup, (!!)
-       , scanl, scanl1, replicate, concatMap, mconcat, foldMap, unzip
+       , scanl, scanl1, replicate, concatMap, mconcat, unzip
        , span, splitAt, break, mapM, zip, maybe)
 import Streamly.Internal.Data.Fold.Type
 import Streamly.Internal.Data.Fold.Tee

--- a/core/src/Streamly/Internal/Data/Fold/Container.hs
+++ b/core/src/Streamly/Internal/Data/Fold/Container.hs
@@ -102,7 +102,7 @@ import qualified Data.IntSet as IntSet
 import qualified Data.Set as Set
 import qualified Streamly.Internal.Data.IsMap as IsMap
 
-import Prelude hiding (length)
+import Prelude hiding (Foldable(..))
 import Streamly.Internal.Data.Fold
 
 -- $setup

--- a/core/src/Streamly/Internal/Data/Fold/Type.hs
+++ b/core/src/Streamly/Internal/Data/Fold/Type.hs
@@ -457,7 +457,7 @@ import Streamly.Internal.Data.Refold.Type (Refold(..))
 
 import qualified Streamly.Internal.Data.Stream.StreamK.Type as K
 
-import Prelude hiding (concatMap, filter, foldr, map, take)
+import Prelude hiding (Foldable(..), concatMap, filter, map, take)
 
 #include "DocTestDataFold.hs"
 

--- a/core/src/Streamly/Internal/Data/Refold/Type.hs
+++ b/core/src/Streamly/Internal/Data/Refold/Type.hs
@@ -47,7 +47,7 @@ import Control.Monad ((>=>))
 import Fusion.Plugin.Types (Fuse(..))
 import Streamly.Internal.Data.Fold.Step (Step(..), mapMStep)
 
-import Prelude hiding (take, iterate)
+import Prelude hiding (Foldable(..), take, iterate)
 
 -- $setup
 -- >>> :m

--- a/core/src/Streamly/Internal/Data/Stream/Common.hs
+++ b/core/src/Streamly/Internal/Data/Stream/Common.hs
@@ -35,7 +35,7 @@ import Streamly.Internal.Data.Fold.Type (Fold (..))
 import qualified Streamly.Internal.Data.Stream.StreamK.Type as K
 import qualified Streamly.Internal.Data.Stream.StreamD.Type as D
 
-import Prelude hiding (foldr, repeat)
+import Prelude hiding (Foldable(..), repeat)
 
 ------------------------------------------------------------------------------
 -- Conversions

--- a/core/src/Streamly/Internal/Data/Stream/StreamD/Eliminate.hs
+++ b/core/src/Streamly/Internal/Data/Stream/StreamD/Eliminate.hs
@@ -104,8 +104,9 @@ import qualified Streamly.Internal.Data.Stream.StreamD.Nesting as Nesting
 import qualified Streamly.Internal.Data.Stream.StreamD.Transform as StreamD
 
 import Prelude hiding
-       ( all, any, elem, foldr, foldr1, head, last, lookup, mapM, mapM_
-       , maximum, minimum, notElem, null, splitAt, tail, (!!))
+       ( Foldable(..), all, any, head, last, lookup, mapM, mapM_
+       , notElem, splitAt, tail, (!!))
+import Data.Foldable (length)
 import Streamly.Internal.Data.Stream.StreamD.Type
 
 #include "DocTestDataStream.hs"

--- a/core/src/Streamly/Internal/Data/Stream/StreamK.hs
+++ b/core/src/Streamly/Internal/Data/Stream/StreamK.hs
@@ -212,11 +212,11 @@ import qualified Streamly.Internal.Data.Stream.StreamD as Stream
 import qualified Prelude
 
 import Prelude
-       hiding (foldl, foldr, last, map, mapM, mapM_, repeat, sequence,
-               take, filter, all, any, takeWhile, drop, dropWhile, minimum,
-               maximum, elem, notElem, null, head, tail, init, zipWith, lookup,
-               foldr1, (!!), replicate, reverse, concatMap, iterate, splitAt)
-
+       hiding (Foldable(..), last, map, mapM, mapM_, repeat, sequence,
+               take, filter, all, any, takeWhile, drop, dropWhile,
+               notElem, head, tail, init, zipWith, lookup,
+               (!!), replicate, reverse, concatMap, iterate, splitAt)
+import Data.Foldable (sum, length)
 import Streamly.Internal.Data.Stream.StreamK.Type
 import Streamly.Internal.Data.Parser.ParserD (ParseError(..))
 


### PR DESCRIPTION
See https://github.com/haskell/core-libraries-committee/issues/167

This is, of course, a bit speculative at the moment, but given that the change does not involve CPP, it should not hurt to merge it early to simplify further impact assessment.

This PR covers `streamly-core` only: `streamly` itself does not seem to be buildable with GHC 9.6, even less so with GHC HEAD.