### PR TITLE
Fix deprecations in MutArray and MutArray/Generic

### DIFF
--- a/core/src/Streamly/Data/MutArray.hs
+++ b/core/src/Streamly/Data/MutArray.hs
@@ -56,14 +56,14 @@ module Streamly.Data.MutArray
 
     -- * Inplace mutation
     , putIndex
-    , putIndexUnsafe
+    , unsafePutIndex
     , modifyIndex
-    , modifyIndexUnsafe
+    , unsafeModifyIndex
     , modify
 
     -- * Random access
     , getIndex
-    , getIndexUnsafe
+    , unsafeGetIndex
 
     -- * Conversion
     , toList
@@ -94,6 +94,9 @@ module Streamly.Data.MutArray
     , write
     , writeAppendN
     , writeAppend
+    , putIndexUnsafe
+    , modifyIndexUnsafe
+    , getIndexUnsafe
     )
 where
 

--- a/core/src/Streamly/Data/MutArray/Generic.hs
+++ b/core/src/Streamly/Data/MutArray/Generic.hs
@@ -34,14 +34,14 @@ module Streamly.Data.MutArray.Generic
 
     -- * Inplace mutation
     , putIndex
-    , putIndexUnsafe
+    , unsafePutIndex
     , modifyIndex
-    , modifyIndexUnsafe
+    , unsafeModifyIndex
     -- , modify
 
     -- * Random reads
     , getIndex
-    , getIndexUnsafe
+    , unsafeGetIndex
 
     -- * Conversion
     , toList
@@ -61,6 +61,9 @@ module Streamly.Data.MutArray.Generic
     , new
     , writeN
     , write
+    , modifyIndexUnsafe
+    , putIndexUnsafe
+    , getIndexUnsafe
     )
 where
 

