### PR TITLE
Generalize type signature of `usingStateT`

### DIFF
--- a/src/Streamly/Internal/Data/Stream/IsStream/Lift.hs
+++ b/src/Streamly/Internal/Data/Stream/IsStream/Lift.hs
@@ -132,9 +132,9 @@ evalStateT s xs = fromStreamD $ D.evalStateT s (toStreamD xs)
 usingStateT
     :: Monad m
     => m s
-    -> (SerialT (StateT s m) a -> SerialT (StateT s m) a)
+    -> (SerialT (StateT s m) a -> SerialT (StateT s m) b)
     -> SerialT m a
-    -> SerialT m a
+    -> SerialT m b
 usingStateT s f = evalStateT s . f . liftInner
 
 -- | Evaluate the inner monad of a stream as 'StateT' and emit the resulting


### PR DESCRIPTION
This PR changes two characters to generalize the type of `usingStateT`. This permits its use with functions that arbitrarily transform the items in a stream.

Here is a motiving example. I rely on the below function as a way to write stream transformations in which each item in a stream can be transformed in a way that depends on an arbitrary state (which is typically built up from previous items in the stream):

```
import qualified Streamly.Data.Stream.Prelude  as S
import qualified Streamly.Internal.Data.Stream as S

stateMap
  :: Monad m => (a -> StateT s m (Maybe b)) -> s -> Stream m a -> Stream m b
stateMap f s = S.catMaybes . S.evalStateT (return s) . S.mapM f . S.liftInner
```

It should be possible to refactor this function as `stateMap f s = S.catMaybes . S.usingStateT (return s) (S.mapM f)`, but presently the type of `usingStateT` would overly constrain the type of `f`.

(I'll also take this opportunity to ask: Is there is an established approach to doing the sort of thing I wrote `stateMap` for? I couldn't find any such pre-packaged functionality in the library.)