### PR TITLE
Variable encoding of Word64

### DIFF
--- a/core/src/Streamly/Internal/Data/Serialize.hs
+++ b/core/src/Streamly/Internal/Data/Serialize.hs
@@ -27,6 +27,7 @@ import Control.Exception (assert)
 import Control.Monad (void)
 import Data.List (foldl')
 import Data.Proxy (Proxy (..))
+import GHC.Generics (Generic)
 import Streamly.Internal.Data.Unbox
     ( MutableByteArray(..)
     , PinnedState(..)
@@ -243,7 +244,7 @@ instance forall a. Serialize a => Serialize [a] where
 -- See https://sqlite.org/src4/doc/trunk/www/varint.wiki
 newtype VLWord64 =
     VLWord64 Word64
-    deriving (Num, Enum, Real, Integral, Show, Eq, Ord, Bounded)
+    deriving (Num, Enum, Real, Integral, Show, Eq, Ord, Bounded, Generic)
 
 -- | div256 x = x `div` 256
 div256 :: Word64 -> Word64


### PR DESCRIPTION
Benchmarks for variable length unsigned integer (Word64):

```
default(0) = Word64 (8 bytes)
default(1) = 239 (1 bytes)
default(2) = 2286 (2 bytes)
default(3) = 67822 (3 bytes)
default(4) = 16777214 (4 bytes)
default(5) = 4294967294 (5 bytes)
default(6) = 1099511627774 (6 bytes)
default(7) = 281474976710654 (7 bytes)
default(8) = 72057594037927934 (8 bytes)
default(9) = 72057594037927936 (9 bytes)
```

```
Data.Serialize(cpuTime)
Benchmark default(0)(μs) default(1) - default(0)(%) default(2) - default(0)(%) default(3) - default(0)(%) default(4) - default(0)(%) default(5) - default(0)(%) default(6) - default(0)(%) default(7) - default(0)(%) default(8) - default(0)(%) default(9) - default(0)(%)
--------- -------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- --------------------------
peek               27.92                   +1450.49                   +1634.66                   +1932.92                   +1955.52                   +1724.21                   +1883.29                   +1824.89                   +2293.49                   +1830.37
roundtrip         113.82                    +796.47                    +892.05                   +1014.92                   +1057.30                   +1102.11                   +1160.94                   +1199.22                   +1381.92                   +1262.00
poke               27.93                    +736.30                    +940.92                   +1040.31                   +1038.34                   +1027.24                   +1343.51                   +1429.92                   +1635.43                   +1439.14
encode            126.19                    +404.90                    +434.02                    +475.34                    +518.12                    +519.95                    +623.76                    +656.39                    +787.94                    +854.61

Data.Serialize(Allocated)
Benchmark default(0)(Bytes) default(1) - default(0)(%) default(2) - default(0)(%) default(3) - default(0)(%) default(4) - default(0)(%) default(5) - default(0)(%) default(6) - default(0)(%) default(7) - default(0)(%) default(8) - default(0)(%) default(9) - default(0)(%)
--------- ----------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- --------------------------
peek                   0.00                  +Infinity                  +Infinity                  +Infinity                  +Infinity                  +Infinity                  +Infinity                  +Infinity                  +Infinity                  +Infinity
poke                   0.00                  +Infinity                  +Infinity                  +Infinity                  +Infinity                  +Infinity                  +Infinity                  +Infinity                  +Infinity                  +Infinity
roundtrip        2399075.00                    +299.44                    +299.36                    +299.55                    +299.45                    +297.81                    +297.81                    +299.44                    +297.81                    +330.80
encode           2399075.00                     +65.79                     +65.80                     +66.36                     +65.78                     +66.34                     +65.81                     +65.27                     +65.80                     +98.81

Data.Serialize(maxrss)
Benchmark default(0)(MiB) default(1) - default(0)(%) default(2) - default(0)(%) default(3) - default(0)(%) default(4) - default(0)(%) default(5) - default(0)(%) default(6) - default(0)(%) default(7) - default(0)(%) default(8) - default(0)(%) default(9) - default(0)(%)
--------- --------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- -------------------------- --------------------------
poke                18.00                      +5.56                       0.00                       0.00                       0.00                       0.00                       0.00                     +11.11                     +11.11                       0.00
roundtrip           18.00                       0.00                       0.00                     +11.11                       0.00                    -900.00                       0.00                      -5.88                       0.00                       0.00
peek                18.00                       0.00                       0.00                       0.00                       0.00                       0.00                       0.00                       0.00                       0.00                     +11.11
encode              20.00                     -11.11                     -11.11                       0.00                     -11.11                     -11.11                     -11.11                      -5.26                     -11.11                     -11.11
```