### PR TITLE
Streamly doesn't build with Stack on Mac OS

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -76,117 +76,117 @@ jobs:
         # run. But we need at least one test where we test without
         # cabal.project because that is how hackage would build it.
         include:
-          - name: head
-            ghc_version: head
-            # The URL may change, to find a working URL go to https://gitlab.haskell.org/ghc/ghc/-/jobs/
-            # Find a debian10/11/12 job, click on a passed/failed status, at the
-            # end of the output you will find the tar.xz name, put that tar
-            # name after "raw/", and put the job name after "job=".
-            # Also see https://github.com/mpickering/ghc-artefact-nix/blob/master/gitlab-artifact.nix
-            #
-            # May also use ghcup for installing ghc head version, use the
-            # version "LatestNightly", and the following config:
-            # ghcup config add-release-channel https://ghc.gitlab.haskell.org/ghcup-metadata/ghcup-nightlies-0.0.7.yaml
-            ghcup_ghc_options: "-u https://gitlab.haskell.org/ghc/ghc/-/jobs/artifacts/master/raw/ghc-x86_64-linux-deb10-int_native-validate.tar.xz?job=x86_64-linux-deb10-int_native-validate"
-            runner: ubuntu-latest
-            build: cabal
-            cabal_version: 3.10.2.0
-            cabal_project: cabal.project.ghc-head
-            disable_sdist_build: "y"
-            ignore_error: true
-          - name: 9.10.1-Werror
-            ghc_version: 9.10.1
-            runner: ubuntu-latest
-            build: cabal
-            cabal_version: 3.10.1.0
-            disable_sdist_build: "y"
-            cabal_project: cabal.project.Werror
-            ignore_error: false
-          - name: 9.10.1-macos
-            ghc_version: 9.10.1
-            runner: macos-latest
-            build: cabal
-            cabal_version: 3.10.1.0
-            disable_sdist_build: "y"
-            cabal_project: cabal.project
-            ignore_error: false
-          - name: 9.10.1-fusion-inspection
-            ghc_version: 9.10.1
-            runner: ubuntu-latest
-            build: cabal
-            cabal_version: 3.10.1.0
-            disable_sdist_build: "y"
-            cabal_project: cabal.project
-            cabal_build_options: "--flag fusion-plugin --flag inspection"
-            ignore_error: false
-          # Note: use linux for warning build for convenient dev testing
-          - name: 9.8.1-Werror
-            ghc_version: 9.8.1
-            runner: ubuntu-latest
-            build: cabal
-            cabal_version: 3.10.1.0
-            disable_sdist_build: "y"
-            cabal_project: cabal.project.Werror
-            ignore_error: false
-        # - name: 9.8.1-docspec
-        #   ghc_version: 9.8.1
-        #   runner: ubuntu-latest
-        #   build: cabal
-        #   cabal_version: 3.10.1.0
-        #   cabal_project: cabal.project.doctest
-        #   disable_test: "y"
-        #   disable_bench: "y"
-        #   disable_docs: "y"
-        #   enable_docspec: "y"
-        #   disable_sdist_build: "y"
-        #   ignore_error: false
-          - name: 9.8.1-fusion-inspection
-            ghc_version: 9.8.1
-            runner: ubuntu-latest
-            build: cabal
-            cabal_version: 3.10.1.0
-            disable_sdist_build: "y"
-            cabal_project: cabal.project
-            cabal_build_options: "--flag fusion-plugin --flag inspection"
-            ignore_error: false
-          - name: 9.6.3-macos
-            ghc_version: 9.6.3
-            runner: macos-latest
-            build: cabal
-            cabal_version: 3.10.1.0
-            disable_sdist_build: "y"
-            cabal_project: cabal.project
-            ignore_error: false
-          - name: 9.4.7
-            ghc_version: 9.4.7
-            runner: ubuntu-latest
-            build: cabal
-            cabal_version: 3.8.1.0
-            disable_sdist_build: "y"
-            cabal_project: cabal.project
-            ignore_error: false
-          - name: 9.2.8
-            ghc_version: 9.2.8
-            runner: ubuntu-latest
-            build: cabal
-            cabal_project: cabal.project
-            cabal_version: 3.6.2.0
-            disable_sdist_build: "y"
-            ignore_error: false
-          - name: 9.0.2-streamly-sdist
-            ghc_version: 9.0.2
-            runner: ubuntu-latest
-            build: cabal
-            cabal_version: 3.6.2.0
-            cabal_project: cabal.project.streamly
-            ignore_error: true
-          - name: 9.0.2-streamly-core-sdist
-            ghc_version: 9.0.2
-            runner: ubuntu-latest
-            build: cabal
-            cabal_version: 3.6.2.0
-            subdir: core
-            ignore_error: false
+        #   - name: head
+        #     ghc_version: head
+        #     # The URL may change, to find a working URL go to https://gitlab.haskell.org/ghc/ghc/-/jobs/
+        #     # Find a debian10/11/12 job, click on a passed/failed status, at the
+        #     # end of the output you will find the tar.xz name, put that tar
+        #     # name after "raw/", and put the job name after "job=".
+        #     # Also see https://github.com/mpickering/ghc-artefact-nix/blob/master/gitlab-artifact.nix
+        #     #
+        #     # May also use ghcup for installing ghc head version, use the
+        #     # version "LatestNightly", and the following config:
+        #     # ghcup config add-release-channel https://ghc.gitlab.haskell.org/ghcup-metadata/ghcup-nightlies-0.0.7.yaml
+        #     ghcup_ghc_options: "-u https://gitlab.haskell.org/ghc/ghc/-/jobs/artifacts/master/raw/ghc-x86_64-linux-deb10-int_native-validate.tar.xz?job=x86_64-linux-deb10-int_native-validate"
+        #     runner: ubuntu-latest
+        #     build: cabal
+        #     cabal_version: 3.10.2.0
+        #     cabal_project: cabal.project.ghc-head
+        #     disable_sdist_build: "y"
+        #     ignore_error: true
+        #   - name: 9.10.1-Werror
+        #     ghc_version: 9.10.1
+        #     runner: ubuntu-latest
+        #     build: cabal
+        #     cabal_version: 3.10.1.0
+        #     disable_sdist_build: "y"
+        #     cabal_project: cabal.project.Werror
+        #     ignore_error: false
+        #   - name: 9.10.1-macos
+        #     ghc_version: 9.10.1
+        #     runner: macos-latest
+        #     build: cabal
+        #     cabal_version: 3.10.1.0
+        #     disable_sdist_build: "y"
+        #     cabal_project: cabal.project
+        #     ignore_error: false
+        #   - name: 9.10.1-fusion-inspection
+        #     ghc_version: 9.10.1
+        #     runner: ubuntu-latest
+        #     build: cabal
+        #     cabal_version: 3.10.1.0
+        #     disable_sdist_build: "y"
+        #     cabal_project: cabal.project
+        #     cabal_build_options: "--flag fusion-plugin --flag inspection"
+        #     ignore_error: false
+        #   # Note: use linux for warning build for convenient dev testing
+        #   - name: 9.8.1-Werror
+        #     ghc_version: 9.8.1
+        #     runner: ubuntu-latest
+        #     build: cabal
+        #     cabal_version: 3.10.1.0
+        #     disable_sdist_build: "y"
+        #     cabal_project: cabal.project.Werror
+        #     ignore_error: false
+        # # - name: 9.8.1-docspec
+        # #   ghc_version: 9.8.1
+        # #   runner: ubuntu-latest
+        # #   build: cabal
+        # #   cabal_version: 3.10.1.0
+        # #   cabal_project: cabal.project.doctest
+        # #   disable_test: "y"
+        # #   disable_bench: "y"
+        # #   disable_docs: "y"
+        # #   enable_docspec: "y"
+        # #   disable_sdist_build: "y"
+        # #   ignore_error: false
+        #   - name: 9.8.1-fusion-inspection
+        #     ghc_version: 9.8.1
+        #     runner: ubuntu-latest
+        #     build: cabal
+        #     cabal_version: 3.10.1.0
+        #     disable_sdist_build: "y"
+        #     cabal_project: cabal.project
+        #     cabal_build_options: "--flag fusion-plugin --flag inspection"
+        #     ignore_error: false
+        #   - name: 9.6.3-macos
+        #     ghc_version: 9.6.3
+        #     runner: macos-latest
+        #     build: cabal
+        #     cabal_version: 3.10.1.0
+        #     disable_sdist_build: "y"
+        #     cabal_project: cabal.project
+        #     ignore_error: false
+        #   - name: 9.4.7
+        #     ghc_version: 9.4.7
+        #     runner: ubuntu-latest
+        #     build: cabal
+        #     cabal_version: 3.8.1.0
+        #     disable_sdist_build: "y"
+        #     cabal_project: cabal.project
+        #     ignore_error: false
+        #   - name: 9.2.8
+        #     ghc_version: 9.2.8
+        #     runner: ubuntu-latest
+        #     build: cabal
+        #     cabal_project: cabal.project
+        #     cabal_version: 3.6.2.0
+        #     disable_sdist_build: "y"
+        #     ignore_error: false
+        #   - name: 9.0.2-streamly-sdist
+        #     ghc_version: 9.0.2
+        #     runner: ubuntu-latest
+        #     build: cabal
+        #     cabal_version: 3.6.2.0
+        #     cabal_project: cabal.project.streamly
+        #     ignore_error: true
+        #   - name: 9.0.2-streamly-core-sdist
+        #     ghc_version: 9.0.2
+        #     runner: ubuntu-latest
+        #     build: cabal
+        #     cabal_version: 3.6.2.0
+        #     subdir: core
+        #     ignore_error: false
           - name: 8.10.7-stack
             runner: ubuntu-latest
             build: stack
