### PR TITLE
Rename multiple array APIs based on certain conventions

### DIFF
--- a/benchmark/Streamly/Benchmark/Data/MutArray.hs
+++ b/benchmark/Streamly/Benchmark/Data/MutArray.hs
@@ -261,9 +261,9 @@ o_1_space_serial_marray value ~(array, indices) =
     , benchIO' "partitionBy (> value/2)" (const (return array))
         $ MArray.partitionBy (> (value `div` 2))
     , benchIO' "strip (< value/2 || > value/2)" (const (return array))
-        $ MArray.strip (\x -> x < value `div` 2 || x > value `div` 2)
+        $ MArray.dropAround (\x -> x < value `div` 2 || x > value `div` 2)
     , benchIO' "strip (> 0)" (const (return array))
-        $ MArray.strip (> 0)
+        $ MArray.dropAround (> 0)
     , benchIO' "modifyIndices (+ 1)" (const (return indices))
         $ Stream.fold (MArray.modifyIndices array (\_idx val -> val + 1))
         . Stream.unfold Array.reader

--- a/core/src/Streamly/Internal/Data/Array.hs
+++ b/core/src/Streamly/Internal/Data/Array.hs
@@ -53,11 +53,9 @@ module Streamly.Internal.Data.Array
     , asCStringUnsafe
 
     -- * Subarrays
-    , unsafeGetSlice
     -- , getSlice
     , indexerFromLen
     , splitterFromLen
-    , splitEndBy_
 
     -- * Streaming Operations
     , streamTransform
@@ -297,39 +295,16 @@ find = Unfold.fold Fold.null . Stream.unfold (indexFinder p)
 -- Slice
 -------------------------------------------------------------------------------
 
