### PR TITLE
Fix race condition in sendExceptionToDriver

### DIFF
--- a/src/Streamly/Internal/Data/Fold/Channel/Type.hs
+++ b/src/Streamly/Internal/Data/Fold/Channel/Type.hs
@@ -314,8 +314,9 @@ sendExceptionToDriver :: Channel m a b -> SomeException -> IO ()
 sendExceptionToDriver sv e = do
     tid <- myThreadId
     writeIORef (closedForInput sv) True
-    void $ tryPutMVar (inputSpaceDoorBell sv) ()
+    -- Should ring the doorbell after sending the message
     void $ sendToDriver sv (FoldException tid e)
+    void $ tryPutMVar (inputSpaceDoorBell sv) ()
 
 data FromSVarState m a b =
       FromSVarRead (Channel m a b)


### PR DESCRIPTION
We were ringing the doorbell too early even before we sent the message, so the doorbell could go waste if the reader woke up before the message was sent.