@@ -195,6 +195,8 @@ jobs:
             disable_docs: "y"
             disable_sdist_build: "y"
             disable_dist_checks: "y"
+            disable_test: "y"
+            disable_bench: "y"
             #sdist_options: "--ignore-check"
             stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
@@ -207,6 +209,8 @@ jobs:
             disable_docs: "y"
             disable_sdist_build: "y"
             disable_dist_checks: "y"
+            disable_test: "y"
+            disable_bench: "y"
             #sdist_options: "--ignore-check"
             stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
@@ -219,6 +223,8 @@ jobs:
             disable_docs: "y"
             disable_sdist_build: "y"
             disable_dist_checks: "y"
+            disable_test: "y"
+            disable_bench: "y"
             #sdist_options: "--ignore-check"
             stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
@@ -231,6 +237,8 @@ jobs:
             disable_docs: "y"
             disable_sdist_build: "y"
             disable_dist_checks: "y"
+            disable_test: "y"
+            disable_bench: "y"
             #sdist_options: "--ignore-check"
             stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
@@ -241,25 +249,25 @@ jobs:
         #   coverage: "y"
         #   cabal_version: 3.6.2.0
         #   ignore_error: false
-          - name: 8.8.4
-            ghc_version: 8.8.4
-            runner: ubuntu-latest
-            build: cabal
-            cabal_version: 3.6.2.0
-            cabal_project: cabal.project
-            disable_sdist_build: "y"
-            disable_docs: "y"
-            ignore_error: false
-          - name: 8.6.5-debug-unoptimized
-            ghc_version: 8.6.5
-            runner: ubuntu-latest
-            build: cabal
-            cabal_version: 3.6.2.0
-            cabal_project: cabal.project
-            cabal_build_options: "--flag debug --flag -opt"
-            disable_sdist_build: "y"
-            disable_docs: "y"
-            ignore_error: false
+          # - name: 8.8.4
+          #   ghc_version: 8.8.4
+          #   runner: ubuntu-latest
+          #   build: cabal
+          #   cabal_version: 3.6.2.0
+          #   cabal_project: cabal.project
+          #   disable_sdist_build: "y"
+          #   disable_docs: "y"
+          #   ignore_error: false
+          # - name: 8.6.5-debug-unoptimized
+          #   ghc_version: 8.6.5
+          #   runner: ubuntu-latest
+          #   build: cabal
+          #   cabal_version: 3.6.2.0
+          #   cabal_project: cabal.project
+          #   cabal_build_options: "--flag debug --flag -opt"
+          #   disable_sdist_build: "y"
+          #   disable_docs: "y"
+          #   ignore_error: false
         # - name: hlint
         #   build: hlint
         #   runner: ubuntu-latest

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -62,13 +62,13 @@ jobs:
       SUBDIR: ${{ matrix.subdir }}
 
     runs-on: ${{ matrix.runner }}