--- | /O(1)/ Slice an array in constant time.
---
--- Caution: The bounds of the slice are not checked.
---
--- /Unsafe/
---
--- /Pre-release/
-{-# INLINE unsafeGetSlice #-}
-unsafeGetSlice, getSliceUnsafe ::
+getSliceUnsafe ::
        forall a. Unbox a
     => Int -- ^ starting index
     -> Int -- ^ length of the slice
     -> Array a
     -> Array a
-unsafeGetSlice index len (Array contents start e) =
-    let size = SIZE_OF(a)
-        start1 = start + (index * size)
-        end1 = start1 + (len * size)
-     in assert (end1 <= e) (Array contents start1 end1)
-
 RENAME(getSliceUnsafe,unsafeGetSlice)
 
--- | Split the array into a stream of slices using a predicate. The element
--- matching the predicate is dropped.
---
--- /Pre-release/
-{-# INLINE splitEndBy_ #-}
-splitEndBy_, sliceEndBy_, splitOn :: (Monad m, Unbox a) =>
+sliceEndBy_, splitOn :: (Monad m, Unbox a) =>
     (a -> Bool) -> Array a -> Stream m (Array a)
-splitEndBy_ predicate arr =
-    fmap (\(i, len) -> getSliceUnsafe i len arr)
-        $ D.indexEndBy_ predicate (read arr)
-
 RENAME(splitOn,splitEndBy_)
 RENAME(sliceEndBy_,splitEndBy_)
 

--- a/core/src/Streamly/Internal/Data/Array.hs
+++ b/core/src/Streamly/Internal/Data/Array.hs
@@ -53,7 +53,7 @@ module Streamly.Internal.Data.Array
     , asCStringUnsafe
 
     -- * Subarrays
-    -- , getSlice
+    -- , sliceOffLen
     , indexerFromLen
     , splitterFromLen
 
@@ -301,7 +301,7 @@ getSliceUnsafe ::
     -> Int -- ^ length of the slice
     -> Array a
     -> Array a
-RENAME(getSliceUnsafe,unsafeGetSlice)
+RENAME(getSliceUnsafe,unsafeSliceOffLen)
 
 sliceEndBy_, splitOn :: (Monad m, Unbox a) =>
     (a -> Bool) -> Array a -> Stream m (Array a)

--- a/core/src/Streamly/Internal/Data/Array.hs
+++ b/core/src/Streamly/Internal/Data/Array.hs
@@ -55,9 +55,9 @@ module Streamly.Internal.Data.Array
     -- * Subarrays
     , unsafeGetSlice
     -- , getSlice
-    , sliceIndexerFromLen
-    , slicerFromLen
-    , sliceEndBy_
+    , indexerFromLen
+    , splitterFromLen
+    , splitEndBy_
 
     -- * Streaming Operations
     , streamTransform
@@ -90,6 +90,9 @@ module Streamly.Internal.Data.Array
     , deserialize
 
     -- * Deprecated
+    , sliceEndBy_
+    , slicerFromLen
+    , sliceIndexerFromLen
     , castUnsafe
     , getSliceUnsafe
     , pinnedSerialize
@@ -320,52 +323,55 @@ RENAME(getSliceUnsafe,unsafeGetSlice)
 -- matching the predicate is dropped.
 --
 -- /Pre-release/
-{-# INLINE sliceEndBy_ #-}
-sliceEndBy_, splitOn :: (Monad m, Unbox a) =>
+{-# INLINE splitEndBy_ #-}
+splitEndBy_, sliceEndBy_, splitOn :: (Monad m, Unbox a) =>
     (a -> Bool) -> Array a -> Stream m (Array a)
-sliceEndBy_ predicate arr =
+splitEndBy_ predicate arr =
     fmap (\(i, len) -> getSliceUnsafe i len arr)
         $ D.indexEndBy_ predicate (read arr)
 
-RENAME(splitOn,sliceEndBy_)
+RENAME(splitOn,splitEndBy_)
+RENAME(sliceEndBy_,splitEndBy_)
 
-{-# INLINE sliceIndexerFromLen #-}
-sliceIndexerFromLen :: forall m a. (Monad m, Unbox a)
+{-# INLINE indexerFromLen #-}
+indexerFromLen, sliceIndexerFromLen :: forall m a. (Monad m, Unbox a)
     => Int -- ^ from index
     -> Int -- ^ length of the slice
     -> Unfold m (Array a) (Int, Int)
-sliceIndexerFromLen from len =
-    Unfold.lmap unsafeThaw (MA.sliceIndexerFromLen from len)
+indexerFromLen from len =
+    Unfold.lmap unsafeThaw (MA.indexerFromLen from len)
+RENAME(sliceIndexerFromLen,indexerFromLen)
 
-{-# DEPRECATED genSlicesFromLen "Please use sliceIndexerFromLen instead." #-}
+{-# DEPRECATED genSlicesFromLen "Please use indexerFromLen instead." #-}
 {-# INLINE genSlicesFromLen #-}
 genSlicesFromLen :: forall m a. (Monad m, Unbox a)
     => Int -- ^ from index
     -> Int -- ^ length of the slice
     -> Unfold m (Array a) (Int, Int)
-genSlicesFromLen = sliceIndexerFromLen
+genSlicesFromLen = indexerFromLen
 
 -- | Generate a stream of slices of specified length from an array, starting
 -- from the supplied array index. The last slice may be shorter than the
 -- requested length.
 --
 -- /Pre-release//
-{-# INLINE slicerFromLen #-}
-slicerFromLen :: forall m a. (Monad m, Unbox a)
+{-# INLINE splitterFromLen #-}
+splitterFromLen, slicerFromLen :: forall m a. (Monad m, Unbox a)
     => Int -- ^ from index
     -> Int -- ^ length of the slice
     -> Unfold m (Array a) (Array a)
-slicerFromLen from len =
+splitterFromLen from len =
     fmap unsafeFreeze
-        $ Unfold.lmap unsafeThaw (MA.slicerFromLen from len)
+        $ Unfold.lmap unsafeThaw (MA.splitterFromLen from len)
+RENAME(slicerFromLen,splitterFromLen)
 
-{-# DEPRECATED getSlicesFromLen "Please use slicerFromLen instead." #-}
+{-# DEPRECATED getSlicesFromLen "Please use splitterFromLen instead." #-}
 {-# INLINE getSlicesFromLen #-}
 getSlicesFromLen :: forall m a. (Monad m, Unbox a)
     => Int -- ^ from index
     -> Int -- ^ length of the slice
     -> Unfold m (Array a) (Array a)
-getSlicesFromLen = slicerFromLen
+getSlicesFromLen = splitterFromLen
 
 -------------------------------------------------------------------------------
 -- Random reads and writes

--- a/core/src/Streamly/Internal/Data/Array/Generic.hs
+++ b/core/src/Streamly/Internal/Data/Array/Generic.hs
@@ -42,13 +42,14 @@ module Streamly.Internal.Data.Array.Generic
     -- * Random Access
     , unsafeGetIndex
     , getIndex
-    , unsafeGetSlice
+    , unsafeSliceOffLen
     , dropAround
 
     -- * Deprecated
     , strip
     , getIndexUnsafe
     , getSliceUnsafe
+    , unsafeGetSlice
     , writeN
     , write
     , fromByteStr#
@@ -288,10 +289,11 @@ createOfLast n = FL.rmapM f (RB.createOf n)
         arr <- RB.copyToMutArray 0 n rb
         return $ unsafeFreeze arr
 
-{-# INLINE unsafeGetSlice #-}
-unsafeGetSlice, getSliceUnsafe :: Int -> Int -> Array a -> Array a
-unsafeGetSlice offset len =
-    unsafeFreeze . MArray.unsafeGetSlice offset len . unsafeThaw
+{-# INLINE unsafeSliceOffLen #-}
+unsafeSliceOffLen, getSliceUnsafe, unsafeGetSlice
+    :: Int -> Int -> Array a -> Array a
+unsafeSliceOffLen offset len =
+    unsafeFreeze . MArray.unsafeSliceOffLen offset len . unsafeThaw
 
 -- XXX This is not efficient as it copies the array. We should support array
 -- slicing so that we can just refer to the underlying array memory instead of
@@ -357,5 +359,6 @@ instance Read a => Read (Array a) where
 -------------------------------------------------------------------------------
 
 RENAME(strip,dropAround)
-RENAME(getSliceUnsafe,unsafeGetSlice)
+RENAME(getSliceUnsafe,unsafeSliceOffLen)
+RENAME(unsafeGetSlice,unsafeSliceOffLen)
 RENAME(getIndexUnsafe,unsafeGetIndex)

--- a/core/src/Streamly/Internal/Data/Array/Generic.hs
+++ b/core/src/Streamly/Internal/Data/Array/Generic.hs
@@ -43,9 +43,10 @@ module Streamly.Internal.Data.Array.Generic
     , unsafeGetIndex
     , getIndex
     , unsafeGetSlice
-    , strip
+    , dropAround
 
     -- * Deprecated
+    , strip
     , getIndexUnsafe
     , getSliceUnsafe
     , writeN
@@ -298,9 +299,10 @@ unsafeGetSlice offset len =
 
 -- | Truncate the array at the beginning and end as long as the predicate
 -- holds true. Returns a slice of the original array.
-{-# INLINE strip #-}
-strip :: (a -> Bool) -> Array a -> Array a
-strip p arr = unsafeFreeze $ unsafePerformIO $ MArray.strip p (unsafeThaw arr)
+{-# INLINE dropAround #-}
+dropAround, strip :: (a -> Bool) -> Array a -> Array a
+dropAround p arr =
+    unsafeFreeze $ unsafePerformIO $ MArray.dropAround p (unsafeThaw arr)
 
 -------------------------------------------------------------------------------
 -- Instances
@@ -354,5 +356,6 @@ instance Read a => Read (Array a) where
 -- Backward Compatibility
 -------------------------------------------------------------------------------
 
+RENAME(strip,dropAround)
 RENAME(getSliceUnsafe,unsafeGetSlice)
 RENAME(getIndexUnsafe,unsafeGetIndex)

--- a/core/src/Streamly/Internal/Data/Array/Type.hs
+++ b/core/src/Streamly/Internal/Data/Array/Type.hs
@@ -37,7 +37,7 @@ module Streamly.Internal.Data.Array.Type
     , unsafeAsForeignPtr
 
     -- * Subarrays
-    , unsafeGetSlice
+    , unsafeSliceOffLen
 
     -- ** Construction
     , empty
@@ -155,6 +155,7 @@ module Streamly.Internal.Data.Array.Type
     , compactMin
 
     -- ** Deprecated
+    , unsafeGetSlice
     , strip
     , stripStart
     , stripEnd
@@ -532,18 +533,19 @@ fromStreamD = fromStream
 -- /Unsafe/
 --
 -- /Pre-release/
-{-# INLINE unsafeGetSlice #-}
-unsafeGetSlice ::
+{-# INLINE unsafeSliceOffLen #-}
+unsafeSliceOffLen, unsafeGetSlice ::
        forall a. Unbox a
     => Int -- ^ starting index
     -> Int -- ^ length of the slice
     -> Array a
     -> Array a
-unsafeGetSlice index len (Array contents start e) =
+unsafeSliceOffLen index len (Array contents start e) =
     let size = SIZE_OF(a)
         start1 = start + (index * size)
         end1 = start1 + (len * size)
      in assert (end1 <= e) (Array contents start1 end1)
+RENAME(unsafeGetSlice,unsafeSliceOffLen)
 
 -------------------------------------------------------------------------------
 -- Streams of arrays
@@ -626,7 +628,7 @@ splitEndBy p arr = D.map unsafeFreeze $ MA.splitEndBy p (unsafeThaw arr)
 splitEndBy_ :: (Monad m, Unbox a) =>
     (a -> Bool) -> Array a -> Stream m (Array a)
 splitEndBy_ predicate arr =
-    fmap (\(i, len) -> unsafeGetSlice i len arr)
+    fmap (\(i, len) -> unsafeSliceOffLen i len arr)
         $ D.indexEndBy_ predicate (read arr)
 
 -- | Convert a stream of arrays into a stream of their elements.

--- a/core/src/Streamly/Internal/Data/MutArray.hs
+++ b/core/src/Streamly/Internal/Data/MutArray.hs
@@ -112,7 +112,7 @@ splitterFromLen, slicerFromLen :: forall m a. (Monad m, Unbox a)
     -> Int -- ^ length of the slice
     -> Unfold m (MutArray a) (MutArray a)
 splitterFromLen from len =
-    let mkSlice arr (i, n) = return $ unsafeGetSlice i n arr
+    let mkSlice arr (i, n) = return $ unsafeSliceOffLen i n arr
      in Unfold.mapM2 mkSlice (indexerFromLen from len)
 RENAME(slicerFromLen,splitterFromLen)
 

--- a/core/src/Streamly/Internal/Data/MutArray.hs
+++ b/core/src/Streamly/Internal/Data/MutArray.hs
@@ -18,8 +18,8 @@ module Streamly.Internal.Data.MutArray
     -- * MutArray.Type module
       module Streamly.Internal.Data.MutArray.Type
     -- * MutArray module
-    , sliceIndexerFromLen
-    , slicerFromLen -- XXX splitterFromLen
+    , indexerFromLen
+    , splitterFromLen
     -- , splitFromLen
     -- , slicesOf
     , compactMax
@@ -39,6 +39,8 @@ module Streamly.Internal.Data.MutArray
     , deserialize
 
     -- * Deprecated
+    , slicerFromLen
+    , sliceIndexerFromLen
     , genSlicesFromLen
     , getSlicesFromLen
     , compactLE
@@ -79,45 +81,47 @@ import Streamly.Internal.Data.IORef.Unboxed
 -- may be shorter than the requested length depending on the array length.
 --
 -- /Pre-release/
-{-# INLINE sliceIndexerFromLen #-}
-sliceIndexerFromLen :: forall m a. (Monad m, Unbox a)
+{-# INLINE indexerFromLen #-}
+indexerFromLen, sliceIndexerFromLen :: forall m a. (Monad m, Unbox a)
     => Int -- ^ from index
     -> Int -- ^ length of the slice
     -> Unfold m (MutArray a) (Int, Int)
-sliceIndexerFromLen from len =
+indexerFromLen from len =
     let fromThenTo n = (from, from + len, n - 1)
         mkSlice n i = return (i, min len (n - i))
      in Unfold.lmap length
         $ Unfold.mapM2 mkSlice
         $ Unfold.lmap fromThenTo Unfold.enumerateFromThenTo
+RENAME(sliceIndexerFromLen,indexerFromLen)
 
-{-# DEPRECATED genSlicesFromLen "Please use sliceIndexerFromLen instead." #-}
+{-# DEPRECATED genSlicesFromLen "Please use indexerFromLen instead." #-}
 genSlicesFromLen :: forall m a. (Monad m, Unbox a)
     => Int -- ^ from index
     -> Int -- ^ length of the slice
     -> Unfold m (MutArray a) (Int, Int)
-genSlicesFromLen = sliceIndexerFromLen
+genSlicesFromLen = indexerFromLen
 
 -- | Generate a stream of slices of specified length from an array, starting
 -- from the supplied array index. The last slice may be shorter than the
 -- requested length depending on the array length.
 --
 -- /Pre-release/
-{-# INLINE slicerFromLen #-}
-slicerFromLen :: forall m a. (Monad m, Unbox a)
+{-# INLINE splitterFromLen #-}
+splitterFromLen, slicerFromLen :: forall m a. (Monad m, Unbox a)
     => Int -- ^ from index
     -> Int -- ^ length of the slice
     -> Unfold m (MutArray a) (MutArray a)
-slicerFromLen from len =
+splitterFromLen from len =
     let mkSlice arr (i, n) = return $ unsafeGetSlice i n arr
-     in Unfold.mapM2 mkSlice (sliceIndexerFromLen from len)
+     in Unfold.mapM2 mkSlice (indexerFromLen from len)
+RENAME(slicerFromLen,splitterFromLen)
 
-{-# DEPRECATED getSlicesFromLen "Please use slicerFromLen instead." #-}
+{-# DEPRECATED getSlicesFromLen "Please use splitterFromLen instead." #-}
 getSlicesFromLen :: forall m a. (Monad m, Unbox a)
     => Int -- ^ from index
     -> Int -- ^ length of the slice
     -> Unfold m (MutArray a) (MutArray a)
-getSlicesFromLen = slicerFromLen
+getSlicesFromLen = splitterFromLen
 
 --------------------------------------------------------------------------------
 -- Serialization/Deserialization using Serialize
@@ -266,7 +270,7 @@ _compactSepByByteCustom byte (Stream.Stream step state) =
         r <- step gst st
         case r of
             Stream.Yield arr s -> do
-                (arr1, marr2) <- breakOn byte arr
+                (arr1, marr2) <- breakEndByWord8_ byte arr
                 return $ case marr2 of
                     Nothing   -> Stream.Skip (Buffering s arr1)
                     Just arr2 -> Stream.Skip (Yielding arr1 (Splitting s arr2))
@@ -277,7 +281,7 @@ _compactSepByByteCustom byte (Stream.Stream step state) =
         r <- step gst st
         case r of
             Stream.Yield arr s -> do
-                (arr1, marr2) <- breakOn byte arr
+                (arr1, marr2) <- breakEndByWord8_ byte arr
                 -- XXX Use spliceExp instead and then rightSize?
                 buf1 <- splice buf arr1
                 return $ case marr2 of
@@ -290,7 +294,7 @@ _compactSepByByteCustom byte (Stream.Stream step state) =
                 else Stream.Skip (Yielding buf Finishing)
 
     step' _ (Splitting st buf) = do
-        (arr1, marr2) <- breakOn byte buf
+        (arr1, marr2) <- breakEndByWord8_ byte buf
         return $ case marr2 of
                 Nothing -> Stream.Skip $ Buffering st arr1
                 Just arr2 -> Stream.Skip $ Yielding arr1 (Splitting st arr2)
@@ -314,7 +318,7 @@ compactSepByByte_, compactOnByte
 -- XXX compare perf of custom vs idiomatic version
 -- compactOnByte = _compactOnByteCustom
 -- XXX use spliceExp and rightSize?
-compactSepByByte_ byte = Stream.splitInnerBy (breakOn byte) splice
+compactSepByByte_ byte = Stream.splitInnerBy (breakEndByWord8_ byte) splice
 
 RENAME(compactOnByte,compactSepByByte_)
 
@@ -330,7 +334,7 @@ compactEndByByte_, compactOnByteSuffix
 compactEndByByte_ byte =
         -- XXX use spliceExp and rightSize?
         Stream.splitInnerBySuffix
-            (\arr -> byteLength arr == 0) (breakOn byte) splice
+            (\arr -> byteLength arr == 0) (breakEndByWord8_ byte) splice
 
 RENAME(compactOnByteSuffix,compactEndByByte_)
 

--- a/core/src/Streamly/Internal/Data/MutArray/Generic.hs
+++ b/core/src/Streamly/Internal/Data/MutArray/Generic.hs
@@ -110,7 +110,7 @@ module Streamly.Internal.Data.MutArray.Generic
     , length
 
     -- * In-place Mutation Algorithms
-    , strip
+    , dropAround
     -- , reverse
     -- , permute
     -- , partitionBy
@@ -162,6 +162,7 @@ module Streamly.Internal.Data.MutArray.Generic
     , clone
 
     -- * Deprecated
+    , strip
     , new
     , writeNUnsafe
     , writeN
@@ -926,9 +927,9 @@ eq a1 a2 =
             then loop (i - 1)
             else return False
 
-{-# INLINE strip #-}
-strip :: MonadIO m => (a -> Bool) -> MutArray a -> m (MutArray a)
-strip p arr = liftIO $ do
+{-# INLINE dropAround #-}
+dropAround, strip :: MonadIO m => (a -> Bool) -> MutArray a -> m (MutArray a)
+dropAround p arr = liftIO $ do
     let lastIndex = length arr - 1
     indexR <- getIndexR lastIndex -- last predicate failing index
     if indexR < 0
@@ -961,6 +962,7 @@ strip p arr = liftIO $ do
 -- Renaming
 --------------------------------------------------------------------------------
 
+RENAME(strip,dropAround)
 RENAME(putIndexUnsafe, unsafePutIndex)
 RENAME(modifyIndexUnsafe, unsafeModifyIndex)
 RENAME(getIndexUnsafe, unsafeGetIndex)

--- a/core/src/Streamly/Internal/Data/MutArray/Generic.hs
+++ b/core/src/Streamly/Internal/Data/MutArray/Generic.hs
@@ -144,10 +144,10 @@ module Streamly.Internal.Data.MutArray.Generic
 
     -- ** Construct from arrays
     -- get chunks without copying
-    , unsafeGetSlice
-    , getSlice
+    , unsafeSliceOffLen
+    , sliceOffLen
     -- , getSlicesFromLenN
-    -- , splitAt -- XXX should be able to express using getSlice
+    -- , splitAt -- XXX should be able to express using sliceOffLen
     -- , breakOn
 
     -- ** Appending arrays
@@ -162,6 +162,8 @@ module Streamly.Internal.Data.MutArray.Generic
     , clone
 
     -- * Deprecated
+    , unsafeGetSlice
+    , getSlice
     , strip
     , new
     , writeNUnsafe
@@ -527,13 +529,13 @@ getIndex i arr =
 -- /Unsafe/
 --
 -- /Pre-release/
-{-# INLINE unsafeGetSlice #-}
-unsafeGetSlice, getSliceUnsafe
+{-# INLINE unsafeSliceOffLen #-}
+unsafeSliceOffLen, getSliceUnsafe, unsafeGetSlice
     :: Int -- ^ from index
     -> Int -- ^ length of the slice
     -> MutArray a
     -> MutArray a
-unsafeGetSlice index len arr@MutArray {..} =
+unsafeSliceOffLen index len arr@MutArray {..} =
     assert (index >= 0 && len >= 0 && index + len <= length arr)
         $ arr {arrStart = newStart, arrEnd = newEnd}
     where
@@ -544,17 +546,17 @@ unsafeGetSlice index len arr@MutArray {..} =
 -- extends out of the array bounds.
 --
 -- /Pre-release/
-{-# INLINE getSlice #-}
-getSlice
+{-# INLINE sliceOffLen #-}
+sliceOffLen, getSlice
     :: Int -- ^ from index
     -> Int -- ^ length of the slice
     -> MutArray a
     -> MutArray a
-getSlice index len arr@MutArray{..} =
+sliceOffLen index len arr@MutArray{..} =
     if index >= 0 && len >= 0 && index + len <= length arr
     then arr {arrStart = newStart, arrEnd = newEnd}
     else error
-             $ "getSlice: invalid slice, index "
+             $ "sliceOffLen: invalid slice, index "
              ++ show index ++ " length " ++ show len
     where
     newStart = arrStart + index
@@ -940,7 +942,7 @@ dropAround p arr = liftIO $ do
         then return arr
         else
            let newLen = indexR - indexL + 1
-            in return $ unsafeGetSlice indexL newLen arr
+            in return $ unsafeSliceOffLen indexL newLen arr
 
     where
 
@@ -967,6 +969,8 @@ RENAME(putIndexUnsafe, unsafePutIndex)
 RENAME(modifyIndexUnsafe, unsafeModifyIndex)
 RENAME(getIndexUnsafe, unsafeGetIndex)
 RENAME(getIndexUnsafeWith, unsafeGetIndexWith)
-RENAME(getSliceUnsafe, unsafeGetSlice)
+RENAME(getSliceUnsafe,unsafeSliceOffLen)
+RENAME(unsafeGetSlice,unsafeSliceOffLen)
 RENAME(putSliceUnsafe, unsafePutSlice)
+RENAME(getSlice,sliceOffLen)
 RENAME(snocUnsafe, unsafeSnoc)

--- a/core/src/Streamly/Internal/Data/StreamK.hs
+++ b/core/src/Streamly/Internal/Data/StreamK.hs
@@ -1583,8 +1583,8 @@ backTrackGenericChunks = go
            then go (n - len) xs (cons x stream)
            else if n == len
            then (cons x stream, xs)
-           else let arr1 = GenArr.unsafeGetSlice (len - n) n x
-                    arr2 = GenArr.unsafeGetSlice 0 (len - n) x
+           else let arr1 = GenArr.unsafeSliceOffLen (len - n) n x
+                    arr2 = GenArr.unsafeSliceOffLen 0 (len - n) x
                  in (cons arr1 stream, arr2:xs)
 
 -- | Similar to 'parseBreak' but works on generic arrays

--- a/core/src/Streamly/Internal/FileSystem/Path/Common.hs
+++ b/core/src/Streamly/Internal/FileSystem/Path/Common.hs
@@ -737,7 +737,7 @@ splitWithFilter
 splitWithFilter filt withSep os arr =
       f (isSeparatorWord os) (Array.read arr)
     & Stream.filter filt
-    & fmap (\(i, len) -> Array.unsafeGetSlice i len arr)
+    & fmap (\(i, len) -> Array.unsafeSliceOffLen i len arr)
 
     where
 
@@ -1086,7 +1086,7 @@ splitFile os arr =
         then
             if baseLen <= 0
             then (Array.empty, arr)
-            else (Array.unsafeGetSlice 0 baseLen base, file) -- "/"
+            else (Array.unsafeSliceOffLen 0 baseLen base, file) -- "/"
         else (arr, Array.empty)
 
 -- | Split a multi-component path into (dir, last component). If the path has a

--- a/core/src/Streamly/Internal/FileSystem/Path/Common.hs
+++ b/core/src/Streamly/Internal/FileSystem/Path/Common.hs
@@ -232,15 +232,15 @@ dropTrailingBy :: (Unbox a, Integral a) =>
 dropTrailingBy os p arr =
     let len = Array.length arr
         n = countTrailingBy p arr
-        arr1 = fst $ Array.unsafeSplitAt (len - n) arr
+        arr1 = fst $ Array.unsafeBreakAt (len - n) arr
      in if n == 0
         then arr
         else if n == len -- "////"
-        then fst $ Array.unsafeSplitAt 1 arr
+        then fst $ Array.unsafeBreakAt 1 arr
         -- "c:////"
         else if (os == Windows)
                 && (Array.unsafeGetIndex (len - n - 1) arr == charToWord ':')
-        then fst $ Array.unsafeSplitAt (len - n + 1) arr
+        then fst $ Array.unsafeBreakAt (len - n + 1) arr
         else arr1
 
 {-# INLINE compactTrailingBy #-}
@@ -250,7 +250,7 @@ compactTrailingBy p arr =
         n = countTrailingBy p arr
      in if n <= 1
         then arr
-        else fst $ Array.unsafeSplitAt (len - n + 1) arr
+        else fst $ Array.unsafeBreakAt (len - n + 1) arr
 
 -- | If the path is @//@ the result is @/@. If it is @a//@ then the result is
 -- @a@. On Windows "c:" and "c:/" are different paths, therefore, we do not
@@ -494,11 +494,11 @@ isBranch os = not . isRooted os
 unsafeSplitPrefix :: (Unbox a, Integral a) =>
     OS -> Int -> Array a -> (Array a, Array a)
 unsafeSplitPrefix os prefixLen arr =
-    Array.unsafeSplitAt cnt arr
+    Array.unsafeBreakAt cnt arr
 
     where
 
-    afterDrive = snd $ Array.unsafeSplitAt prefixLen arr
+    afterDrive = snd $ Array.unsafeBreakAt prefixLen arr
     n = countLeadingBy (isSeparatorWord os) afterDrive
     cnt = prefixLen + n
 
@@ -576,11 +576,11 @@ parseSegment arr sepOff = (segOff, segCnt)
 
     where
 
-    arr1 = snd $ Array.unsafeSplitAt sepOff arr
+    arr1 = snd $ Array.unsafeBreakAt sepOff arr
     sepCnt = countLeadingBy (isSeparatorWord Windows) arr1
     segOff = sepOff + sepCnt
 
-    arr2 = snd $ Array.unsafeSplitAt segOff arr
+    arr2 = snd $ Array.unsafeBreakAt segOff arr
     segCnt = countLeadingBy (not . isSeparatorWord Windows) arr2
 
 -- XXX We can split a path as "root, . , rest" or "root, /, rest".
@@ -643,7 +643,7 @@ unsafeSplitUNC arr =
 
     where
 
-    arr1 = snd $ Array.unsafeSplitAt 2 arr
+    arr1 = snd $ Array.unsafeBreakAt 2 arr
     cnt1 = countLeadingBy (not . isSeparatorWord Windows) arr1
     sepOff = 2 + cnt1
 
@@ -1072,7 +1072,7 @@ splitFile os arr =
                 $ Array.readRev arr
         arrLen = Array.length arr
         baseLen = arrLen - fileLen
-        (base, file) = Array.unsafeSplitAt baseLen arr
+        (base, file) = Array.unsafeBreakAt baseLen arr
         fileFirst = Array.unsafeGetIndex 0 file
         fileSecond = Array.unsafeGetIndex 1 file
      in
@@ -1174,7 +1174,7 @@ splitExtensionBy c os arr =
         arrLen = Array.length arr
         baseLen = arrLen - extLen
         -- XXX We can use reverse split operation on the array
-        res@(base, ext) = Array.unsafeSplitAt baseLen arr
+        res@(base, ext) = Array.unsafeBreakAt baseLen arr
         baseLast = Array.unsafeGetIndexRev 0 base
         extFirst = Array.unsafeGetIndex 0 ext
      in
@@ -1319,9 +1319,9 @@ splitAllExtensionsBy isFileName extChar os arr =
         baseLen = foldArr (Fold.takeEndBy_ (== extChar) Fold.length) file
         extLen = fileLen - baseLen
      in
-        -- XXX unsafeSplitAt itself should use Array.empty in case of no split
+        -- XXX unsafeBreakAt itself should use Array.empty in case of no split
         if fileLen > 0 && extLen > 1 && extLen /= fileLen
-        then (Array.unsafeSplitAt (arrLen - extLen) arr)
+        then (Array.unsafeBreakAt (arrLen - extLen) arr)
         else (arr, Array.empty)
 
 -- |
@@ -1498,7 +1498,7 @@ validatePathWith allowRoot Windows path
 
     where
 
-    postDrive = snd $ Array.unsafeSplitAt 2 path
+    postDrive = snd $ Array.unsafeBreakAt 2 path
     postDriveSep = countLeadingBy (isSeparatorWord Windows) postDrive
 
     -- XXX check invalid chars in the path root as well - except . and '?'?
@@ -1531,7 +1531,7 @@ validatePathWith allowRoot Windows path
         $ Stream.toList
         $ fmap toUp
         $ Array.read
-        $ Array.strip isSpace
+        $ Array.dropAround isSpace
         $ fst $ Array.breakEndBy_ (== extensionWord) x
 
     components =
@@ -1822,7 +1822,7 @@ doAppend os a b = unsafePerformIO $ do
             else pure arr1
     let arrB =
             if sepA && sepB
-            then snd $ Array.unsafeSplitAt 1 b
+            then snd $ Array.unsafeBreakAt 1 b
             else b
     arr3 <- MutArray.unsafeSplice arr2 (Array.unsafeThaw arrB)
     return (Array.unsafeFreeze arr3)

--- a/core/src/Streamly/Internal/Unicode/Stream.hs
+++ b/core/src/Streamly/Internal/Unicode/Stream.hs
@@ -737,7 +737,7 @@ mkEvenW8Chunks (D.Stream step state) = D.Stream step1 (MECSInit state)
                 Yield arr st1 ->
                     let len = Array.length arr
                      in if (len .&. 1) == 1
-                        then let arr1 = Array.unsafeGetSlice 0 (len - 1) arr
+                        then let arr1 = Array.unsafeSliceOffLen 0 (len - 1) arr
                                  remElem = Array.unsafeGetIndex (len - 1) arr
                               in Yield arr1 (MECSBuffer remElem st1)
                         else Yield arr (MECSInit st1)
@@ -756,11 +756,11 @@ mkEvenW8Chunks (D.Stream step state) = D.Stream step1 (MECSInit state)
                 Yield arr st1 ->
                     let len = Array.length arr
                      in if (len .&. 1) == 1
-                        then let arr1 = Array.unsafeGetSlice 1 (len - 1) arr
+                        then let arr1 = Array.unsafeSliceOffLen 1 (len - 1) arr
                                  fstElem = Array.unsafeGetIndex 0 arr
                                  w16 = Array.fromList [remElem, fstElem]
                               in Yield w16 (MECSYieldAndInit arr1 st1)
-                        else let arr1 = Array.unsafeGetSlice 1 (len - 2) arr
+                        else let arr1 = Array.unsafeSliceOffLen 1 (len - 2) arr
                                  fstElem = Array.unsafeGetIndex 0 arr
                                  lstElem = Array.unsafeGetIndex (len - 1) arr
                                  w16 = Array.fromList [remElem, fstElem]

--- a/src/Streamly/Internal/FileSystem/Event/Linux.hs
+++ b/src/Streamly/Internal/FileSystem/Event/Linux.hs
@@ -192,7 +192,7 @@ import qualified Streamly.Internal.FileSystem.Path as Path
 
 import qualified Streamly.Internal.Data.Array as A
     ( asCStringUnsafe, unsafePinnedAsPtr
-    , unsafeGetSlice, read
+    , unsafeSliceOffLen, read
     )
 import qualified Streamly.Internal.FileSystem.DirIO as Dir (readDirs)
 import qualified Streamly.Internal.Data.Parser as PR
@@ -664,7 +664,7 @@ removeTrailingSlash path =
             Nothing -> error "removeTrailingSlash: Bug: Invalid index"
             Just x ->
                 if x == fromIntegral (ord '/')
-                then A.unsafeGetSlice 0 n path
+                then A.unsafeSliceOffLen 0 n path
                 else path
     else path
 

--- a/test/Streamly/Test/Data/Array.hs
+++ b/test/Streamly/Test/Data/Array.hs
@@ -84,42 +84,42 @@ testLastN_LN len n = do
 testStrip :: IO Bool
 testStrip = do
     dt <- MA.fromList "abcDEFgeh"
-    dt' <- MA.strip isLower dt
+    dt' <- MA.dropAround isLower dt
     x <- MA.toList dt'
     return $ x == "DEF"
 
 testStripLeft :: IO Bool
 testStripLeft = do
     dt <- MA.fromList "abcDEF"
-    dt' <- MA.strip isLower dt
+    dt' <- MA.dropAround isLower dt
     x <- MA.toList dt'
     return $ x == "DEF"
 
 testStripRight :: IO Bool
 testStripRight = do
     dt <- MA.fromList "DEFgeh"
-    dt' <- MA.strip isLower dt
+    dt' <- MA.dropAround isLower dt
     x <- MA.toList dt'
     return $ x == "DEF"
 
 testStripZero :: IO Bool
 testStripZero = do
     dt <- MA.fromList "DEF"
-    dt' <- MA.strip isLower dt
+    dt' <- MA.dropAround isLower dt
     x <- MA.toList dt'
     return $ x == "DEF"
 
 testStripEmpty :: IO Bool
 testStripEmpty = do
     dt <- MA.fromList "abc"
-    dt' <- MA.strip isLower dt
+    dt' <- MA.dropAround isLower dt
     x <- MA.toList dt'
     return $ x == ""
 
 testStripNull :: IO Bool
 testStripNull = do
     dt <- MA.fromList ""
-    dt' <- MA.strip isLower dt
+    dt' <- MA.dropAround isLower dt
     x <- MA.toList dt'
     return $ x == ""
 
@@ -168,7 +168,7 @@ testByteLengthWithMA _ = do
 
 testBreakOn :: [Word8] -> Word8 -> [Word8] -> Maybe [Word8] -> IO ()
 testBreakOn inp sep bef aft = do
-    (bef_, aft_) <- A.breakOn sep (A.fromList inp)
+    (bef_, aft_) <- A.breakEndByWord8_ sep (A.fromList inp)
     bef_ `shouldBe` A.fromList bef
     aft_ `shouldBe` fmap A.fromList aft
 

--- a/test/Streamly/Test/Data/Array.hs
+++ b/test/Streamly/Test/Data/Array.hs
@@ -126,7 +126,7 @@ testStripNull = do
 unsafeSlice :: Int -> Int -> [Int] -> Bool
 unsafeSlice i n list =
     let lst = take n $ drop i list
-        arr = A.toList $ A.unsafeGetSlice i n $ A.fromList list
+        arr = A.toList $ A.unsafeSliceOffLen i n $ A.fromList list
      in arr == lst
 
 testBubbleWith :: Bool -> Property
@@ -211,13 +211,13 @@ testAsPtrUnsafeMA = do
 
 testUnsafePinnedAsPtr :: IO ()
 testUnsafePinnedAsPtr = do
-    arr <- MA.unsafeGetSlice 10 50 <$> MA.fromList ([0 .. 99] :: [Int])
+    arr <- MA.unsafeSliceOffLen 10 50 <$> MA.fromList ([0 .. 99] :: [Int])
     let arr1 = A.unsafeFreeze arr
     A.unsafePinnedAsPtr arr1 getIntList `shouldReturn` [10 .. 59]
 
 testUnsafeAsForeignPtr :: IO ()
 testUnsafeAsForeignPtr = do
-    arr <- MA.unsafeGetSlice 10 50 <$> MA.fromList ([0 .. 99] :: [Int])
+    arr <- MA.unsafeSliceOffLen 10 50 <$> MA.fromList ([0 .. 99] :: [Int])
     let arr1 = A.unsafeFreeze arr
     A.unsafeAsForeignPtr arr1 getIntList1 `shouldReturn` [10 .. 59]
     where
@@ -225,7 +225,7 @@ testUnsafeAsForeignPtr = do
 
 testForeignPtrConversionId :: IO ()
 testForeignPtrConversionId = do
-    arr0 <- MA.unsafeGetSlice 10 50 <$> MA.fromList ([0 .. 99] :: [Word8])
+    arr0 <- MA.unsafeSliceOffLen 10 50 <$> MA.fromList ([0 .. 99] :: [Word8])
     let arr = A.unsafeFreeze arr0
     A.unsafeAsForeignPtr arr $ \a b -> do
         res <- A.unsafeFromForeignPtr a b
@@ -235,7 +235,7 @@ testForeignPtrConversionId = do
 
 testUnsafeFromForeignPtr :: IO ()
 testUnsafeFromForeignPtr = do
-    arr0 <- MA.unsafeGetSlice 10 50 <$> MA.fromList ([0 .. 99] :: [Word8])
+    arr0 <- MA.unsafeSliceOffLen 10 50 <$> MA.fromList ([0 .. 99] :: [Word8])
     let arr = A.unsafeFreeze arr0
     A.unsafePinnedAsPtr arr $ \ptr len -> do
         fptr <- newForeignPtr_ ptr
@@ -244,7 +244,7 @@ testUnsafeFromForeignPtr = do
 
 testFromCString# :: IO ()
 testFromCString# = do
-    arr0 <- MA.unsafeGetSlice 10 50 <$> MA.fromList ([0 .. 99] :: [Word8])
+    arr0 <- MA.unsafeSliceOffLen 10 50 <$> MA.fromList ([0 .. 99] :: [Word8])
     let arr = A.unsafeFreeze arr0
     A.unsafePinnedAsPtr (arr <> A.fromList [0]) $ \(Ptr addr#) _ -> do
         arr1 <- A.fromCString# addr#
@@ -253,7 +253,7 @@ testFromCString# = do
 
 testFromW16CString# :: IO ()
 testFromW16CString# = do
-    arr0 <- MA.unsafeGetSlice 10 50 <$> MA.fromList ([0 .. 99] :: [Word16])
+    arr0 <- MA.unsafeSliceOffLen 10 50 <$> MA.fromList ([0 .. 99] :: [Word16])
     let arr = A.unsafeFreeze arr0
     A.unsafePinnedAsPtr (arr <> A.fromList [0]) $ \(Ptr addr#) _ -> do
         arr1 <- A.fromW16CString# addr#


### PR DESCRIPTION
break -> into 2 parts
split -> into many parts
strip* -> dropWhile*