--- a/core/src/Streamly/Internal/Data/Array/Generic.hs
+++ b/core/src/Streamly/Internal/Data/Array/Generic.hs
@@ -250,7 +250,7 @@ streamFold f arr = f (read arr)
 {-# INLINE getIndexUnsafe #-}
 getIndexUnsafe :: Int -> Array a -> a
 getIndexUnsafe i arr =
-    unsafePerformIO $ MArray.getIndexUnsafe i (unsafeThaw arr)
+    unsafePerformIO $ MArray.unsafeGetIndex i (unsafeThaw arr)
 
 -- | Lookup the element at the given index. Index starts from 0.
 --

--- a/core/src/Streamly/Internal/Data/ParserK/Type.hs
+++ b/core/src/Streamly/Internal/Data/ParserK/Type.hs
@@ -57,7 +57,7 @@ import Streamly.Internal.System.IO (unsafeInlineIO)
 import qualified Control.Monad.Fail as Fail
 import qualified Streamly.Internal.Data.Array.Type as Array
 import qualified Streamly.Internal.Data.MutArray.Generic as GenArr
-    ( getIndexUnsafeWith
+    ( unsafeGetIndexWith
     )
 import qualified Streamly.Internal.Data.Array.Generic as GenArr
 import qualified Streamly.Internal.Data.Parser.Type as ParserD
@@ -654,7 +654,7 @@ adaptCGWith pstep initial extract cont !offset0 !usedCount !input = do
         go !_ !cur !pst | cur >= end =
             onContinue len  pst
         go !_ !cur !pst = do
-            let !x = unsafeInlineIO $ GenArr.getIndexUnsafeWith contents cur
+            let !x = unsafeInlineIO $ GenArr.unsafeGetIndexWith contents cur
             pRes <- pstep pst x
             let next = cur + 1
                 back n = next - n

--- a/core/src/Streamly/Internal/Data/Ring/Generic.hs
+++ b/core/src/Streamly/Internal/Data/Ring/Generic.hs
@@ -101,7 +101,7 @@ unsafeInsertRingWith :: Ring a -> a -> IO Int
 unsafeInsertRingWith Ring{..} x = do
     assertM(ringMax >= 1)
     assertM(ringHead < ringMax)
-    MutArray.putIndexUnsafe ringHead ringArr x
+    MutArray.unsafePutIndex ringHead ringArr x
     let rh1 = ringHead + 1
         next = if rh1 == ringMax then 0 else rh1
     return next
@@ -145,8 +145,8 @@ toMutArray adj n Ring{..} =
             -- same array without reallocation.
             arr <- liftIO $ MutArray.emptyOf len
             arr1 <- MutArray.uninit arr len
-            MutArray.putSliceUnsafe ringArr idx arr1 0 (ringMax - idx)
-            MutArray.putSliceUnsafe ringArr 0 arr1 (ringMax - idx) (end - ringMax)
+            MutArray.unsafePutSlice ringArr idx arr1 0 (ringMax - idx)
+            MutArray.unsafePutSlice ringArr 0 arr1 (ringMax - idx) (end - ringMax)
             return arr1
 
 -- | Copy out the mutable ring to a mutable Array.
@@ -161,8 +161,8 @@ copyToMutArray adj n Ring{..} = do
             end = idx + len
         arr <- MutArray.emptyOf len
         arr1 <- MutArray.uninit arr len
-        MutArray.putSliceUnsafe ringArr idx arr1 0 (ringMax - idx)
-        MutArray.putSliceUnsafe ringArr 0 arr1 (ringMax - idx) (end - ringMax)
+        MutArray.unsafePutSlice ringArr idx arr1 0 (ringMax - idx)
+        MutArray.unsafePutSlice ringArr 0 arr1 (ringMax - idx) (end - ringMax)
         return arr1
 
 -- This would be theoretically slower than toMutArray because of a branch

--- a/test/Streamly/Test/FileSystem/Event/Common.hs
+++ b/test/Streamly/Test/FileSystem/Event/Common.hs
@@ -54,6 +54,7 @@ import System.Directory
     , createDirectoryIfMissing
     , createDirectoryLink
     , doesDirectoryExist
+    , doesFileExist
     , removeFile
     , removePathForcibly
     , renameDirectory
@@ -310,15 +311,24 @@ rootDirMove suffix events =
 
 createFileWithParent :: FilePath -> FilePath -> IO ()
 createFileWithParent file parent = do
-    let dir = takeDirectory (parent </> file)
-    putStrLn $ "Creating dir: " ++ dir
+    let filepath = parent </> file
+    let dir = takeDirectory filepath
+    putStrLn $ "createFileWithParent: file ["
+        ++ file ++ "] dir [" ++ dir ++ "]"
+    putStrLn $ "Ensuring dir: " ++ dir
     createDirectoryIfMissing True dir
     r <- doesDirectoryExist dir
     if r
     then do
-        putStrLn $ "Opening: " ++ (parent </> file)
-        openFile (parent </> file) WriteMode >>= hClose
-        putStrLn $ "Opened: " ++ (parent </> file)
+        putStrLn $ "Ensured dir: " ++ dir
+        when (not (null file)) $ do
+            exists <- doesFileExist filepath
+            if not exists
+            then do
+                putStrLn $ "Creating file: " ++ (parent </> file)
+                openFile (parent </> file) WriteMode >>= hClose
+                putStrLn $ "Created file: " ++ (parent </> file)
+            else error $ "File exists: " ++ filepath
     else error $ "Could not create dir: " ++ dir
 
 createFile :: FilePath -> FilePath -> IO ()

--- a/test/Streamly/Test/FileSystem/Event/Linux.hs
+++ b/test/Streamly/Test/FileSystem/Event/Linux.hs
@@ -10,7 +10,7 @@ module Streamly.Test.FileSystem.Event.Linux (main) where
 
 import Streamly.Internal.FileSystem.Event.Linux (Event)
 -- #if __GLASGOW_HASKELL__ == 902
-#if 0
+#if 1
 import qualified Data.List as List
 #endif
 import qualified Streamly.Internal.FileSystem.Event.Linux as Event
@@ -99,12 +99,11 @@ main = do
 
     let symTests =
 #if 0
-             -- when root is a symlinked dir, it does not recv touch, isDeleted
-             -- or rootDeleted, rootUnwatched events.
-             -- We are not seeing isAttrModified event as well, so disabling
-             -- this altogether.
+             -- No events occur when a symlink root is moved. when root is a
+             -- symlinked dir, it does not recv touch, isDeleted or
+             -- rootDeleted, rootUnwatched events. We are not seeing
+             -- isAttrModified event as well, so disabling this altogether.
               dirDelete "" (\dir -> [(dir, dirEvent Event.isAttrsModified)])
-            -- No events occur when a symlink root is moved
             :
 #endif
             regSymTests
@@ -112,7 +111,7 @@ main = do
     let w = Event.watchWith (Event.setAllEvents True)
         run = runTests moduleName "non-recursive" w
 
-#if 0
+#if 1
     let failingTests =
             [ "File deleted (file1)"
             , "File modified (file1)"
@@ -121,14 +120,14 @@ main = do
 #endif
 
     run DirType
-#if 0
-        $ filter (\(desc, _, _, _) -> List.notElem desc failingTests)
+#if 1
+        $ filter (\(desc, _, _, _) -> desc `List.notElem` failingTests)
 #endif
         regTests
 
     run SymLinkOrigPath
-#if 0
-        $ filter (\(desc, _, _, _) -> List.notElem desc failingTests)
+#if 1
+        $ filter (\(desc, _, _, _) -> desc `List.notElem` failingTests)
 #endif
         symTests
 
@@ -185,7 +184,7 @@ main = do
     --      uncaught exception: IOException of type ResourceBusy
     --      /tmp/fsevent_dir-a5bd0df64c44ab27/watch-root/file: openFile: resource busy (file is locked)
 
-#if 0
+#if 1
     let failingRecTests = failingTests ++
             [ "File created (subdir/file)"
             , "File deleted (subdir/file1)"
@@ -195,14 +194,14 @@ main = do
 #endif
 
     runRec DirType
-#if 0
-        $ filter (\(desc, _, _, _) -> List.notElem desc failingRecTests)
+#if 1
+        $ filter (\(desc, _, _, _) -> desc `List.notElem` failingRecTests)
 #endif
         recRegTests
 
     runRec SymLinkOrigPath
-#if 0
-        $ filter (\(desc, _, _, _) -> List.notElem desc failingRecTests)
+#if 1
+        $ filter (\(desc, _, _, _) -> desc `List.notElem` failingRecTests)
 #endif
         recSymTests
 #endif


### PR DESCRIPTION
Earlier:
* We deprecated the existing APIs but missed exporting the new ones.
* We missed renaming/deprecating the Generic MutArray APIs