-    continue-on-error: ${{ matrix.ignore_error }}
+    # continue-on-error: ${{ matrix.ignore_error }}
     strategy:
-      fail-fast: true
+      # fail-fast: true
       matrix:
         # The order is important to optimize fail-fast.
-        name:
-          - 9.10.1-Werror
+        # name:
+        #   - 9.10.1-Werror
         # - 9.8.1-docspec
         # - 8.10.7-coverage
 
@@ -200,7 +200,7 @@ jobs:
             #sdist_options: "--ignore-check"
             stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
-            ignore_error: false
+            # ignore_error: false
           - name: 9.6.6-stack
             runner: macos-latest
             build: stack
@@ -214,7 +214,7 @@ jobs:
             #sdist_options: "--ignore-check"
             stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
-            ignore_error: false
+            # ignore_error: false
           - name: 9.8.2-stack-nightly-june
             runner: macos-latest
             build: stack
@@ -228,7 +228,7 @@ jobs:
             #sdist_options: "--ignore-check"
             stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
-            ignore_error: false
+            # ignore_error: false
           - name: 9.8.2-stack-nightly-september
             runner: macos-latest
             build: stack
@@ -242,7 +242,7 @@ jobs:
             #sdist_options: "--ignore-check"
             stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
-            ignore_error: false
+            # ignore_error: false
         # - name: 8.10.7-coverage
         #   ghc_version: 8.10.7
         #   runner: ubuntu-latest

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -199,6 +199,18 @@ jobs:
             stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
             ignore_error: false
