### PR TITLE
Deprecate all the modules related to SVar

### DIFF
--- a/src/Streamly/Internal/Data/Fold/Prelude.hs
+++ b/src/Streamly/Internal/Data/Fold/Prelude.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 -- |
 -- Module      : Streamly.Internal.Data.Fold.Prelude
 -- Copyright   : (c) 2022 Composewell Technologies

--- a/src/Streamly/Internal/Data/Fold/SVar.hs
+++ b/src/Streamly/Internal/Data/Fold/SVar.hs
@@ -9,6 +9,7 @@
 --
 --
 module Streamly.Internal.Data.Fold.SVar
+    {-# DEPRECATED "The functionality is moved to Fold.Concurrent" #-}
     (
       write
     , writeLimited

--- a/src/Streamly/Internal/Data/SVar.hs
+++ b/src/Streamly/Internal/Data/SVar.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 -- |
 -- Module      : Streamly.Internal.Data.SVar
 -- Copyright   : (c) 2017 Composewell Technologies

--- a/src/Streamly/Internal/Data/SVar/Dispatch.hs
+++ b/src/Streamly/Internal/Data/SVar/Dispatch.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 -- |
 -- Module      : Streamly.Internal.Data.SVar.Dispatch
 -- Copyright   : (c) 2017 Composewell Technologies
@@ -8,6 +10,7 @@
 --
 --
 module Streamly.Internal.Data.SVar.Dispatch
+    {-# DEPRECATED "The functionality is moved to Channel.*" #-}
     (
     -- * Latency collection
       collectLatency

--- a/src/Streamly/Internal/Data/SVar/Pull.hs
+++ b/src/Streamly/Internal/Data/SVar/Pull.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 -- |
 -- Module      : Streamly.Internal.Data.SVar.Pull
 -- Copyright   : (c) 2017 Composewell Technologies
@@ -8,6 +10,7 @@
 --
 --
 module Streamly.Internal.Data.SVar.Pull
+    {-# DEPRECATED "The functionality is moved to Channel.*" #-}
     (
     -- * Read Output
       readOutputQBasic

--- a/src/Streamly/Internal/Data/SVar/Worker.hs
+++ b/src/Streamly/Internal/Data/SVar/Worker.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 -- |
 -- Module      : Streamly.Internal.Data.SVar.Worker
 -- Copyright   : (c) 2017 Composewell Technologies
@@ -8,6 +10,7 @@
 --
 --
 module Streamly.Internal.Data.SVar.Worker
+    {-# DEPRECATED "The functionality is moved to Channel.*" #-}
     (
     -- * Adjusting Limits
       decrementYieldLimit

--- a/src/Streamly/Internal/Data/Stream/SVar.hs
+++ b/src/Streamly/Internal/Data/Stream/SVar.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 -- |
 -- Module      : Streamly.Internal.Data.Stream.SVar
 -- Copyright   : (c) 2022 Composewell Technologies

--- a/src/Streamly/Internal/Data/Stream/SVar/Eliminate.hs
+++ b/src/Streamly/Internal/Data/Stream/SVar/Eliminate.hs
@@ -10,6 +10,7 @@
 -- Eliminate a stream by distributing it to multiple SVars concurrently.
 --
 module Streamly.Internal.Data.Stream.SVar.Eliminate
+    {-# DEPRECATED "The functionality is moved to Channel.*" #-}
     (
     -- * Concurrent Function Application
       toSVarParallel

--- a/src/Streamly/Internal/Data/Stream/SVar/Generate.hs
+++ b/src/Streamly/Internal/Data/Stream/SVar/Generate.hs
@@ -18,6 +18,7 @@
 --
 --
 module Streamly.Internal.Data.Stream.SVar.Generate
+    {-# DEPRECATED "SVar is replaced by Channel." #-}
     (
     -- * Write to SVar
       toSVar

--- a/src/Streamly/Internal/Data/Unfold/Prelude.hs
+++ b/src/Streamly/Internal/Data/Unfold/Prelude.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 -- |
 -- Module      : Streamly.Internal.Data.Unfold.Prelude
 -- Copyright   : (c) 2022 Composewell Technologies
@@ -9,6 +11,7 @@
 module Streamly.Internal.Data.Unfold.Prelude
     (
       module Streamly.Internal.Data.Unfold.Exception
+    -- * Deprecated
     , module Streamly.Internal.Data.Unfold.SVar
     )
 where

--- a/src/Streamly/Internal/Data/Unfold/SVar.hs
+++ b/src/Streamly/Internal/Data/Unfold/SVar.hs
@@ -8,6 +8,7 @@
 -- Portability : GHC
 --
 module Streamly.Internal.Data.Unfold.SVar
+    {-# DEPRECATED "The functionality is moved to Channel.*" #-}
     (
       fromSVar
     , fromProducer


### PR DESCRIPTION
Is there replacement for the behaviour in `Streamly.Internal.Data.Unfold.SVar`
and `Streamly.Internal.Data.Fold.SVar`?

If not, we can create the same APIs replacing `SVar` with `Channel`.

Replace:
- [ ] Streamly.Internal.Data.Unfold.SVar
- [ ] Streamly.Internal.Data.Fold.SVar