### PR TITLE
Dir: replace FilePath with OsPath

### DIFF
--- a/core/src/Streamly/Internal/FileSystem/Dir.hs
+++ b/core/src/Streamly/Internal/FileSystem/Dir.hs
@@ -82,7 +82,7 @@ module Streamly.Internal.FileSystem.Dir
     )
 where
 
-import Control.Monad.Catch (MonadCatch)
+import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Bifunctor (bimap)
 import Data.Either (isRight, isLeft, fromLeft, fromRight)
@@ -90,18 +90,22 @@ import Data.Function ((&))
 import Streamly.Data.Stream (Stream)
 import Streamly.Internal.Data.Unfold (Step(..))
 import Streamly.Internal.Data.Unfold.Type (Unfold(..))
-import System.FilePath ((</>))
 #if (defined linux_HOST_OS) || (defined darwin_HOST_OS)
-import System.Posix (DirStream, openDirStream, readDirStream, closeDirStream)
+import qualified System.OsPath.Posix as OsPathPosix
+import System.Posix.Directory.PosixPath (DirStream, closeDirStream)
+import qualified System.Posix.Directory.PosixPath as PosixPath
 #elif defined(mingw32_HOST_OS)
 import qualified System.Win32 as Win32
 #else
 #error "Unsupported architecture"
 #endif
+import qualified System.OsPath as OsPath
+import System.OsPath (OsPath, (</>))
+import System.OsString.Internal.Types as OsString
 import qualified Streamly.Data.Unfold as UF
 import qualified Streamly.Internal.Data.Unfold as UF (mapM2, bracketIO)
 import qualified Streamly.Data.Stream as S
-import qualified System.Directory as Dir
+import qualified System.Directory.OsPath as Dir
 
 import Prelude hiding (read)
 
@@ -240,18 +244,27 @@ toStreamWithBufferOf chunkSize h = AS.concat $ toChunksWithBufferOf chunkSize h
 -- XXX exception handling
 
 #if (defined linux_HOST_OS) || (defined darwin_HOST_OS)