+          - name: 9.8.2-stack
+            runner: macos-latest
+            build: stack
+            resolver: nightly-2024-06-20
+            stack_yaml: stack.yaml
+            disable_docs: "y"
+            disable_sdist_build: "y"
+            disable_dist_checks: "y"
+            #sdist_options: "--ignore-check"
+            stack_build_options: "--flag streamly-benchmarks:-opt"
+            cabal_version: 3.12.1.0
+            ignore_error: false
         # - name: 8.10.7-coverage
         #   ghc_version: 8.10.7
         #   runner: ubuntu-latest

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -198,7 +198,7 @@ jobs:
             disable_test: "y"
             disable_bench: "y"
             #sdist_options: "--ignore-check"
-            stack_build_options: "--flag streamly-benchmarks:-opt"
+            # stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
             # ignore_error: false
           - name: 9.6.6-stack
@@ -212,7 +212,7 @@ jobs:
             disable_test: "y"
             disable_bench: "y"
             #sdist_options: "--ignore-check"
-            stack_build_options: "--flag streamly-benchmarks:-opt"
+            # stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
             # ignore_error: false
           - name: 9.8.2-stack-nightly-june
@@ -226,7 +226,7 @@ jobs:
             disable_test: "y"
             disable_bench: "y"
             #sdist_options: "--ignore-check"
-            stack_build_options: "--flag streamly-benchmarks:-opt"
+            # stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
             # ignore_error: false
           - name: 9.8.2-stack-nightly-september
@@ -240,7 +240,7 @@ jobs:
             disable_test: "y"
             disable_bench: "y"
             #sdist_options: "--ignore-check"
-            stack_build_options: "--flag streamly-benchmarks:-opt"
+            # stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
             # ignore_error: false
         # - name: 8.10.7-coverage

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -199,10 +199,34 @@ jobs:
             stack_build_options: "--flag streamly-benchmarks:-opt"
             cabal_version: 3.12.1.0
             ignore_error: false
-          - name: 9.8.2-stack
+          - name: 9.6.6-stack
+            runner: macos-latest
+            build: stack
+            resolver: lts-22.35
+            stack_yaml: stack.yaml
+            disable_docs: "y"
+            disable_sdist_build: "y"
+            disable_dist_checks: "y"
+            #sdist_options: "--ignore-check"
+            stack_build_options: "--flag streamly-benchmarks:-opt"
+            cabal_version: 3.12.1.0
+            ignore_error: false
+          - name: 9.8.2-stack-nightly-june
             runner: macos-latest
             build: stack
             resolver: nightly-2024-06-20
+            stack_yaml: stack.yaml
+            disable_docs: "y"
+            disable_sdist_build: "y"
+            disable_dist_checks: "y"
+            #sdist_options: "--ignore-check"
+            stack_build_options: "--flag streamly-benchmarks:-opt"
+            cabal_version: 3.12.1.0
+            ignore_error: false
+          - name: 9.8.2-stack-nightly-september
+            runner: macos-latest
+            build: stack
+            resolver: nightly-2024-09-23
             stack_yaml: stack.yaml
             disable_docs: "y"
             disable_sdist_build: "y"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,14 @@
 resolver: lts-22.0
 packages:
 - '.'
-- './benchmark'
-- './test'
+# - './benchmark'
+# - './test'
 - './core'
 
 extra-deps:
-  - tasty-bench-0.3.1
-  - lockfree-queue-0.2.4
-  - unicode-data-0.6.0
+  # - tasty-bench-0.3.1
+  # - lockfree-queue-0.2.4
+  # - unicode-data-0.6.0
 
 #allow-newer: true
 rebuild-ghc-options: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,8 +7,8 @@ packages:
 
 extra-deps:
   # - tasty-bench-0.3.1
-  # - lockfree-queue-0.2.4
-  # - unicode-data-0.6.0
+  - lockfree-queue-0.2.4
+  - unicode-data-0.6.0
 
 #allow-newer: true
 rebuild-ghc-options: true


### PR DESCRIPTION
Added CI in order to investigate `stack build` failing  on Mac OS. See issue #2833.