### PR TITLE
Future-proof against potential Prelude.foldl' - part 2

### DIFF
--- a/benchmark/Streamly/Benchmark/Data/Stream/Common.hs
+++ b/benchmark/Streamly/Benchmark/Data/Stream/Common.hs
@@ -103,7 +103,7 @@ import qualified Streamly.Internal.Data.Stream.StreamD as StreamK
 #endif
 
 import Gauge
-import Prelude hiding (mapM, replicate)
+import Prelude hiding (Foldable(..), mapM, replicate)
 
 #ifdef USE_STREAMK
 toStream :: Applicative m => StreamK m a -> Stream m a

--- a/benchmark/Streamly/Benchmark/Data/Stream/StreamK.hs
+++ b/benchmark/Streamly/Benchmark/Data/Stream/StreamK.hs
@@ -26,7 +26,7 @@ import Control.Monad (when)
 import Data.Maybe (isJust)
 import System.Random (randomRIO)
 import Prelude hiding
-    ( tail, mapM_, foldl, last, map, mapM, concatMap, zipWith, init, iterate
+    ( Foldable(..), tail, mapM_, last, map, mapM, concatMap, zipWith, init, iterate
     , repeat, replicate
     )
 
@@ -167,15 +167,15 @@ fromFoldable streamLen n = S.fromFoldable [n..n+streamLen]
 {-# INLINE fromFoldableM #-}
 fromFoldableM :: Monad m => Int -> Int -> Stream m Int
 fromFoldableM streamLen n =
-    Prelude.foldr S.consM S.nil (Prelude.fmap return [n..n+streamLen])
+    List.foldr S.consM S.nil (Prelude.fmap return [n..n+streamLen])
 
 {-# INLINABLE concatMapFoldableWith #-}
-concatMapFoldableWith :: Foldable f
+concatMapFoldableWith :: P.Foldable f
     => (Stream m b -> Stream m b -> Stream m b)
     -> (a -> Stream m b)
     -> f a
     -> Stream m b
-concatMapFoldableWith f g = Prelude.foldr (f . g) S.nil
+concatMapFoldableWith f g = P.foldr (f . g) S.nil
 
 {-# INLINE concatMapFoldableSerial #-}
 concatMapFoldableSerial :: Int -> Int -> Stream m Int

--- a/src/Streamly/Internal/Data/Stream/IsStream/Eliminate.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Eliminate.hs
@@ -182,9 +182,9 @@ import qualified Streamly.Internal.Data.Stream.StreamK.Type as K
 import qualified System.IO as IO
 
 import Prelude hiding
-       ( drop, take, takeWhile, foldr , foldl, mapM_, sequence, all, any, sum
-       , product, elem, notElem, maximum, minimum, head, last, tail, length
-       , null , reverse, init, and, or, lookup, foldr1, (!!) , splitAt, break
+       ( Foldable(..), drop, take, takeWhile, mapM_, sequence, all, any
+       , notElem, head, last, tail
+       , reverse, init, and, or, lookup, (!!), splitAt, break
        , mconcat)
 
 -- $setup

--- a/src/Streamly/Internal/Data/Stream/IsStream/Top.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Top.hs
@@ -85,7 +85,7 @@ import qualified Streamly.Internal.Data.Stream.IsStream.Transform as Stream
 import qualified Streamly.Internal.Data.Stream.IsStream.Type as IsStream
 import qualified Streamly.Internal.Data.Stream.StreamD as StreamD
 
-import Prelude hiding (filter, zipWith, concatMap, concat)
+import Prelude hiding (Foldable(..), filter, zipWith, concatMap, concat)
 
 -- $setup
 -- >>> :m

--- a/src/Streamly/Internal/Data/Stream/IsStream/Type.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Type.hs
@@ -133,7 +133,8 @@ import qualified Streamly.Internal.Data.Stream.Serial as Stream
 import qualified Streamly.Internal.Data.Stream.Zip as Zip
 import qualified Streamly.Internal.Data.Stream.ZipAsync as ZipAsync
 
-import Prelude hiding (foldr, repeat)
+import Prelude hiding (Foldable(..), repeat)
+import Data.Foldable (Foldable)
 
 #include "inline.hs"
 

--- a/src/Streamly/Prelude.hs
+++ b/src/Streamly/Prelude.hs
@@ -943,10 +943,10 @@ where
 
 import Streamly.Internal.Control.Concurrent (MonadAsync)
 import Prelude
-       hiding (filter, drop, dropWhile, take, takeWhile, zipWith, foldr,
-               foldl, map, mapM, mapM_, sequence, all, any, sum, product, elem,
-               notElem, maximum, minimum, head, last, tail, length, null,
-               reverse, iterate, init, and, or, lookup, foldr1, (!!),
+       hiding (Foldable(..), filter, drop, dropWhile, take, takeWhile, zipWith,
+               map, mapM, mapM_, sequence, all, any,
+               notElem, head, last, tail,
+               reverse, iterate, init, and, or, lookup, (!!),
                scanl, scanl1, repeat, replicate, concatMap, span)
 
 import Streamly.Internal.Data.Stream.IsStream


### PR DESCRIPTION
Continuing #2414. 

I built a patched GHC 9.4 to be able to complete an impact assessment without waiting for #2415. This patch now covers `streamly` package itself and all the rest of the repo.