-{-# INLINE streamReader #-}
-streamReader :: MonadIO m => Unfold m DirStream FilePath
-streamReader = Unfold step return
 
+openDirStream :: OsPath -> IO DirStream
+openDirStream filename = 
+    PosixPath.openDirStream $ OsString.getOsString filename
+
+readDirStream :: DirStream -> IO OsPath
+readDirStream dirStream = do 
+    filepath <- PosixPath.readDirStream dirStream
+    return $ OsString.OsString filepath
+
+{-# INLINE streamReader #-}
+streamReader :: (MonadIO m, MonadThrow m) => Unfold m DirStream OsPath
+streamReader = Unfold step return
     where
 
     step strm = do
         -- XXX Use readDirStreamMaybe
         file <- liftIO $ readDirStream strm
-        case file of
-            [] -> return Stop
-            _ -> return $ Yield file strm
+        if file == mempty
+        then return Stop
+        else return $ Yield file strm
 
 #elif defined(mingw32_HOST_OS)
 openDirStream :: String -> IO (Win32.HANDLE, Win32.FindData)
@@ -261,7 +274,7 @@ closeDirStream :: (Win32.HANDLE, Win32.FindData) -> IO ()
 closeDirStream (h, _) = Win32.findClose h
 
 {-# INLINE streamReader #-}
-streamReader :: MonadIO m => Unfold m (Win32.HANDLE, Win32.FindData) FilePath
+streamReader :: MonadIO m => Unfold m (Win32.HANDLE, Win32.FindData) OsPath
 streamReader = Unfold step return
 
     where
@@ -270,8 +283,9 @@ streamReader = Unfold step return
         more <- liftIO $ Win32.findNextFile h fdat
         if more
         then do
-            file <- liftIO $ Win32.getFindDataFileName fdat
-            return $ Yield file (h, fdat)
+            filepath <- liftIO $ Win32.getFindDataFileName fdat
+            filename <- OsPath.encodeUtf filepath
+            return $ Yield filename (h, fdat)
         else return Stop
 #endif
 
@@ -279,16 +293,19 @@ streamReader = Unfold step return
 --  "." and ".." entries.
 --
 --  /Internal/
---
+
 {-# INLINE reader #-}
-reader :: (MonadIO m, MonadCatch m) => Unfold m FilePath FilePath
+reader :: (MonadIO m, MonadCatch m) => Unfold m OsPath OsPath
 reader =
+    let
+        dot = OsPath.unsafeFromChar '.'
+    in 
 -- XXX Instead of using bracketIO for each iteration of the loop we should
 -- instead yield a buffer of dir entries in each iteration and then use an
 -- unfold and concat to flatten those entries. That should improve the
 -- performance.
       UF.bracketIO openDirStream closeDirStream streamReader
-    & UF.filter (\x -> x /= "." && x /= "..")
+    & UF.filter (\x -> x /= OsPath.pack [dot] && x /= OsPath.pack [dot, dot])
 
 -- XXX We can use a more general mechanism to filter the contents of a
 -- directory. We can just stat each child and pass on the stat information. We
@@ -301,17 +318,17 @@ reader =
 --  /Internal/
 --
 {-# INLINE eitherReader #-}
-eitherReader :: (MonadIO m, MonadCatch m) => Unfold m FilePath (Either FilePath FilePath)
+eitherReader :: (MonadIO m, MonadCatch m) => Unfold m OsPath (Either OsPath OsPath)
 eitherReader = UF.mapM2 classify reader
 
     where
 
     classify dir x = do
-        r <- liftIO $ Dir.doesDirectoryExist (dir ++ "/" ++ x)
+        r <- liftIO $ Dir.doesDirectoryExist (dir </> x)
         return $ if r then Left x else Right x
 
 {-# INLINE eitherReaderPaths #-}
-eitherReaderPaths ::(MonadIO m, MonadCatch m) => Unfold m FilePath (Either FilePath FilePath)
+eitherReaderPaths ::(MonadIO m, MonadCatch m) => Unfold m OsPath (Either OsPath OsPath)
 eitherReaderPaths =
     UF.mapM2 (\dir -> return . bimap (dir </>) (dir </>)) eitherReader
 
@@ -321,7 +338,7 @@ eitherReaderPaths =
 --  /Internal/
 --
 {-# INLINE fileReader #-}
-fileReader :: (MonadIO m, MonadCatch m) => Unfold m FilePath FilePath
+fileReader :: (MonadIO m, MonadCatch m) => Unfold m OsPath OsPath
 fileReader = fmap (fromRight undefined) $ UF.filter isRight eitherReader
 
 -- | Read directories only. Filter out "." and ".." entries.
@@ -329,19 +346,19 @@ fileReader = fmap (fromRight undefined) $ UF.filter isRight eitherReader
 --  /Internal/
 --
 {-# INLINE dirReader #-}
-dirReader :: (MonadIO m, MonadCatch m) => Unfold m FilePath FilePath
+dirReader :: (MonadIO m, MonadCatch m) => Unfold m OsPath OsPath
 dirReader = fmap (fromLeft undefined) $ UF.filter isLeft eitherReader
 
 -- | Raw read of a directory.
 --
 -- /Pre-release/
 {-# INLINE read #-}
-read :: (MonadIO m, MonadCatch m) => FilePath -> Stream m FilePath
+read :: (MonadIO m, MonadCatch m) => OsPath -> Stream m OsPath
 read = S.unfold reader
 
 {-# DEPRECATED toStream "Please use 'read' instead" #-}
 {-# INLINE toStream #-}
-toStream :: (MonadIO m, MonadCatch m) => String -> Stream m String
+toStream :: (MonadIO m, MonadCatch m) => OsPath -> Stream m OsPath
 toStream = read
 
 -- | Read directories as Left and files as Right. Filter out "." and ".."
@@ -349,18 +366,18 @@ toStream = read
 --
 -- /Pre-release/
 {-# INLINE readEither #-}
-readEither :: (MonadIO m, MonadCatch m) => FilePath -> Stream m (Either FilePath FilePath)
+readEither :: (MonadIO m, MonadCatch m) => OsPath -> Stream m (Either OsPath OsPath)
 readEither = S.unfold eitherReader
 
 -- | Like 'readEither' but prefix the names of the files and directories with
 -- the supplied directory path.
 {-# INLINE readEitherPaths #-}
-readEitherPaths :: (MonadIO m, MonadCatch m) => FilePath -> Stream m (Either FilePath FilePath)
+readEitherPaths :: (MonadIO m, MonadCatch m) => OsPath -> Stream m (Either OsPath OsPath)
 readEitherPaths dir = fmap (bimap (dir </>) (dir </>)) $ readEither dir
 
 {-# DEPRECATED toEither "Please use 'readEither' instead" #-}
 {-# INLINE toEither #-}
-toEither :: (MonadIO m, MonadCatch m) => FilePath -> Stream m (Either FilePath FilePath)
+toEither :: (MonadIO m, MonadCatch m) => OsPath -> Stream m (Either OsPath OsPath)
 toEither = readEither
 
 -- | Read files only.
@@ -368,12 +385,12 @@ toEither = readEither
 --  /Internal/
 --
 {-# INLINE readFiles #-}
-readFiles :: (MonadIO m, MonadCatch m) => FilePath -> Stream m FilePath
+readFiles :: (MonadIO m, MonadCatch m) => OsPath -> Stream m OsPath
 readFiles = S.unfold fileReader
 
 {-# DEPRECATED toFiles "Please use 'readFiles' instead" #-}
 {-# INLINE toFiles #-}
-toFiles :: (MonadIO m, MonadCatch m) => FilePath -> Stream m FilePath
+toFiles :: (MonadIO m, MonadCatch m) => OsPath -> Stream m OsPath
 toFiles = readFiles
 
 -- | Read directories only.
@@ -381,12 +398,12 @@ toFiles = readFiles
 --  /Internal/
 --
 {-# INLINE readDirs #-}
-readDirs :: (MonadIO m, MonadCatch m) => FilePath -> Stream m FilePath
+readDirs :: (MonadIO m, MonadCatch m) => OsPath -> Stream m OsPath
 readDirs = S.unfold dirReader
 
 {-# DEPRECATED toDirs "Please use 'readDirs' instead" #-}
 {-# INLINE toDirs #-}
-toDirs :: (MonadIO m, MonadCatch m) => String -> Stream m String
+toDirs :: (MonadIO m, MonadCatch m) => OsPath -> Stream m OsPath
 toDirs = readDirs
 
 {-

--- a/src/Streamly/Internal/FileSystem/Event/Linux.hs
+++ b/src/Streamly/Internal/FileSystem/Event/Linux.hs
@@ -152,6 +152,7 @@ where
 
 import Control.Monad (void, when)
 import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Catch (MonadThrow)
 import Data.Bits ((.|.), (.&.), complement)
 import Data.Char (ord)
 import Data.Foldable (foldlM)
@@ -173,7 +174,8 @@ import GHC.IO.FD (fdFD, mkFD)
 import GHC.IO.Handle.FD (mkHandleFromFD)
 import Streamly.Data.Stream (Stream)
 import Streamly.Data.Parser (Parser)
-import System.Directory (doesDirectoryExist)
+import System.Directory.OsPath (doesDirectoryExist)
+import qualified System.OsPath as OsPath
 import System.IO (Handle, hClose, IOMode(ReadMode))
 import GHC.IO.Handle.FD (handleToFd)
 
@@ -615,8 +617,10 @@ foreign import ccall unsafe
 -- separated bytes. So these may fail or convert the path in an unexpected
 -- manner. We should ultimately remove all usage of these.
 
-toUtf8 :: MonadIO m => String -> m (Array Word8)
-toUtf8 = A.fromStream . U.encodeUtf8 . S.fromList
+toUtf8 :: (MonadIO m, MonadThrow m) => OsPath.OsPath -> m (Array Word8)
+toUtf8 path = do
+    str <- OsPath.decodeUtf path
+    A.fromStream . U.encodeUtf8 . S.fromList $ str
 
 utf8ToString :: Array Word8 -> String
 utf8ToString = runIdentity . S.fold FL.toList . U.decodeUtf8' . A.read
@@ -716,12 +720,13 @@ addToWatch cfg@Config{..} watch0@(Watch handle wdMap) root0 path0 = do
     --
     -- XXX readDirs currently uses paths as String, we need to convert it
     -- to "/" separated by byte arrays.
-    pathIsDir <- doesDirectoryExist $ utf8ToString absPath
+    absPathOsString <- OsPath.encodeUtf (utf8ToString absPath)
+    pathIsDir <- doesDirectoryExist absPathOsString
     when (watchRec && pathIsDir) $ do
         let f = addToWatch cfg watch0 root . appendPaths path
             in S.fold (FL.drainMapM f)
                 $ S.mapM toUtf8
-                $ Dir.readDirs $ utf8ToString absPath
+                $ Dir.readDirs absPathOsString
 
 foreign import ccall unsafe
     "sys/inotify.h inotify_rm_watch" c_inotify_rm_watch

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.13
+resolver: lts-22.0
 packages:
 - '.'
 - './benchmark'

--- a/streamly.cabal
+++ b/streamly.cabal
@@ -518,6 +518,7 @@ library
                      , hashable          >= 1.3   && < 1.5
                      , unordered-containers >= 0.2 && < 0.3
                      , heaps             >= 0.3     && < 0.5
+                     , filepath          >= 1.4.100 && < 1.6
 
                     -- concurrency
                      , atomic-primops    >= 0.8   && < 0.9


### PR DESCRIPTION
Fixes #2168 for Dir, File is yet to be done.

I've hacked this together mostly to get some benchmarks if it addresses #2200 and it does!

Note that you have to pass `-L` to `find` so that it resolves symlinks to get the same behavior.

On a directory with about 855k items:

```
$ time ListDir > /dev/null

real	0m3.567s
user	0m5.506s
sys	0m8.586s

$ time find -L > /dev/null

real	0m3.990s
user	0m0.396s
sys	0m3.568s
```

```
$ \time ListDir >/dev/null
5.51user 8.62system 0:03.64elapsed 387%CPU (0avgtext+0avgdata 48728maxresident)k
0inputs+0outputs (5major+13618minor)pagefaults 0swaps

$ \time find -L > /dev/null
0.37user 3.57system 0:03.97elapsed 99%CPU (0avgtext+0avgdata 38796maxresident)k
0inputs+0outputs (0major+10246minor)pagefaults 0swaps
```