### PR TITLE
Do not expose fairCrossWith

### DIFF
--- a/core/src/Streamly/Data/Stream.hs
+++ b/core/src/Streamly/Data/Stream.hs
@@ -567,7 +567,7 @@ module Streamly.Data.Stream
     -- "crossMap" or "nestWith".
     , crossWith
     , cross
-    , fairCrossWith
+    -- , fairCrossWith
     , fairCross
     -- , joinInner
     -- , CrossStream (..)


### PR DESCRIPTION
We can just use `fairCross` followed by `map` and it should fuse.